### PR TITLE
Replace placeholders for docfx landing pages.

### DIFF
--- a/Docfx/index.md
+++ b/Docfx/index.md
@@ -1,6 +1,6 @@
 # Reaqtor
 
-Reaqtor is a framework for creating reliable, stateful, distributed, and scalable event processing based on Rx.
+Reaqtor is a framework for creating reliable, stateful, distributed, and scalable event processing based on [Reactive Extensions (Rx)](https://github.com/dotnet/reactive).
 
 Reaqtor is composed of 3 layers:
 

--- a/Docfx/nuqleon/index.md
+++ b/Docfx/nuqleon/index.md
@@ -1,3 +1,8 @@
 # Nuqleon
 
-Add something about the framework.
+Nuqleon provides a set of libraries which are reusable beyond Reaqtor. Many of these libraries have been used to implement other services. The libraries can be categorized in four big buckets:
+
+* BCL - A set of .NET Base Class Library extensions including collections, memory management, reflection APIs, etc.
+* DataModel - An implementation of a structural data model based on the JSON type system of primitives, arrays, and objects.
+* JSON - Libraries to work with JSON, which are also used for Bonsai expression tree serialization and DataModel serialization.
+* LINQ - Libraries to work with expression trees, including visitors, optimizers, Bonsai serialization, and more.

--- a/Docfx/reaqtive/index.md
+++ b/Docfx/reaqtive/index.md
@@ -1,3 +1,5 @@
 # Reaqtive
 
-Add something about the framework.
+Reaqtive is a set of stand-alone libraries that implement a variant of Rx with additional capabilities such as state persistence and support for hosting in an execution environment.
+
+The libraries provide the core abstractions as well as LINQ query operator implementations.

--- a/Docfx/reaqtor/index.md
+++ b/Docfx/reaqtor/index.md
@@ -1,3 +1,8 @@
 # Reaqtor
 
-Add something about the framework.
+Reaqtor provides a set of libraries that are essential to building distributed, reliable, stateful, and highly scalable reactive solutions. It roughly consists of the following core components:
+
+* Client-side abstractions used to build client libraries used to create and delete subscriptions, manage streams, publish events, etc.
+* A query engine that provides reliable execution of Reaqtive queries, including state persistence through checkpointing.
+* Facilities for reliable event flows across services, using sequence numbers and with replay capabilities.
+* Libraries to aid with hosting of query engines in services.

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 # About Reaqtor
 
-[Reaqtor](https://reaqtive.net) is a framework for reliable, stateful, distributed, and scalable event processing based on [Reactive Extensions (Rx)](https://github.com/dotnet/reactive). 
+[Reaqtor](https://reaqtive.net) is a framework for reliable, stateful, distributed, and scalable event processing based on [Reactive Extensions (Rx)](https://github.com/dotnet/reactive).
 
 Reaqtor has been in [development for over 10 years](https://reaqtive.net/history). It is the evolution of the Reactive Extensions & powers services across Bing and M365.
 


### PR DESCRIPTION
Initial work to improve on landing pages for the different layers of the product. See https://github.com/reaqtive/reaqtor/issues/6