### PR TITLE
Move Marvin hash code to common location.

### DIFF
--- a/All.sln
+++ b/All.sln
@@ -90,8 +90,8 @@ EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{F311C5BB-DFEC-40F7-9E78-F7439201F3BD}"
 	ProjectSection(SolutionItems) = preProject
 		.editorconfig = .editorconfig
-		azure-pipelines.yml = azure-pipelines.yml
 		Common\AssertEx.cs = Common\AssertEx.cs
+		azure-pipelines.yml = azure-pipelines.yml
 		coverlet.runsettings = coverlet.runsettings
 		Directory.Build.props = Directory.Build.props
 		Directory.Build.targets = Directory.Build.targets

--- a/Common/Marvin.cs
+++ b/Common/Marvin.cs
@@ -1,0 +1,126 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT License.
+// See the LICENSE file in the project root for more information.
+
+//
+// Revision history:
+//
+// BD - January 2017 - Created this file.
+//
+
+using System.Diagnostics;
+
+namespace System
+{
+    /// <summary>
+    /// Provides support for Marvin hashing of strings.
+    /// </summary>
+    internal static class Marvin
+    {
+        /// <summary>
+        /// Computes the Marvin32 hash code for the specified string.
+        /// </summary>
+        /// <param name="str">The string to compute the Marvin32 hash code for.</param>
+        /// <param name="seed">Seed value to compute the hash. This can be used to randomize the hash code.</param>
+        /// <returns>The Marvin32 hash code of the specified string.</returns>
+        public static int GetMarvin32Hash(this string str, ulong seed)
+        {
+            if (str == null)
+            {
+                return 0;
+            }
+
+            return GetMarvin32HashCore(str, 0, str.Length, seed);
+        }
+
+        /// <summary>
+        /// Computes the Marvin32 hash code for the specified string.
+        /// </summary>
+        /// <param name="str">The string to compute the Marvin32 hash code for.</param>
+        /// <param name="startIndex">The index of the first character to start computing the hash from.</param>
+        /// <param name="length">The number of characters to include in the hash.</param>
+        /// <param name="seed">Seed value to compute the hash. This can be used to randomize the hash code.</param>
+        /// <returns>The Marvin32 hash code of the specified string.</returns>
+        public static int GetMarvin32Hash(this string str, int startIndex, int length, ulong seed)
+        {
+            if (str == null)
+            {
+                return 0;
+            }
+
+            return GetMarvin32HashCore(str, startIndex, length, seed);
+        }
+
+        private static int GetMarvin32HashCore(string str, int startIndex, int length, ulong seed)
+        {
+            // NB: This code is adapted from the CoreCLR hash code in https://github.com/dotnet/coreclr/blob/master/src/vm/marvin32.cpp
+            //     and is patented by Microsoft (US 20130262421 A1).
+
+            var state = new Marvin32State
+            {
+                Lo = (uint)(seed),
+                Hi = (uint)(seed >> 32)
+            };
+
+            var len = length;
+
+            for (var i = startIndex; len >= 2; i += 2, len -= 2)
+            {
+                Marvin32Mix(ref state, TwoInt16ToInt32LittleEndian(str, i));
+            }
+
+            uint final = 0x80;
+
+            if (len != 0)
+            {
+                Debug.Assert(len == 1);
+
+                var c = (uint)str[length - 1];
+
+                var b1 = c & 0x00FF;
+                var b2 = c >> 8;
+
+                final = (final << 8) | b1;
+                final = (final << 8) | b2;
+            }
+
+            Marvin32Mix(ref state, final);
+            Marvin32Mix(ref state, 0);
+
+            return unchecked((int)(state.Lo ^ state.Hi));
+        }
+
+        private static void Marvin32Mix(ref Marvin32State state, uint value)
+        {
+            state.Lo += value;
+            state.Hi ^= state.Lo;
+
+            state.Lo = RotateLeft(state.Lo, 20) + state.Hi;
+            state.Hi = RotateLeft(state.Hi, 09) ^ state.Lo;
+
+            state.Lo = RotateLeft(state.Lo, 27) + state.Hi;
+            state.Hi = RotateLeft(state.Hi, 19);
+        }
+
+        private static uint RotateLeft(uint x, int k) => (x << k) | (x >> (32 - k));
+
+        private static uint TwoInt16ToInt32LittleEndian(string str, int i)
+        {
+            var c1 = (uint)str[i];
+            var b1 = c1 & 0x00FF;
+            var b2 = c1 & 0xFF00;
+
+            var c2 = (uint)str[i + 1];
+            var b3 = c2 & 0x00FF;
+            var b4 = c2 & 0xFF00;
+
+            return (b1 | b2) | (b3 | b4) << 16;
+        }
+
+        private struct Marvin32State
+        {
+            public uint Hi;
+            public uint Lo;
+        }
+    }
+}

--- a/Nuqleon/Core/BCL/Nuqleon.StringSegment/Nuqleon.StringSegment.csproj
+++ b/Nuqleon/Core/BCL/Nuqleon.StringSegment/Nuqleon.StringSegment.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;netstandard2.1;net472;net50</TargetFrameworks>
@@ -7,6 +7,10 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Nuqleon.Memory\Nuqleon.Memory.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Include="..\..\..\..\Common\Marvin.cs" Link="System\Marvin.cs" />
   </ItemGroup>
 
 </Project>

--- a/Nuqleon/Core/BCL/Nuqleon.StringSegment/System/StringSegment.cs
+++ b/Nuqleon/Core/BCL/Nuqleon.StringSegment/System/StringSegment.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 
@@ -198,7 +198,7 @@ namespace System
         /// Gets a hash code for the string segment.
         /// </summary>
         /// <returns>Hash code for the string segment.</returns>
-        public override int GetHashCode() => String == null ? 0 : String.GetHashCode() ^ StartIndex ^ Length;  // NB: same as ArraySegment<T>
+        public override int GetHashCode() => String == null ? 0 : Marvin.GetMarvin32Hash(String, StartIndex, Length, 0UL);
 
         /// <summary>
         /// Checks whether the string segment is equal to the specified object.

--- a/Nuqleon/Core/BCL/Tests.Nuqleon.StringSegment/System/StringSegmentTests.cs
+++ b/Nuqleon/Core/BCL/Tests.Nuqleon.StringSegment/System/StringSegmentTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 
@@ -1642,13 +1642,12 @@ namespace Tests
         {
             Assert.AreEqual(0, default(StringSegment).GetHashCode());
 
-            var bar = new StringSegment("bar").GetHashCode();
-            var foo = new StringSegment("foo").GetHashCode();
-            var qux = new StringSegment("qux").GetHashCode();
+            var s1 = new StringSegment("foobarqux", 3, 3);
+            var s2 = new StringSegment("barfoo", 0, 3);
+            var s3 = new StringSegment("quxfoobar", 6, 3);
 
-            Assert.AreNotEqual(bar, foo);
-            Assert.AreNotEqual(foo, qux);
-            Assert.AreNotEqual(0, bar + foo + qux);
+            Assert.AreNotEqual(s1.GetHashCode(), s2.GetHashCode());
+            Assert.AreNotEqual(s1.GetHashCode(), s3.GetHashCode());
         }
 
         [TestMethod]

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Bonsai.Hashing/Nuqleon.Linq.Expressions.Bonsai.Hashing.csproj
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Bonsai.Hashing/Nuqleon.Linq.Expressions.Bonsai.Hashing.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;netstandard2.1;net472;net50</TargetFrameworks>
@@ -8,6 +8,10 @@
   <ItemGroup>
     <ProjectReference Include="..\Nuqleon.Linq.Expressions.Bonsai\Nuqleon.Linq.Expressions.Bonsai.csproj" />
     <ProjectReference Include="..\..\BCL\Nuqleon.Memory\Nuqleon.Memory.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Include="..\..\..\..\Common\Marvin.cs" Link="System\Marvin.cs" />
   </ItemGroup>
 
 </Project>

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Bonsai.Hashing/System/Linq/Expressions/HashHelpers.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Bonsai.Hashing/System/Linq/Expressions/HashHelpers.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 
@@ -7,8 +7,6 @@
 //
 // BD - January 2017 - Created this file.
 //
-
-using System.Diagnostics;
 
 namespace System
 {
@@ -73,92 +71,5 @@ namespace System
         /// <param name="f">The sixth hash value to combine.</param>
         /// <returns>A combination of the five hash codes.</returns>
         public static int Combine(int a, int b, int c, int d, int e, int f) => Combine(Combine(a, b, c, d, e), f);
-
-        /// <summary>
-        /// Computes the Marvin32 hash code for the specified string.
-        /// </summary>
-        /// <param name="str">The string to compute the Marvin32 hash code for.</param>
-        /// <param name="seed">Seed value to compute the hash. This can be used to randomize the hash code.</param>
-        /// <returns>The Marvin32 hash code of the specified string.</returns>
-        public static int GetMarvin32Hash(this string str, ulong seed)
-        {
-            // NB: This code is adapted from the CoreCLR hash code in https://github.com/dotnet/coreclr/blob/master/src/vm/marvin32.cpp
-            //     and is patented by Microsoft (US 20130262421 A1).
-
-            if (str == null)
-            {
-                return 0;
-            }
-
-            var state = new Marvin32State
-            {
-                Lo = (uint)(seed),
-                Hi = (uint)(seed >> 32)
-            };
-
-            var len = str.Length;
-
-            for (var i = 0; len >= 2; i += 2, len -= 2)
-            {
-                Marvin32Mix(ref state, TwoInt16ToInt32LittleEndian(str, i));
-            }
-
-            uint final = 0x80;
-
-            if (len != 0)
-            {
-                Debug.Assert(len == 1);
-
-#if NET5_0 || NETSTANDARD2_1
-                var c = (uint)str[^1];
-#else
-                var c = (uint)str[str.Length - 1];
-#endif
-
-                var b1 = c & 0x00FF;
-                var b2 = c >> 8;
-
-                final = (final << 8) | b1;
-                final = (final << 8) | b2;
-            }
-
-            Marvin32Mix(ref state, final);
-            Marvin32Mix(ref state, 0);
-
-            return unchecked((int)(state.Lo ^ state.Hi));
-        }
-
-        private static void Marvin32Mix(ref Marvin32State state, uint value)
-        {
-            state.Lo += value;
-            state.Hi ^= state.Lo;
-
-            state.Lo = RotateLeft(state.Lo, 20) + state.Hi;
-            state.Hi = RotateLeft(state.Hi, 09) ^ state.Lo;
-
-            state.Lo = RotateLeft(state.Lo, 27) + state.Hi;
-            state.Hi = RotateLeft(state.Hi, 19);
-        }
-
-        private static uint RotateLeft(uint x, int k) => (x << k) | (x >> (32 - k));
-
-        private static uint TwoInt16ToInt32LittleEndian(string str, int i)
-        {
-            var c1 = (uint)str[i];
-            var b1 = c1 & 0x00FF;
-            var b2 = c1 & 0xFF00;
-
-            var c2 = (uint)str[i + 1];
-            var b3 = c2 & 0x00FF;
-            var b4 = c2 & 0xFF00;
-
-            return (b1 | b2) | (b3 | b4) << 16;
-        }
-
-        private struct Marvin32State
-        {
-            public uint Hi;
-            public uint Lo;
-        }
     }
 }

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Bonsai.Hashing/System/Linq/Expressions/StableExpressionSlimHasher.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Bonsai.Hashing/System/Linq/Expressions/StableExpressionSlimHasher.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 


### PR DESCRIPTION
Also using it in `StringSegment.GetHashCode()` which has a known limitation.

It seems that `*.cs` files when touched get a change on the first line, maybe due to a BOM being present. We should have a look at that separately and make it consistent across the board.