### PR TITLE
Fix the BOM in all *.cs files.

### DIFF
--- a/Common/TestUtilities/AssertEx.cs
+++ b/Common/TestUtilities/AssertEx.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/BCL/Nuqleon.Collections.Specialized/GlobalSuppressions.cs
+++ b/Nuqleon/Core/BCL/Nuqleon.Collections.Specialized/GlobalSuppressions.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/BCL/Nuqleon.Collections.Specialized/Properties/AssemblyInfo.cs
+++ b/Nuqleon/Core/BCL/Nuqleon.Collections.Specialized/Properties/AssemblyInfo.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/BCL/Nuqleon.Collections.Specialized/System/Collections/Specialized/BitArrayFactory.cs
+++ b/Nuqleon/Core/BCL/Nuqleon.Collections.Specialized/System/Collections/Specialized/BitArrayFactory.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/BCL/Nuqleon.Collections.Specialized/System/Collections/Specialized/BitArraySlim.cs
+++ b/Nuqleon/Core/BCL/Nuqleon.Collections.Specialized/System/Collections/Specialized/BitArraySlim.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/BCL/Nuqleon.Collections.Specialized/System/Collections/Specialized/ByteArray.cs
+++ b/Nuqleon/Core/BCL/Nuqleon.Collections.Specialized/System/Collections/Specialized/ByteArray.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/BCL/Nuqleon.Collections.Specialized/System/Collections/Specialized/DecoratedBitArray.cs
+++ b/Nuqleon/Core/BCL/Nuqleon.Collections.Specialized/System/Collections/Specialized/DecoratedBitArray.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/BCL/Nuqleon.Collections.Specialized/System/Collections/Specialized/EnumDictionary.cs
+++ b/Nuqleon/Core/BCL/Nuqleon.Collections.Specialized/System/Collections/Specialized/EnumDictionary.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/BCL/Nuqleon.Collections.Specialized/System/Collections/Specialized/EnumDictionary{TKey,TValue,TBitArray}.cs
+++ b/Nuqleon/Core/BCL/Nuqleon.Collections.Specialized/System/Collections/Specialized/EnumDictionary{TKey,TValue,TBitArray}.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/BCL/Nuqleon.Collections.Specialized/System/Collections/Specialized/EnumDictionary{TKey}.cs
+++ b/Nuqleon/Core/BCL/Nuqleon.Collections.Specialized/System/Collections/Specialized/EnumDictionary{TKey}.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/BCL/Nuqleon.Collections.Specialized/System/Collections/Specialized/EnumSizeResolutionError.cs
+++ b/Nuqleon/Core/BCL/Nuqleon.Collections.Specialized/System/Collections/Specialized/EnumSizeResolutionError.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/BCL/Nuqleon.Collections.Specialized/System/Collections/Specialized/EnumSizeResolutionException.cs
+++ b/Nuqleon/Core/BCL/Nuqleon.Collections.Specialized/System/Collections/Specialized/EnumSizeResolutionException.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/BCL/Nuqleon.Collections.Specialized/System/Collections/Specialized/IBitArray.cs
+++ b/Nuqleon/Core/BCL/Nuqleon.Collections.Specialized/System/Collections/Specialized/IBitArray.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/BCL/Nuqleon.Collections.Specialized/System/Collections/Specialized/IByteArray.cs
+++ b/Nuqleon/Core/BCL/Nuqleon.Collections.Specialized/System/Collections/Specialized/IByteArray.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/BCL/Nuqleon.Documentation/Properties/AssemblyInfo.cs
+++ b/Nuqleon/Core/BCL/Nuqleon.Documentation/Properties/AssemblyInfo.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/BCL/Nuqleon.Documentation/XmlDocumentation.cs
+++ b/Nuqleon/Core/BCL/Nuqleon.Documentation/XmlDocumentation.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/BCL/Nuqleon.IO.StreamSegment/Properties/AssemblyInfo.cs
+++ b/Nuqleon/Core/BCL/Nuqleon.IO.StreamSegment/Properties/AssemblyInfo.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/BCL/Nuqleon.IO.StreamSegment/System/IO/StreamSegment.cs
+++ b/Nuqleon/Core/BCL/Nuqleon.IO.StreamSegment/System/IO/StreamSegment.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/BCL/Nuqleon.Memory/Errors.cs
+++ b/Nuqleon/Core/BCL/Nuqleon.Memory/Errors.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/BCL/Nuqleon.Memory/GlobalSuppressions.cs
+++ b/Nuqleon/Core/BCL/Nuqleon.Memory/GlobalSuppressions.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/BCL/Nuqleon.Memory/PooledObjects.Generated.cs
+++ b/Nuqleon/Core/BCL/Nuqleon.Memory/PooledObjects.Generated.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/BCL/Nuqleon.Memory/Properties/AssemblyInfo.cs
+++ b/Nuqleon/Core/BCL/Nuqleon.Memory/Properties/AssemblyInfo.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/BCL/Nuqleon.Memory/System/Collections/Generic/EqualityComparerExtensions.Generated.cs
+++ b/Nuqleon/Core/BCL/Nuqleon.Memory/System/Collections/Generic/EqualityComparerExtensions.Generated.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/BCL/Nuqleon.Memory/System/Collections/Generic/FastComparer.cs
+++ b/Nuqleon/Core/BCL/Nuqleon.Memory/System/Collections/Generic/FastComparer.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/BCL/Nuqleon.Memory/System/Collections/Generic/FastEqualityComparer.cs
+++ b/Nuqleon/Core/BCL/Nuqleon.Memory/System/Collections/Generic/FastEqualityComparer.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/BCL/Nuqleon.Memory/System/Collections/Generic/PooledDictionary.cs
+++ b/Nuqleon/Core/BCL/Nuqleon.Memory/System/Collections/Generic/PooledDictionary.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/BCL/Nuqleon.Memory/System/Collections/Generic/PooledHashSet.cs
+++ b/Nuqleon/Core/BCL/Nuqleon.Memory/System/Collections/Generic/PooledHashSet.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/BCL/Nuqleon.Memory/System/Collections/Generic/PooledList.cs
+++ b/Nuqleon/Core/BCL/Nuqleon.Memory/System/Collections/Generic/PooledList.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/BCL/Nuqleon.Memory/System/Collections/Generic/PooledQueue.cs
+++ b/Nuqleon/Core/BCL/Nuqleon.Memory/System/Collections/Generic/PooledQueue.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/BCL/Nuqleon.Memory/System/Collections/Generic/PooledStack.cs
+++ b/Nuqleon/Core/BCL/Nuqleon.Memory/System/Collections/Generic/PooledStack.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/BCL/Nuqleon.Memory/System/HashHelpers.Generated.cs
+++ b/Nuqleon/Core/BCL/Nuqleon.Memory/System/HashHelpers.Generated.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/BCL/Nuqleon.Memory/System/HashHelpers.cs
+++ b/Nuqleon/Core/BCL/Nuqleon.Memory/System/HashHelpers.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/BCL/Nuqleon.Memory/System/IO/PooledMemoryStream.cs
+++ b/Nuqleon/Core/BCL/Nuqleon.Memory/System/IO/PooledMemoryStream.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/BCL/Nuqleon.Memory/System/ITuplet.cs
+++ b/Nuqleon/Core/BCL/Nuqleon.Memory/System/ITuplet.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/BCL/Nuqleon.Memory/System/Maybe.cs
+++ b/Nuqleon/Core/BCL/Nuqleon.Memory/System/Maybe.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/BCL/Nuqleon.Memory/System/MaybeEqualityComparer.cs
+++ b/Nuqleon/Core/BCL/Nuqleon.Memory/System/MaybeEqualityComparer.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/BCL/Nuqleon.Memory/System/Memory/Bundle.Generated.cs
+++ b/Nuqleon/Core/BCL/Nuqleon.Memory/System/Memory/Bundle.Generated.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/BCL/Nuqleon.Memory/System/Memory/Bundle.cs
+++ b/Nuqleon/Core/BCL/Nuqleon.Memory/System/Memory/Bundle.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/BCL/Nuqleon.Memory/System/Memory/Cache.Generated.cs
+++ b/Nuqleon/Core/BCL/Nuqleon.Memory/System/Memory/Cache.Generated.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/BCL/Nuqleon.Memory/System/Memory/Cache.cs
+++ b/Nuqleon/Core/BCL/Nuqleon.Memory/System/Memory/Cache.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/BCL/Nuqleon.Memory/System/Memory/CacheDictionary.cs
+++ b/Nuqleon/Core/BCL/Nuqleon.Memory/System/Memory/CacheDictionary.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/BCL/Nuqleon.Memory/System/Memory/CacheEntry.cs
+++ b/Nuqleon/Core/BCL/Nuqleon.Memory/System/Memory/CacheEntry.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/BCL/Nuqleon.Memory/System/Memory/CacheExtensions.cs
+++ b/Nuqleon/Core/BCL/Nuqleon.Memory/System/Memory/CacheExtensions.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/BCL/Nuqleon.Memory/System/Memory/CacheStorage.cs
+++ b/Nuqleon/Core/BCL/Nuqleon.Memory/System/Memory/CacheStorage.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/BCL/Nuqleon.Memory/System/Memory/ConcurrentCacheDictionary.cs
+++ b/Nuqleon/Core/BCL/Nuqleon.Memory/System/Memory/ConcurrentCacheDictionary.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/BCL/Nuqleon.Memory/System/Memory/ConcurrentMemoizationCacheFactory.Unbounded.cs
+++ b/Nuqleon/Core/BCL/Nuqleon.Memory/System/Memory/ConcurrentMemoizationCacheFactory.Unbounded.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/BCL/Nuqleon.Memory/System/Memory/ConcurrentMemoizationCacheFactory.cs
+++ b/Nuqleon/Core/BCL/Nuqleon.Memory/System/Memory/ConcurrentMemoizationCacheFactory.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/BCL/Nuqleon.Memory/System/Memory/Deconstructed.Generated.cs
+++ b/Nuqleon/Core/BCL/Nuqleon.Memory/System/Memory/Deconstructed.Generated.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/BCL/Nuqleon.Memory/System/Memory/Deconstructed.cs
+++ b/Nuqleon/Core/BCL/Nuqleon.Memory/System/Memory/Deconstructed.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/BCL/Nuqleon.Memory/System/Memory/DefaultDiscardable.cs
+++ b/Nuqleon/Core/BCL/Nuqleon.Memory/System/Memory/DefaultDiscardable.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/BCL/Nuqleon.Memory/System/Memory/DiscardableBase.cs
+++ b/Nuqleon/Core/BCL/Nuqleon.Memory/System/Memory/DiscardableBase.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/BCL/Nuqleon.Memory/System/Memory/EntityMetrics.cs
+++ b/Nuqleon/Core/BCL/Nuqleon.Memory/System/Memory/EntityMetrics.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/BCL/Nuqleon.Memory/System/Memory/FunctionMemoizationExtensions.Generated.cs
+++ b/Nuqleon/Core/BCL/Nuqleon.Memory/System/Memory/FunctionMemoizationExtensions.Generated.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/BCL/Nuqleon.Memory/System/Memory/FunctionMemoizationExtensions.Nullary.cs
+++ b/Nuqleon/Core/BCL/Nuqleon.Memory/System/Memory/FunctionMemoizationExtensions.Nullary.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/BCL/Nuqleon.Memory/System/Memory/FunctionMemoizationExtensions.TDelegate.cs
+++ b/Nuqleon/Core/BCL/Nuqleon.Memory/System/Memory/FunctionMemoizationExtensions.TDelegate.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/BCL/Nuqleon.Memory/System/Memory/ICache.cs
+++ b/Nuqleon/Core/BCL/Nuqleon.Memory/System/Memory/ICache.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/BCL/Nuqleon.Memory/System/Memory/ICacheDictionary.cs
+++ b/Nuqleon/Core/BCL/Nuqleon.Memory/System/Memory/ICacheDictionary.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/BCL/Nuqleon.Memory/System/Memory/ICacheStorage.cs
+++ b/Nuqleon/Core/BCL/Nuqleon.Memory/System/Memory/ICacheStorage.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/BCL/Nuqleon.Memory/System/Memory/IClearable.cs
+++ b/Nuqleon/Core/BCL/Nuqleon.Memory/System/Memory/IClearable.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/BCL/Nuqleon.Memory/System/Memory/IDiscardable.cs
+++ b/Nuqleon/Core/BCL/Nuqleon.Memory/System/Memory/IDiscardable.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/BCL/Nuqleon.Memory/System/Memory/IFreeable.cs
+++ b/Nuqleon/Core/BCL/Nuqleon.Memory/System/Memory/IFreeable.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/BCL/Nuqleon.Memory/System/Memory/IInternCache.cs
+++ b/Nuqleon/Core/BCL/Nuqleon.Memory/System/Memory/IInternCache.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/BCL/Nuqleon.Memory/System/Memory/IMemoizationCache.cs
+++ b/Nuqleon/Core/BCL/Nuqleon.Memory/System/Memory/IMemoizationCache.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/BCL/Nuqleon.Memory/System/Memory/IMemoizationCacheEntryMetrics.cs
+++ b/Nuqleon/Core/BCL/Nuqleon.Memory/System/Memory/IMemoizationCacheEntryMetrics.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/BCL/Nuqleon.Memory/System/Memory/IMemoizationCacheFactory.cs
+++ b/Nuqleon/Core/BCL/Nuqleon.Memory/System/Memory/IMemoizationCacheFactory.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/BCL/Nuqleon.Memory/System/Memory/IMemoizationCache`2.cs
+++ b/Nuqleon/Core/BCL/Nuqleon.Memory/System/Memory/IMemoizationCache`2.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/BCL/Nuqleon.Memory/System/Memory/IMemoizedDelegate.cs
+++ b/Nuqleon/Core/BCL/Nuqleon.Memory/System/Memory/IMemoizedDelegate.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/BCL/Nuqleon.Memory/System/Memory/IMemoizer.cs
+++ b/Nuqleon/Core/BCL/Nuqleon.Memory/System/Memory/IMemoizer.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/BCL/Nuqleon.Memory/System/Memory/IObjectPool.cs
+++ b/Nuqleon/Core/BCL/Nuqleon.Memory/System/Memory/IObjectPool.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/BCL/Nuqleon.Memory/System/Memory/IObjectPoolAllocateFree.cs
+++ b/Nuqleon/Core/BCL/Nuqleon.Memory/System/Memory/IObjectPoolAllocateFree.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/BCL/Nuqleon.Memory/System/Memory/IObjectPoolNew.cs
+++ b/Nuqleon/Core/BCL/Nuqleon.Memory/System/Memory/IObjectPoolNew.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/BCL/Nuqleon.Memory/System/Memory/IReadOnlyIndexed.cs
+++ b/Nuqleon/Core/BCL/Nuqleon.Memory/System/Memory/IReadOnlyIndexed.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/BCL/Nuqleon.Memory/System/Memory/IReference.cs
+++ b/Nuqleon/Core/BCL/Nuqleon.Memory/System/Memory/IReference.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/BCL/Nuqleon.Memory/System/Memory/ITrimmable.cs
+++ b/Nuqleon/Core/BCL/Nuqleon.Memory/System/Memory/ITrimmable.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/BCL/Nuqleon.Memory/System/Memory/IValueOrError.cs
+++ b/Nuqleon/Core/BCL/Nuqleon.Memory/System/Memory/IValueOrError.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/BCL/Nuqleon.Memory/System/Memory/IWeakCacheDictionary.cs
+++ b/Nuqleon/Core/BCL/Nuqleon.Memory/System/Memory/IWeakCacheDictionary.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/BCL/Nuqleon.Memory/System/Memory/IWeakInternCache.cs
+++ b/Nuqleon/Core/BCL/Nuqleon.Memory/System/Memory/IWeakInternCache.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/BCL/Nuqleon.Memory/System/Memory/IWeakMemoizationCacheFactory.cs
+++ b/Nuqleon/Core/BCL/Nuqleon.Memory/System/Memory/IWeakMemoizationCacheFactory.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/BCL/Nuqleon.Memory/System/Memory/IWeakMemoizer.cs
+++ b/Nuqleon/Core/BCL/Nuqleon.Memory/System/Memory/IWeakMemoizer.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/BCL/Nuqleon.Memory/System/Memory/InternCache.Strong.cs
+++ b/Nuqleon/Core/BCL/Nuqleon.Memory/System/Memory/InternCache.Strong.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/BCL/Nuqleon.Memory/System/Memory/InternCache.Weak.cs
+++ b/Nuqleon/Core/BCL/Nuqleon.Memory/System/Memory/InternCache.Weak.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/BCL/Nuqleon.Memory/System/Memory/InternCache.cs
+++ b/Nuqleon/Core/BCL/Nuqleon.Memory/System/Memory/InternCache.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/BCL/Nuqleon.Memory/System/Memory/LruCacheStorage.cs
+++ b/Nuqleon/Core/BCL/Nuqleon.Memory/System/Memory/LruCacheStorage.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/BCL/Nuqleon.Memory/System/Memory/MemoizationCacheBase.cs
+++ b/Nuqleon/Core/BCL/Nuqleon.Memory/System/Memory/MemoizationCacheBase.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/BCL/Nuqleon.Memory/System/Memory/MemoizationCacheBase`2.cs
+++ b/Nuqleon/Core/BCL/Nuqleon.Memory/System/Memory/MemoizationCacheBase`2.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/BCL/Nuqleon.Memory/System/Memory/MemoizationCacheExtensions.cs
+++ b/Nuqleon/Core/BCL/Nuqleon.Memory/System/Memory/MemoizationCacheExtensions.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/BCL/Nuqleon.Memory/System/Memory/MemoizationCacheFactory.Evict.cs
+++ b/Nuqleon/Core/BCL/Nuqleon.Memory/System/Memory/MemoizationCacheFactory.Evict.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/BCL/Nuqleon.Memory/System/Memory/MemoizationCacheFactory.Lru.cs
+++ b/Nuqleon/Core/BCL/Nuqleon.Memory/System/Memory/MemoizationCacheFactory.Lru.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/BCL/Nuqleon.Memory/System/Memory/MemoizationCacheFactory.Nop.cs
+++ b/Nuqleon/Core/BCL/Nuqleon.Memory/System/Memory/MemoizationCacheFactory.Nop.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/BCL/Nuqleon.Memory/System/Memory/MemoizationCacheFactory.Unbounded.cs
+++ b/Nuqleon/Core/BCL/Nuqleon.Memory/System/Memory/MemoizationCacheFactory.Unbounded.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/BCL/Nuqleon.Memory/System/Memory/MemoizationCacheFactory.cs
+++ b/Nuqleon/Core/BCL/Nuqleon.Memory/System/Memory/MemoizationCacheFactory.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/BCL/Nuqleon.Memory/System/Memory/MemoizationCacheFactoryExtensions.cs
+++ b/Nuqleon/Core/BCL/Nuqleon.Memory/System/Memory/MemoizationCacheFactoryExtensions.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/BCL/Nuqleon.Memory/System/Memory/MemoizationOptions.cs
+++ b/Nuqleon/Core/BCL/Nuqleon.Memory/System/Memory/MemoizationOptions.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/BCL/Nuqleon.Memory/System/Memory/MemoizedDelegate.cs
+++ b/Nuqleon/Core/BCL/Nuqleon.Memory/System/Memory/MemoizedDelegate.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/BCL/Nuqleon.Memory/System/Memory/Memoizer.cs
+++ b/Nuqleon/Core/BCL/Nuqleon.Memory/System/Memory/Memoizer.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/BCL/Nuqleon.Memory/System/Memory/ObjectPool.cs
+++ b/Nuqleon/Core/BCL/Nuqleon.Memory/System/Memory/ObjectPool.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/BCL/Nuqleon.Memory/System/Memory/PooledObject.cs
+++ b/Nuqleon/Core/BCL/Nuqleon.Memory/System/Memory/PooledObject.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/BCL/Nuqleon.Memory/System/Memory/SynchronizedMemoizationCacheBase`2.cs
+++ b/Nuqleon/Core/BCL/Nuqleon.Memory/System/Memory/SynchronizedMemoizationCacheBase`2.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/BCL/Nuqleon.Memory/System/Memory/Trimmable.cs
+++ b/Nuqleon/Core/BCL/Nuqleon.Memory/System/Memory/Trimmable.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/BCL/Nuqleon.Memory/System/Memory/UnboundedMemoizationCacheBase`2.cs
+++ b/Nuqleon/Core/BCL/Nuqleon.Memory/System/Memory/UnboundedMemoizationCacheBase`2.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/BCL/Nuqleon.Memory/System/Memory/UnboundedMemoizationCacheWithExceptionBase`2.cs
+++ b/Nuqleon/Core/BCL/Nuqleon.Memory/System/Memory/UnboundedMemoizationCacheWithExceptionBase`2.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/BCL/Nuqleon.Memory/System/Memory/ValueOrError.cs
+++ b/Nuqleon/Core/BCL/Nuqleon.Memory/System/Memory/ValueOrError.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/BCL/Nuqleon.Memory/System/Memory/ValueOrErrorError`1.cs
+++ b/Nuqleon/Core/BCL/Nuqleon.Memory/System/Memory/ValueOrErrorError`1.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/BCL/Nuqleon.Memory/System/Memory/ValueOrErrorKind.cs
+++ b/Nuqleon/Core/BCL/Nuqleon.Memory/System/Memory/ValueOrErrorKind.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/BCL/Nuqleon.Memory/System/Memory/ValueOrErrorValue`1.cs
+++ b/Nuqleon/Core/BCL/Nuqleon.Memory/System/Memory/ValueOrErrorValue`1.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/BCL/Nuqleon.Memory/System/Memory/WeakCacheDictionary.cs
+++ b/Nuqleon/Core/BCL/Nuqleon.Memory/System/Memory/WeakCacheDictionary.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/BCL/Nuqleon.Memory/System/Memory/WeakMemoizationCacheFactory.Evict.cs
+++ b/Nuqleon/Core/BCL/Nuqleon.Memory/System/Memory/WeakMemoizationCacheFactory.Evict.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/BCL/Nuqleon.Memory/System/Memory/WeakMemoizationCacheFactory.Nop.cs
+++ b/Nuqleon/Core/BCL/Nuqleon.Memory/System/Memory/WeakMemoizationCacheFactory.Nop.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/BCL/Nuqleon.Memory/System/Memory/WeakMemoizationCacheFactory.Unbounded.cs
+++ b/Nuqleon/Core/BCL/Nuqleon.Memory/System/Memory/WeakMemoizationCacheFactory.Unbounded.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/BCL/Nuqleon.Memory/System/Memory/WeakMemoizationCacheFactory.cs
+++ b/Nuqleon/Core/BCL/Nuqleon.Memory/System/Memory/WeakMemoizationCacheFactory.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/BCL/Nuqleon.Memory/System/Memory/WeakMemoizationCacheFactoryExtensions.cs
+++ b/Nuqleon/Core/BCL/Nuqleon.Memory/System/Memory/WeakMemoizationCacheFactoryExtensions.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/BCL/Nuqleon.Memory/System/ServiceProviderExtensions.cs
+++ b/Nuqleon/Core/BCL/Nuqleon.Memory/System/ServiceProviderExtensions.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/BCL/Nuqleon.Memory/System/Text/PooledStringBuilder.cs
+++ b/Nuqleon/Core/BCL/Nuqleon.Memory/System/Text/PooledStringBuilder.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/BCL/Nuqleon.Memory/System/Tuplet.Generated.cs
+++ b/Nuqleon/Core/BCL/Nuqleon.Memory/System/Tuplet.Generated.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/BCL/Nuqleon.Memory/System/Tuplet.cs
+++ b/Nuqleon/Core/BCL/Nuqleon.Memory/System/Tuplet.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/BCL/Nuqleon.Memory/System/WeakReferenceExtensions.cs
+++ b/Nuqleon/Core/BCL/Nuqleon.Memory/System/WeakReferenceExtensions.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/BCL/Nuqleon.Reflection.Virtualization/Properties/AssemblyInfo.cs
+++ b/Nuqleon/Core/BCL/Nuqleon.Reflection.Virtualization/Properties/AssemblyInfo.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/BCL/Nuqleon.Reflection.Virtualization/System/Reflection/Virtualization/AssemblyIntrospectionProviderExtensions.cs
+++ b/Nuqleon/Core/BCL/Nuqleon.Reflection.Virtualization/System/Reflection/Virtualization/AssemblyIntrospectionProviderExtensions.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/BCL/Nuqleon.Reflection.Virtualization/System/Reflection/Virtualization/AssemblyLoadingProviderExtensions.cs
+++ b/Nuqleon/Core/BCL/Nuqleon.Reflection.Virtualization/System/Reflection/Virtualization/AssemblyLoadingProviderExtensions.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/BCL/Nuqleon.Reflection.Virtualization/System/Reflection/Virtualization/ComTypeLoadingProviderExtensions.cs
+++ b/Nuqleon/Core/BCL/Nuqleon.Reflection.Virtualization/System/Reflection/Virtualization/ComTypeLoadingProviderExtensions.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/BCL/Nuqleon.Reflection.Virtualization/System/Reflection/Virtualization/Contracts.cs
+++ b/Nuqleon/Core/BCL/Nuqleon.Reflection.Virtualization/System/Reflection/Virtualization/Contracts.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/BCL/Nuqleon.Reflection.Virtualization/System/Reflection/Virtualization/EventInfoIntrospectionProviderExtensions.cs
+++ b/Nuqleon/Core/BCL/Nuqleon.Reflection.Virtualization/System/Reflection/Virtualization/EventInfoIntrospectionProviderExtensions.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/BCL/Nuqleon.Reflection.Virtualization/System/Reflection/Virtualization/FieldInfoIntrospectionProviderExtensions.cs
+++ b/Nuqleon/Core/BCL/Nuqleon.Reflection.Virtualization/System/Reflection/Virtualization/FieldInfoIntrospectionProviderExtensions.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/BCL/Nuqleon.Reflection.Virtualization/System/Reflection/Virtualization/IAssemblyLoadingProvider.cs
+++ b/Nuqleon/Core/BCL/Nuqleon.Reflection.Virtualization/System/Reflection/Virtualization/IAssemblyLoadingProvider.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/BCL/Nuqleon.Reflection.Virtualization/System/Reflection/Virtualization/IComTypeLoadingProvider.cs
+++ b/Nuqleon/Core/BCL/Nuqleon.Reflection.Virtualization/System/Reflection/Virtualization/IComTypeLoadingProvider.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/BCL/Nuqleon.Reflection.Virtualization/System/Reflection/Virtualization/IEventInfoIntrospectionProvider.cs
+++ b/Nuqleon/Core/BCL/Nuqleon.Reflection.Virtualization/System/Reflection/Virtualization/IEventInfoIntrospectionProvider.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/BCL/Nuqleon.Reflection.Virtualization/System/Reflection/Virtualization/IFieldInfoIntrospectionProvider.cs
+++ b/Nuqleon/Core/BCL/Nuqleon.Reflection.Virtualization/System/Reflection/Virtualization/IFieldInfoIntrospectionProvider.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/BCL/Nuqleon.Reflection.Virtualization/System/Reflection/Virtualization/IMemberInfoIntrospectionProvider.cs
+++ b/Nuqleon/Core/BCL/Nuqleon.Reflection.Virtualization/System/Reflection/Virtualization/IMemberInfoIntrospectionProvider.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/BCL/Nuqleon.Reflection.Virtualization/System/Reflection/Virtualization/IMethodBaseIntrospectionProvider.cs
+++ b/Nuqleon/Core/BCL/Nuqleon.Reflection.Virtualization/System/Reflection/Virtualization/IMethodBaseIntrospectionProvider.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/BCL/Nuqleon.Reflection.Virtualization/System/Reflection/Virtualization/IMethodCreationProvider.cs
+++ b/Nuqleon/Core/BCL/Nuqleon.Reflection.Virtualization/System/Reflection/Virtualization/IMethodCreationProvider.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/BCL/Nuqleon.Reflection.Virtualization/System/Reflection/Virtualization/IMethodInfoIntrospectionProvider.cs
+++ b/Nuqleon/Core/BCL/Nuqleon.Reflection.Virtualization/System/Reflection/Virtualization/IMethodInfoIntrospectionProvider.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/BCL/Nuqleon.Reflection.Virtualization/System/Reflection/Virtualization/IModuleIntrospectionProvider.cs
+++ b/Nuqleon/Core/BCL/Nuqleon.Reflection.Virtualization/System/Reflection/Virtualization/IModuleIntrospectionProvider.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/BCL/Nuqleon.Reflection.Virtualization/System/Reflection/Virtualization/IModuleLoadingProvider.cs
+++ b/Nuqleon/Core/BCL/Nuqleon.Reflection.Virtualization/System/Reflection/Virtualization/IModuleLoadingProvider.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/BCL/Nuqleon.Reflection.Virtualization/System/Reflection/Virtualization/IParameterInfoIntrospectionProvider.cs
+++ b/Nuqleon/Core/BCL/Nuqleon.Reflection.Virtualization/System/Reflection/Virtualization/IParameterInfoIntrospectionProvider.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/BCL/Nuqleon.Reflection.Virtualization/System/Reflection/Virtualization/IPropertyInfoIntrospectionProvider.cs
+++ b/Nuqleon/Core/BCL/Nuqleon.Reflection.Virtualization/System/Reflection/Virtualization/IPropertyInfoIntrospectionProvider.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/BCL/Nuqleon.Reflection.Virtualization/System/Reflection/Virtualization/IReflectionCreationProvider.cs
+++ b/Nuqleon/Core/BCL/Nuqleon.Reflection.Virtualization/System/Reflection/Virtualization/IReflectionCreationProvider.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/BCL/Nuqleon.Reflection.Virtualization/System/Reflection/Virtualization/IReflectionHandlerResolver.cs
+++ b/Nuqleon/Core/BCL/Nuqleon.Reflection.Virtualization/System/Reflection/Virtualization/IReflectionHandlerResolver.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/BCL/Nuqleon.Reflection.Virtualization/System/Reflection/Virtualization/IReflectionIntrospectionProvider.cs
+++ b/Nuqleon/Core/BCL/Nuqleon.Reflection.Virtualization/System/Reflection/Virtualization/IReflectionIntrospectionProvider.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/BCL/Nuqleon.Reflection.Virtualization/System/Reflection/Virtualization/IReflectionInvocationProvider.cs
+++ b/Nuqleon/Core/BCL/Nuqleon.Reflection.Virtualization/System/Reflection/Virtualization/IReflectionInvocationProvider.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/BCL/Nuqleon.Reflection.Virtualization/System/Reflection/Virtualization/IReflectionLoadingProvider.cs
+++ b/Nuqleon/Core/BCL/Nuqleon.Reflection.Virtualization/System/Reflection/Virtualization/IReflectionLoadingProvider.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/BCL/Nuqleon.Reflection.Virtualization/System/Reflection/Virtualization/IReflectionProvider.cs
+++ b/Nuqleon/Core/BCL/Nuqleon.Reflection.Virtualization/System/Reflection/Virtualization/IReflectionProvider.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/BCL/Nuqleon.Reflection.Virtualization/System/Reflection/Virtualization/IReflectionTypeSystemProvider.cs
+++ b/Nuqleon/Core/BCL/Nuqleon.Reflection.Virtualization/System/Reflection/Virtualization/IReflectionTypeSystemProvider.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/BCL/Nuqleon.Reflection.Virtualization/System/Reflection/Virtualization/ITypeCreationProvider.cs
+++ b/Nuqleon/Core/BCL/Nuqleon.Reflection.Virtualization/System/Reflection/Virtualization/ITypeCreationProvider.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/BCL/Nuqleon.Reflection.Virtualization/System/Reflection/Virtualization/ITypeLoadingProvider.cs
+++ b/Nuqleon/Core/BCL/Nuqleon.Reflection.Virtualization/System/Reflection/Virtualization/ITypeLoadingProvider.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/BCL/Nuqleon.Reflection.Virtualization/System/Reflection/Virtualization/MethodBaseIntrospectionProviderExtensions.cs
+++ b/Nuqleon/Core/BCL/Nuqleon.Reflection.Virtualization/System/Reflection/Virtualization/MethodBaseIntrospectionProviderExtensions.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/BCL/Nuqleon.Reflection.Virtualization/System/Reflection/Virtualization/ModuleIntrospectionProviderExtensions.cs
+++ b/Nuqleon/Core/BCL/Nuqleon.Reflection.Virtualization/System/Reflection/Virtualization/ModuleIntrospectionProviderExtensions.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/BCL/Nuqleon.Reflection.Virtualization/System/Reflection/Virtualization/ModuleLoadingProviderExtensions.cs
+++ b/Nuqleon/Core/BCL/Nuqleon.Reflection.Virtualization/System/Reflection/Virtualization/ModuleLoadingProviderExtensions.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/BCL/Nuqleon.Reflection.Virtualization/System/Reflection/Virtualization/ParameterInfoIntrospectionProviderExtensions.cs
+++ b/Nuqleon/Core/BCL/Nuqleon.Reflection.Virtualization/System/Reflection/Virtualization/ParameterInfoIntrospectionProviderExtensions.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/BCL/Nuqleon.Reflection.Virtualization/System/Reflection/Virtualization/PropertyInfoIntrospectionProviderExtensions.cs
+++ b/Nuqleon/Core/BCL/Nuqleon.Reflection.Virtualization/System/Reflection/Virtualization/PropertyInfoIntrospectionProviderExtensions.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/BCL/Nuqleon.Reflection.Virtualization/System/Reflection/Virtualization/ReflectionInvocationProviderExtensions.cs
+++ b/Nuqleon/Core/BCL/Nuqleon.Reflection.Virtualization/System/Reflection/Virtualization/ReflectionInvocationProviderExtensions.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/BCL/Nuqleon.Reflection.Virtualization/System/Reflection/Virtualization/ReflectionTypeSystemProviderExtensions.cs
+++ b/Nuqleon/Core/BCL/Nuqleon.Reflection.Virtualization/System/Reflection/Virtualization/ReflectionTypeSystemProviderExtensions.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/BCL/Nuqleon.Reflection.Virtualization/System/Reflection/Virtualization/TypeLoadingProviderExtensions.cs
+++ b/Nuqleon/Core/BCL/Nuqleon.Reflection.Virtualization/System/Reflection/Virtualization/TypeLoadingProviderExtensions.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/BCL/Nuqleon.Runtime.Remoting.Tasks/Properties/AssemblyInfo.cs
+++ b/Nuqleon/Core/BCL/Nuqleon.Runtime.Remoting.Tasks/Properties/AssemblyInfo.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/BCL/Nuqleon.Runtime.Remoting.Tasks/System/Runtime/Remoting/Tasks/ICancellationProvider.cs
+++ b/Nuqleon/Core/BCL/Nuqleon.Runtime.Remoting.Tasks/System/Runtime/Remoting/Tasks/ICancellationProvider.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/BCL/Nuqleon.Runtime.Remoting.Tasks/System/Runtime/Remoting/Tasks/RemoteCancellationDisposable.cs
+++ b/Nuqleon/Core/BCL/Nuqleon.Runtime.Remoting.Tasks/System/Runtime/Remoting/Tasks/RemoteCancellationDisposable.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/BCL/Nuqleon.Runtime.Remoting.Tasks/System/Runtime/Remoting/Tasks/RemoteProxyBase.cs
+++ b/Nuqleon/Core/BCL/Nuqleon.Runtime.Remoting.Tasks/System/Runtime/Remoting/Tasks/RemoteProxyBase.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/BCL/Nuqleon.Runtime.Remoting.Tasks/System/Runtime/Remoting/Tasks/RemoteServiceBase.cs
+++ b/Nuqleon/Core/BCL/Nuqleon.Runtime.Remoting.Tasks/System/Runtime/Remoting/Tasks/RemoteServiceBase.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/BCL/Nuqleon.Runtime.Remoting.Tasks/System/Runtime/Remoting/Tasks/Reply.cs
+++ b/Nuqleon/Core/BCL/Nuqleon.Runtime.Remoting.Tasks/System/Runtime/Remoting/Tasks/Reply.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/BCL/Nuqleon.StringSegment/Properties/AssemblyInfo.cs
+++ b/Nuqleon/Core/BCL/Nuqleon.StringSegment/Properties/AssemblyInfo.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/BCL/Nuqleon.StringSegment/System/Globalization/CompareInfoExtensions.cs
+++ b/Nuqleon/Core/BCL/Nuqleon.StringSegment/System/Globalization/CompareInfoExtensions.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/BCL/Nuqleon.StringSegment/System/StringSegmentCharEnumerator.cs
+++ b/Nuqleon/Core/BCL/Nuqleon.StringSegment/System/StringSegmentCharEnumerator.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/BCL/Nuqleon.StringSegment/System/Text/StringBuilderStringSegmentExtensions.cs
+++ b/Nuqleon/Core/BCL/Nuqleon.StringSegment/System/Text/StringBuilderStringSegmentExtensions.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/BCL/Nuqleon.StringSegment/System/UnsafeCharBuffer.cs
+++ b/Nuqleon/Core/BCL/Nuqleon.StringSegment/System/UnsafeCharBuffer.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/BCL/Nuqleon.Time/Properties/AssemblyInfo.cs
+++ b/Nuqleon/Core/BCL/Nuqleon.Time/Properties/AssemblyInfo.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/BCL/Nuqleon.Time/System/Time/ClockExtensions.cs
+++ b/Nuqleon/Core/BCL/Nuqleon.Time/System/Time/ClockExtensions.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/BCL/Nuqleon.Time/System/Time/IClock.cs
+++ b/Nuqleon/Core/BCL/Nuqleon.Time/System/Time/IClock.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/BCL/Nuqleon.Time/System/Time/IStopwatch.cs
+++ b/Nuqleon/Core/BCL/Nuqleon.Time/System/Time/IStopwatch.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/BCL/Nuqleon.Time/System/Time/IStopwatchFactory.cs
+++ b/Nuqleon/Core/BCL/Nuqleon.Time/System/Time/IStopwatchFactory.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/BCL/Nuqleon.Time/System/Time/StopwatchBase.cs
+++ b/Nuqleon/Core/BCL/Nuqleon.Time/System/Time/StopwatchBase.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/BCL/Nuqleon.Time/System/Time/StopwatchFactory.cs
+++ b/Nuqleon/Core/BCL/Nuqleon.Time/System/Time/StopwatchFactory.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/BCL/Nuqleon.Time/System/Time/StopwatchFactoryExtensions.cs
+++ b/Nuqleon/Core/BCL/Nuqleon.Time/System/Time/StopwatchFactoryExtensions.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/BCL/Nuqleon.Time/System/Time/VirtualTimeClock.cs
+++ b/Nuqleon/Core/BCL/Nuqleon.Time/System/Time/VirtualTimeClock.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/BCL/Tests.Nuqleon.Collections.Specialized/System/Collections/Specialized/BitArrayTests.cs
+++ b/Nuqleon/Core/BCL/Tests.Nuqleon.Collections.Specialized/System/Collections/Specialized/BitArrayTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/BCL/Tests.Nuqleon.Collections.Specialized/System/Collections/Specialized/ByteArrayTests.cs
+++ b/Nuqleon/Core/BCL/Tests.Nuqleon.Collections.Specialized/System/Collections/Specialized/ByteArrayTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/BCL/Tests.Nuqleon.Collections.Specialized/System/Collections/Specialized/EnumDictionaryFactoryTests.cs
+++ b/Nuqleon/Core/BCL/Tests.Nuqleon.Collections.Specialized/System/Collections/Specialized/EnumDictionaryFactoryTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/BCL/Tests.Nuqleon.Collections.Specialized/System/Collections/Specialized/EnumDictionaryFactoryTests.generated.cs
+++ b/Nuqleon/Core/BCL/Tests.Nuqleon.Collections.Specialized/System/Collections/Specialized/EnumDictionaryFactoryTests.generated.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/BCL/Tests.Nuqleon.Collections.Specialized/System/Collections/Specialized/EnumDictionaryTests.cs
+++ b/Nuqleon/Core/BCL/Tests.Nuqleon.Collections.Specialized/System/Collections/Specialized/EnumDictionaryTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/BCL/Tests.Nuqleon.Documentation/Tests.cs
+++ b/Nuqleon/Core/BCL/Tests.Nuqleon.Documentation/Tests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/BCL/Tests.Nuqleon.IO.StreamSegment/System/IO/StreamSegmentTests.cs
+++ b/Nuqleon/Core/BCL/Tests.Nuqleon.IO.StreamSegment/System/IO/StreamSegmentTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/BCL/Tests.Nuqleon.Memory/Dummies/MyClearable.cs
+++ b/Nuqleon/Core/BCL/Tests.Nuqleon.Memory/Dummies/MyClearable.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/BCL/Tests.Nuqleon.Memory/Dummies/MyFreeable.cs
+++ b/Nuqleon/Core/BCL/Tests.Nuqleon.Memory/Dummies/MyFreeable.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/BCL/Tests.Nuqleon.Memory/System/Collections/Generic/PooledDictionaryTests.cs
+++ b/Nuqleon/Core/BCL/Tests.Nuqleon.Memory/System/Collections/Generic/PooledDictionaryTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/BCL/Tests.Nuqleon.Memory/System/Collections/Generic/PooledHashSetTests.cs
+++ b/Nuqleon/Core/BCL/Tests.Nuqleon.Memory/System/Collections/Generic/PooledHashSetTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/BCL/Tests.Nuqleon.Memory/System/Collections/Generic/PooledListTests.cs
+++ b/Nuqleon/Core/BCL/Tests.Nuqleon.Memory/System/Collections/Generic/PooledListTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/BCL/Tests.Nuqleon.Memory/System/Collections/Generic/PooledQueueTests.cs
+++ b/Nuqleon/Core/BCL/Tests.Nuqleon.Memory/System/Collections/Generic/PooledQueueTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/BCL/Tests.Nuqleon.Memory/System/Collections/Generic/PooledStackTests.cs
+++ b/Nuqleon/Core/BCL/Tests.Nuqleon.Memory/System/Collections/Generic/PooledStackTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/BCL/Tests.Nuqleon.Memory/System/IO/PooledMemoryStreamTests.cs
+++ b/Nuqleon/Core/BCL/Tests.Nuqleon.Memory/System/IO/PooledMemoryStreamTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/BCL/Tests.Nuqleon.Memory/System/Memory/BundleTests.cs
+++ b/Nuqleon/Core/BCL/Tests.Nuqleon.Memory/System/Memory/BundleTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/BCL/Tests.Nuqleon.Memory/System/Memory/CacheDictionaryTests.cs
+++ b/Nuqleon/Core/BCL/Tests.Nuqleon.Memory/System/Memory/CacheDictionaryTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/BCL/Tests.Nuqleon.Memory/System/Memory/CacheEntryTests.cs
+++ b/Nuqleon/Core/BCL/Tests.Nuqleon.Memory/System/Memory/CacheEntryTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/BCL/Tests.Nuqleon.Memory/System/Memory/CacheExamples.cs
+++ b/Nuqleon/Core/BCL/Tests.Nuqleon.Memory/System/Memory/CacheExamples.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/BCL/Tests.Nuqleon.Memory/System/Memory/CacheStorageTests.cs
+++ b/Nuqleon/Core/BCL/Tests.Nuqleon.Memory/System/Memory/CacheStorageTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/BCL/Tests.Nuqleon.Memory/System/Memory/CacheTests.Generated.cs
+++ b/Nuqleon/Core/BCL/Tests.Nuqleon.Memory/System/Memory/CacheTests.Generated.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/BCL/Tests.Nuqleon.Memory/System/Memory/CacheTests.cs
+++ b/Nuqleon/Core/BCL/Tests.Nuqleon.Memory/System/Memory/CacheTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/BCL/Tests.Nuqleon.Memory/System/Memory/ConcurrentCacheDictionaryTests.cs
+++ b/Nuqleon/Core/BCL/Tests.Nuqleon.Memory/System/Memory/ConcurrentCacheDictionaryTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/BCL/Tests.Nuqleon.Memory/System/Memory/ConcurrentMemoizationCacheFactoryTests.cs
+++ b/Nuqleon/Core/BCL/Tests.Nuqleon.Memory/System/Memory/ConcurrentMemoizationCacheFactoryTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/BCL/Tests.Nuqleon.Memory/System/Memory/DeconstructedTests.Generated.cs
+++ b/Nuqleon/Core/BCL/Tests.Nuqleon.Memory/System/Memory/DeconstructedTests.Generated.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/BCL/Tests.Nuqleon.Memory/System/Memory/DeconstructedTests.cs
+++ b/Nuqleon/Core/BCL/Tests.Nuqleon.Memory/System/Memory/DeconstructedTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/BCL/Tests.Nuqleon.Memory/System/Memory/EqualityComparerExtensionTests.Generated.cs
+++ b/Nuqleon/Core/BCL/Tests.Nuqleon.Memory/System/Memory/EqualityComparerExtensionTests.Generated.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/BCL/Tests.Nuqleon.Memory/System/Memory/FunctionMemoizationExtensionsTests.Generated.cs
+++ b/Nuqleon/Core/BCL/Tests.Nuqleon.Memory/System/Memory/FunctionMemoizationExtensionsTests.Generated.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/BCL/Tests.Nuqleon.Memory/System/Memory/FunctionMemoizationExtensionsTests.cs
+++ b/Nuqleon/Core/BCL/Tests.Nuqleon.Memory/System/Memory/FunctionMemoizationExtensionsTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/BCL/Tests.Nuqleon.Memory/System/Memory/InternCacheTests.cs
+++ b/Nuqleon/Core/BCL/Tests.Nuqleon.Memory/System/Memory/InternCacheTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/BCL/Tests.Nuqleon.Memory/System/Memory/LruCacheStorageTests.cs
+++ b/Nuqleon/Core/BCL/Tests.Nuqleon.Memory/System/Memory/LruCacheStorageTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/BCL/Tests.Nuqleon.Memory/System/Memory/MemoizationCacheBaseTests.cs
+++ b/Nuqleon/Core/BCL/Tests.Nuqleon.Memory/System/Memory/MemoizationCacheBaseTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/BCL/Tests.Nuqleon.Memory/System/Memory/MemoizationCacheExtensionsTests.cs
+++ b/Nuqleon/Core/BCL/Tests.Nuqleon.Memory/System/Memory/MemoizationCacheExtensionsTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/BCL/Tests.Nuqleon.Memory/System/Memory/MemoizationCacheFactoryExtensionsTests.cs
+++ b/Nuqleon/Core/BCL/Tests.Nuqleon.Memory/System/Memory/MemoizationCacheFactoryExtensionsTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/BCL/Tests.Nuqleon.Memory/System/Memory/MemoizationCacheFactoryTests.cs
+++ b/Nuqleon/Core/BCL/Tests.Nuqleon.Memory/System/Memory/MemoizationCacheFactoryTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/BCL/Tests.Nuqleon.Memory/System/Memory/MemoizationCacheFactoryTestsBase.cs
+++ b/Nuqleon/Core/BCL/Tests.Nuqleon.Memory/System/Memory/MemoizationCacheFactoryTestsBase.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/BCL/Tests.Nuqleon.Memory/System/Memory/MemoizedDelegateCacheTests.cs
+++ b/Nuqleon/Core/BCL/Tests.Nuqleon.Memory/System/Memory/MemoizedDelegateCacheTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/BCL/Tests.Nuqleon.Memory/System/Memory/MemoizerTests.cs
+++ b/Nuqleon/Core/BCL/Tests.Nuqleon.Memory/System/Memory/MemoizerTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/BCL/Tests.Nuqleon.Memory/System/Memory/TrimmableTests.cs
+++ b/Nuqleon/Core/BCL/Tests.Nuqleon.Memory/System/Memory/TrimmableTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/BCL/Tests.Nuqleon.Memory/System/Memory/ValueOrErrorTests.cs
+++ b/Nuqleon/Core/BCL/Tests.Nuqleon.Memory/System/Memory/ValueOrErrorTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/BCL/Tests.Nuqleon.Memory/System/Memory/WeakCacheDictionaryTests.cs
+++ b/Nuqleon/Core/BCL/Tests.Nuqleon.Memory/System/Memory/WeakCacheDictionaryTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/BCL/Tests.Nuqleon.Memory/System/Memory/WeakMemoizationCacheFactoryExtensionsTests.cs
+++ b/Nuqleon/Core/BCL/Tests.Nuqleon.Memory/System/Memory/WeakMemoizationCacheFactoryExtensionsTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/BCL/Tests.Nuqleon.Memory/System/Memory/WeakMemoizationCacheFactoryTests.cs
+++ b/Nuqleon/Core/BCL/Tests.Nuqleon.Memory/System/Memory/WeakMemoizationCacheFactoryTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/BCL/Tests.Nuqleon.Memory/System/ServiceProviderExtensionsTests.cs
+++ b/Nuqleon/Core/BCL/Tests.Nuqleon.Memory/System/ServiceProviderExtensionsTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/BCL/Tests.Nuqleon.Memory/System/Text/PooledStringBuilderTests.cs
+++ b/Nuqleon/Core/BCL/Tests.Nuqleon.Memory/System/Text/PooledStringBuilderTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/BCL/Tests.Nuqleon.Memory/System/TupletTests.Generated.cs
+++ b/Nuqleon/Core/BCL/Tests.Nuqleon.Memory/System/TupletTests.Generated.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/BCL/Tests.Nuqleon.Memory/System/TupletTests.cs
+++ b/Nuqleon/Core/BCL/Tests.Nuqleon.Memory/System/TupletTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/BCL/Tests.Nuqleon.Memory/TestBase.cs
+++ b/Nuqleon/Core/BCL/Tests.Nuqleon.Memory/TestBase.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/BCL/Tests.Nuqleon.Memory/TestHelpers.cs
+++ b/Nuqleon/Core/BCL/Tests.Nuqleon.Memory/TestHelpers.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/BCL/Tests.Nuqleon.Reflection.Virtualization/System/Reflection/VirtualizationTests.cs
+++ b/Nuqleon/Core/BCL/Tests.Nuqleon.Reflection.Virtualization/System/Reflection/VirtualizationTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/BCL/Tests.Nuqleon.Runtime.Remoting.Tasks/System/Runtime/Remoting/Tasks/RemoteBaseTests.cs
+++ b/Nuqleon/Core/BCL/Tests.Nuqleon.Runtime.Remoting.Tasks/System/Runtime/Remoting/Tasks/RemoteBaseTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/BCL/Tests.Nuqleon.Runtime.Remoting.Tasks/System/Runtime/Remoting/Tasks/RemoteCancellationDisposableTests.cs
+++ b/Nuqleon/Core/BCL/Tests.Nuqleon.Runtime.Remoting.Tasks/System/Runtime/Remoting/Tasks/RemoteCancellationDisposableTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/BCL/Tests.Nuqleon.Runtime.Remoting.Tasks/System/Runtime/Remoting/Tasks/ReplyTests.cs
+++ b/Nuqleon/Core/BCL/Tests.Nuqleon.Runtime.Remoting.Tasks/System/Runtime/Remoting/Tasks/ReplyTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/BCL/Tests.Nuqleon.StringSegment/System/Text/StringBuilderStringSegmentExtensionsTests.cs
+++ b/Nuqleon/Core/BCL/Tests.Nuqleon.StringSegment/System/Text/StringBuilderStringSegmentExtensionsTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/BCL/Tests.Nuqleon.Time/System/Time/ClockExtensionsTests.cs
+++ b/Nuqleon/Core/BCL/Tests.Nuqleon.Time/System/Time/ClockExtensionsTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/BCL/Tests.Nuqleon.Time/System/Time/StopwatchTests.cs
+++ b/Nuqleon/Core/BCL/Tests.Nuqleon.Time/System/Time/StopwatchTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/BCL/Tests.Nuqleon.Time/System/Time/VirtualTimeClockTests.cs
+++ b/Nuqleon/Core/BCL/Tests.Nuqleon.Time/System/Time/VirtualTimeClockTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/DataModel/Nuqleon.DataModel.CompilerServices/Bonsai/EntitySubstitution/DataTypeToTypeSlimConverter.cs
+++ b/Nuqleon/Core/DataModel/Nuqleon.DataModel.CompilerServices/Bonsai/EntitySubstitution/DataTypeToTypeSlimConverter.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/DataModel/Nuqleon.DataModel.CompilerServices/Bonsai/EntitySubstitution/EntityTypeSlimSubstitutor.cs
+++ b/Nuqleon/Core/DataModel/Nuqleon.DataModel.CompilerServices/Bonsai/EntitySubstitution/EntityTypeSlimSubstitutor.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/DataModel/Nuqleon.DataModel.CompilerServices/Bonsai/EntitySubstitution/EnumAwareTypeSlimSubstitutor.cs
+++ b/Nuqleon/Core/DataModel/Nuqleon.DataModel.CompilerServices/Bonsai/EntitySubstitution/EnumAwareTypeSlimSubstitutor.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/DataModel/Nuqleon.DataModel.CompilerServices/Bonsai/EntitySubstitution/ExpressionSlimEntityTypeRecordizer.cs
+++ b/Nuqleon/Core/DataModel/Nuqleon.DataModel.CompilerServices/Bonsai/EntitySubstitution/ExpressionSlimEntityTypeRecordizer.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/DataModel/Nuqleon.DataModel.CompilerServices/Bonsai/EntitySubstitution/ExpressionSlimEntityTypeSubstitutor.cs
+++ b/Nuqleon/Core/DataModel/Nuqleon.DataModel.CompilerServices/Bonsai/EntitySubstitution/ExpressionSlimEntityTypeSubstitutor.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/DataModel/Nuqleon.DataModel.CompilerServices/Bonsai/EntitySubstitution/FindEntityTypeSlims.cs
+++ b/Nuqleon/Core/DataModel/Nuqleon.DataModel.CompilerServices/Bonsai/EntitySubstitution/FindEntityTypeSlims.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/DataModel/Nuqleon.DataModel.CompilerServices/Bonsai/EntitySubstitution/PropertyDataSlim.cs
+++ b/Nuqleon/Core/DataModel/Nuqleon.DataModel.CompilerServices/Bonsai/EntitySubstitution/PropertyDataSlim.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/DataModel/Nuqleon.DataModel.CompilerServices/Bonsai/EntitySubstitution/RecordDataTypeToTypeSlimConverter.cs
+++ b/Nuqleon/Core/DataModel/Nuqleon.DataModel.CompilerServices/Bonsai/EntitySubstitution/RecordDataTypeToTypeSlimConverter.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/DataModel/Nuqleon.DataModel.CompilerServices/Bonsai/Expressions/DataModelTypeSpace.cs
+++ b/Nuqleon/Core/DataModel/Nuqleon.DataModel.CompilerServices/Bonsai/Expressions/DataModelTypeSpace.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/DataModel/Nuqleon.DataModel.CompilerServices/Bonsai/Reflection/DataModelConstructorInfoSlim.cs
+++ b/Nuqleon/Core/DataModel/Nuqleon.DataModel.CompilerServices/Bonsai/Reflection/DataModelConstructorInfoSlim.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/DataModel/Nuqleon.DataModel.CompilerServices/Bonsai/Reflection/TypeCarryingTypeToTypeSlimConverter.cs
+++ b/Nuqleon/Core/DataModel/Nuqleon.DataModel.CompilerServices/Bonsai/Reflection/TypeCarryingTypeToTypeSlimConverter.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/DataModel/Nuqleon.DataModel.CompilerServices/EntityTypeSubstitutor.cs
+++ b/Nuqleon/Core/DataModel/Nuqleon.DataModel.CompilerServices/EntityTypeSubstitutor.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/DataModel/Nuqleon.DataModel.CompilerServices/ExpressionEntityTypeAnonymizer.cs
+++ b/Nuqleon/Core/DataModel/Nuqleon.DataModel.CompilerServices/ExpressionEntityTypeAnonymizer.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/DataModel/Nuqleon.DataModel.CompilerServices/ExpressionEntityTypeRecordizer.cs
+++ b/Nuqleon/Core/DataModel/Nuqleon.DataModel.CompilerServices/ExpressionEntityTypeRecordizer.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/DataModel/Nuqleon.DataModel.CompilerServices/ExpressionEntityTypeSubstitutor.cs
+++ b/Nuqleon/Core/DataModel/Nuqleon.DataModel.CompilerServices/ExpressionEntityTypeSubstitutor.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/DataModel/Nuqleon.DataModel.CompilerServices/FindEntityTypes.cs
+++ b/Nuqleon/Core/DataModel/Nuqleon.DataModel.CompilerServices/FindEntityTypes.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/DataModel/Nuqleon.DataModel.CompilerServices/GlobalSuppressions.cs
+++ b/Nuqleon/Core/DataModel/Nuqleon.DataModel.CompilerServices/GlobalSuppressions.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/DataModel/Nuqleon.DataModel.CompilerServices/HashHelpers.cs
+++ b/Nuqleon/Core/DataModel/Nuqleon.DataModel.CompilerServices/HashHelpers.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/DataModel/Nuqleon.DataModel.CompilerServices/Internal/DataTypeHelpers.cs
+++ b/Nuqleon/Core/DataModel/Nuqleon.DataModel.CompilerServices/Internal/DataTypeHelpers.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/DataModel/Nuqleon.DataModel.CompilerServices/Internal/EnumAwareTypeSubstitutor.cs
+++ b/Nuqleon/Core/DataModel/Nuqleon.DataModel.CompilerServices/Internal/EnumAwareTypeSubstitutor.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/DataModel/Nuqleon.DataModel.CompilerServices/Internal/Helpers.cs
+++ b/Nuqleon/Core/DataModel/Nuqleon.DataModel.CompilerServices/Internal/Helpers.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/DataModel/Nuqleon.DataModel.CompilerServices/Internal/TypeExtensions.cs
+++ b/Nuqleon/Core/DataModel/Nuqleon.DataModel.CompilerServices/Internal/TypeExtensions.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/DataModel/Nuqleon.DataModel.CompilerServices/KnownTypeBase.cs
+++ b/Nuqleon/Core/DataModel/Nuqleon.DataModel.CompilerServices/KnownTypeBase.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/DataModel/Nuqleon.DataModel.CompilerServices/Properties/AssemblyInfo.cs
+++ b/Nuqleon/Core/DataModel/Nuqleon.DataModel.CompilerServices/Properties/AssemblyInfo.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/DataModel/Nuqleon.DataModel.CompilerServices/TypeSystem/ArrayDataType.cs
+++ b/Nuqleon/Core/DataModel/Nuqleon.DataModel.CompilerServices/TypeSystem/ArrayDataType.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/DataModel/Nuqleon.DataModel.CompilerServices/TypeSystem/DataEnumValue.cs
+++ b/Nuqleon/Core/DataModel/Nuqleon.DataModel.CompilerServices/TypeSystem/DataEnumValue.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/DataModel/Nuqleon.DataModel.CompilerServices/TypeSystem/DataModelTypeVisitorBase.cs
+++ b/Nuqleon/Core/DataModel/Nuqleon.DataModel.CompilerServices/TypeSystem/DataModelTypeVisitorBase.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/DataModel/Nuqleon.DataModel.CompilerServices/TypeSystem/DataProperty.cs
+++ b/Nuqleon/Core/DataModel/Nuqleon.DataModel.CompilerServices/TypeSystem/DataProperty.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/DataModel/Nuqleon.DataModel.CompilerServices/TypeSystem/DataType.cs
+++ b/Nuqleon/Core/DataModel/Nuqleon.DataModel.CompilerServices/TypeSystem/DataType.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/DataModel/Nuqleon.DataModel.CompilerServices/TypeSystem/DataTypeChecker.cs
+++ b/Nuqleon/Core/DataModel/Nuqleon.DataModel.CompilerServices/TypeSystem/DataTypeChecker.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/DataModel/Nuqleon.DataModel.CompilerServices/TypeSystem/DataTypeEqualityComparer.cs
+++ b/Nuqleon/Core/DataModel/Nuqleon.DataModel.CompilerServices/TypeSystem/DataTypeEqualityComparer.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/DataModel/Nuqleon.DataModel.CompilerServices/TypeSystem/DataTypeError.cs
+++ b/Nuqleon/Core/DataModel/Nuqleon.DataModel.CompilerServices/TypeSystem/DataTypeError.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/DataModel/Nuqleon.DataModel.CompilerServices/TypeSystem/DataTypeException.cs
+++ b/Nuqleon/Core/DataModel/Nuqleon.DataModel.CompilerServices/TypeSystem/DataTypeException.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/DataModel/Nuqleon.DataModel.CompilerServices/TypeSystem/DataTypeKinds.cs
+++ b/Nuqleon/Core/DataModel/Nuqleon.DataModel.CompilerServices/TypeSystem/DataTypeKinds.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/DataModel/Nuqleon.DataModel.CompilerServices/TypeSystem/DataTypeObjectEqualityComparator.cs
+++ b/Nuqleon/Core/DataModel/Nuqleon.DataModel.CompilerServices/TypeSystem/DataTypeObjectEqualityComparator.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/DataModel/Nuqleon.DataModel.CompilerServices/TypeSystem/DataTypeObjectEqualityComparer.cs
+++ b/Nuqleon/Core/DataModel/Nuqleon.DataModel.CompilerServices/TypeSystem/DataTypeObjectEqualityComparer.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/DataModel/Nuqleon.DataModel.CompilerServices/TypeSystem/DataTypeVisitor.Generic.cs
+++ b/Nuqleon/Core/DataModel/Nuqleon.DataModel.CompilerServices/TypeSystem/DataTypeVisitor.Generic.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/DataModel/Nuqleon.DataModel.CompilerServices/TypeSystem/DataTypeVisitor.cs
+++ b/Nuqleon/Core/DataModel/Nuqleon.DataModel.CompilerServices/TypeSystem/DataTypeVisitor.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/DataModel/Nuqleon.DataModel.CompilerServices/TypeSystem/ExpressionDataType.cs
+++ b/Nuqleon/Core/DataModel/Nuqleon.DataModel.CompilerServices/TypeSystem/ExpressionDataType.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/DataModel/Nuqleon.DataModel.CompilerServices/TypeSystem/FunctionDataType.cs
+++ b/Nuqleon/Core/DataModel/Nuqleon.DataModel.CompilerServices/TypeSystem/FunctionDataType.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/DataModel/Nuqleon.DataModel.CompilerServices/TypeSystem/OpenGenericParameterDataType.cs
+++ b/Nuqleon/Core/DataModel/Nuqleon.DataModel.CompilerServices/TypeSystem/OpenGenericParameterDataType.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/DataModel/Nuqleon.DataModel.CompilerServices/TypeSystem/PrimitiveDataType.cs
+++ b/Nuqleon/Core/DataModel/Nuqleon.DataModel.CompilerServices/TypeSystem/PrimitiveDataType.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/DataModel/Nuqleon.DataModel.CompilerServices/TypeSystem/PrimitiveDataTypeKinds.cs
+++ b/Nuqleon/Core/DataModel/Nuqleon.DataModel.CompilerServices/TypeSystem/PrimitiveDataTypeKinds.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/DataModel/Nuqleon.DataModel.CompilerServices/TypeSystem/QuotationDataType.cs
+++ b/Nuqleon/Core/DataModel/Nuqleon.DataModel.CompilerServices/TypeSystem/QuotationDataType.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/DataModel/Nuqleon.DataModel.CompilerServices/TypeSystem/StructuralDataType.cs
+++ b/Nuqleon/Core/DataModel/Nuqleon.DataModel.CompilerServices/TypeSystem/StructuralDataType.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/DataModel/Nuqleon.DataModel.CompilerServices/TypeSystem/StructuralDataTypeKinds.cs
+++ b/Nuqleon/Core/DataModel/Nuqleon.DataModel.CompilerServices/TypeSystem/StructuralDataTypeKinds.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/DataModel/Nuqleon.DataModel.CompilerServices/TypeSystem/StructuralDataTypeReference.cs
+++ b/Nuqleon/Core/DataModel/Nuqleon.DataModel.CompilerServices/TypeSystem/StructuralDataTypeReference.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/DataModel/Nuqleon.DataModel.CompilerServices/TypeSystem/TypeToDataTypeConverter.cs
+++ b/Nuqleon/Core/DataModel/Nuqleon.DataModel.CompilerServices/TypeSystem/TypeToDataTypeConverter.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/DataModel/Nuqleon.DataModel.Serialization.Binary/ArrayPool.cs
+++ b/Nuqleon/Core/DataModel/Nuqleon.DataModel.Serialization.Binary/ArrayPool.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/DataModel/Nuqleon.DataModel.Serialization.Binary/CustomMemoryStreamPool.cs
+++ b/Nuqleon/Core/DataModel/Nuqleon.DataModel.Serialization.Binary/CustomMemoryStreamPool.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/DataModel/Nuqleon.DataModel.Serialization.Binary/DataTypeBinarySerializer.cs
+++ b/Nuqleon/Core/DataModel/Nuqleon.DataModel.Serialization.Binary/DataTypeBinarySerializer.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/DataModel/Nuqleon.DataModel.Serialization.Binary/ExpressionHelpers.cs
+++ b/Nuqleon/Core/DataModel/Nuqleon.DataModel.Serialization.Binary/ExpressionHelpers.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/DataModel/Nuqleon.DataModel.Serialization.Binary/Factory/CycleDetector.cs
+++ b/Nuqleon/Core/DataModel/Nuqleon.DataModel.Serialization.Binary/Factory/CycleDetector.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/DataModel/Nuqleon.DataModel.Serialization.Binary/Factory/DataTypeToCycleDetector.cs
+++ b/Nuqleon/Core/DataModel/Nuqleon.DataModel.Serialization.Binary/Factory/DataTypeToCycleDetector.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/DataModel/Nuqleon.DataModel.Serialization.Binary/Factory/DataTypeToDeserializer.Generated.cs
+++ b/Nuqleon/Core/DataModel/Nuqleon.DataModel.Serialization.Binary/Factory/DataTypeToDeserializer.Generated.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/DataModel/Nuqleon.DataModel.Serialization.Binary/Factory/DataTypeToDeserializer.Primitives.cs
+++ b/Nuqleon/Core/DataModel/Nuqleon.DataModel.Serialization.Binary/Factory/DataTypeToDeserializer.Primitives.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/DataModel/Nuqleon.DataModel.Serialization.Binary/Factory/DataTypeToDeserializer.cs
+++ b/Nuqleon/Core/DataModel/Nuqleon.DataModel.Serialization.Binary/Factory/DataTypeToDeserializer.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/DataModel/Nuqleon.DataModel.Serialization.Binary/Factory/DataTypeToSerializer.Generated.cs
+++ b/Nuqleon/Core/DataModel/Nuqleon.DataModel.Serialization.Binary/Factory/DataTypeToSerializer.Generated.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/DataModel/Nuqleon.DataModel.Serialization.Binary/Factory/DataTypeToSerializer.Primitives.cs
+++ b/Nuqleon/Core/DataModel/Nuqleon.DataModel.Serialization.Binary/Factory/DataTypeToSerializer.Primitives.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/DataModel/Nuqleon.DataModel.Serialization.Binary/Factory/DataTypeToSerializer.cs
+++ b/Nuqleon/Core/DataModel/Nuqleon.DataModel.Serialization.Binary/Factory/DataTypeToSerializer.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/DataModel/Nuqleon.DataModel.Serialization.Binary/GlobalSuppressions.cs
+++ b/Nuqleon/Core/DataModel/Nuqleon.DataModel.Serialization.Binary/GlobalSuppressions.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/DataModel/Nuqleon.DataModel.Serialization.Binary/IExpressionSerializer.cs
+++ b/Nuqleon/Core/DataModel/Nuqleon.DataModel.Serialization.Binary/IExpressionSerializer.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/DataModel/Nuqleon.DataModel.Serialization.Binary/Properties/AssemblyInfo.cs
+++ b/Nuqleon/Core/DataModel/Nuqleon.DataModel.Serialization.Binary/Properties/AssemblyInfo.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/DataModel/Nuqleon.DataModel.Serialization.Binary/Protocol.cs
+++ b/Nuqleon/Core/DataModel/Nuqleon.DataModel.Serialization.Binary/Protocol.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/DataModel/Nuqleon.DataModel.Serialization.Binary/ReflectionConstants.cs
+++ b/Nuqleon/Core/DataModel/Nuqleon.DataModel.Serialization.Binary/ReflectionConstants.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/DataModel/Nuqleon.DataModel.Serialization.Binary/StreamHelpers.Generated.cs
+++ b/Nuqleon/Core/DataModel/Nuqleon.DataModel.Serialization.Binary/StreamHelpers.Generated.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/DataModel/Nuqleon.DataModel.Serialization.Binary/StreamHelpers.cs
+++ b/Nuqleon/Core/DataModel/Nuqleon.DataModel.Serialization.Binary/StreamHelpers.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/DataModel/Nuqleon.DataModel.Serialization.Json/CharArrayPool.cs
+++ b/Nuqleon/Core/DataModel/Nuqleon.DataModel.Serialization.Json/CharArrayPool.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/DataModel/Nuqleon.DataModel.Serialization.Json/DataConverter.cs
+++ b/Nuqleon/Core/DataModel/Nuqleon.DataModel.Serialization.Json/DataConverter.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/DataModel/Nuqleon.DataModel.Serialization.Json/DataSerializer.cs
+++ b/Nuqleon/Core/DataModel/Nuqleon.DataModel.Serialization.Json/DataSerializer.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/DataModel/Nuqleon.DataModel.Serialization.Json/DataSerializerException.cs
+++ b/Nuqleon/Core/DataModel/Nuqleon.DataModel.Serialization.Json/DataSerializerException.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/DataModel/Nuqleon.DataModel.Serialization.Json/ExpressionJsonConverter.cs
+++ b/Nuqleon/Core/DataModel/Nuqleon.DataModel.Serialization.Json/ExpressionJsonConverter.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/DataModel/Nuqleon.DataModel.Serialization.Json/GlobalSuppressions.cs
+++ b/Nuqleon/Core/DataModel/Nuqleon.DataModel.Serialization.Json/GlobalSuppressions.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/DataModel/Nuqleon.DataModel.Serialization.Json/JsonDataSerializer.cs
+++ b/Nuqleon/Core/DataModel/Nuqleon.DataModel.Serialization.Json/JsonDataSerializer.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/DataModel/Nuqleon.DataModel.Serialization.Json/MappingContractResolver.cs
+++ b/Nuqleon/Core/DataModel/Nuqleon.DataModel.Serialization.Json/MappingContractResolver.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/DataModel/Nuqleon.DataModel.Serialization.Json/Properties/AssemblyInfo.cs
+++ b/Nuqleon/Core/DataModel/Nuqleon.DataModel.Serialization.Json/Properties/AssemblyInfo.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/DataModel/Nuqleon.DataModel.Serialization.Json/TypeExtensions.cs
+++ b/Nuqleon/Core/DataModel/Nuqleon.DataModel.Serialization.Json/TypeExtensions.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/DataModel/Nuqleon.DataModel/KnownTypeAttribute.cs
+++ b/Nuqleon/Core/DataModel/Nuqleon.DataModel/KnownTypeAttribute.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/DataModel/Nuqleon.DataModel/MappingAttribute.cs
+++ b/Nuqleon/Core/DataModel/Nuqleon.DataModel/MappingAttribute.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/DataModel/Nuqleon.DataModel/Properties/AssemblyInfo.cs
+++ b/Nuqleon/Core/DataModel/Nuqleon.DataModel/Properties/AssemblyInfo.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/DataModel/Nuqleon.DataModel/Unit.cs
+++ b/Nuqleon/Core/DataModel/Nuqleon.DataModel/Unit.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/DataModel/Tests.Nuqleon.DataModel.CompilerServices/AnonymizationTests.cs
+++ b/Nuqleon/Core/DataModel/Tests.Nuqleon.DataModel.CompilerServices/AnonymizationTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/DataModel/Tests.Nuqleon.DataModel.CompilerServices/Bonsai/EntitySubstitution/DataTypeToTypeSlimConverterTests.cs
+++ b/Nuqleon/Core/DataModel/Tests.Nuqleon.DataModel.CompilerServices/Bonsai/EntitySubstitution/DataTypeToTypeSlimConverterTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/DataModel/Tests.Nuqleon.DataModel.CompilerServices/Bonsai/EntitySubstitution/ExpressionSlimEntityTypeRecordizerTests.More.cs
+++ b/Nuqleon/Core/DataModel/Tests.Nuqleon.DataModel.CompilerServices/Bonsai/EntitySubstitution/ExpressionSlimEntityTypeRecordizerTests.More.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/DataModel/Tests.Nuqleon.DataModel.CompilerServices/Bonsai/EntitySubstitution/ExpressionSlimEntityTypeRecordizerTests.cs
+++ b/Nuqleon/Core/DataModel/Tests.Nuqleon.DataModel.CompilerServices/Bonsai/EntitySubstitution/ExpressionSlimEntityTypeRecordizerTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/DataModel/Tests.Nuqleon.DataModel.CompilerServices/EntityTypeSubstitutorTests.cs
+++ b/Nuqleon/Core/DataModel/Tests.Nuqleon.DataModel.CompilerServices/EntityTypeSubstitutorTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/DataModel/Tests.Nuqleon.DataModel.CompilerServices/ExpressionEntityTypeAnonymizerTests.cs
+++ b/Nuqleon/Core/DataModel/Tests.Nuqleon.DataModel.CompilerServices/ExpressionEntityTypeAnonymizerTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/DataModel/Tests.Nuqleon.DataModel.CompilerServices/ExpressionEntityTypeRecordizerTests.Concurrency.cs
+++ b/Nuqleon/Core/DataModel/Tests.Nuqleon.DataModel.CompilerServices/ExpressionEntityTypeRecordizerTests.Concurrency.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/DataModel/Tests.Nuqleon.DataModel.CompilerServices/ExpressionEntityTypeRecordizerTests.More.cs
+++ b/Nuqleon/Core/DataModel/Tests.Nuqleon.DataModel.CompilerServices/ExpressionEntityTypeRecordizerTests.More.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/DataModel/Tests.Nuqleon.DataModel.CompilerServices/ExpressionEntityTypeRecordizerTests.cs
+++ b/Nuqleon/Core/DataModel/Tests.Nuqleon.DataModel.CompilerServices/ExpressionEntityTypeRecordizerTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/DataModel/Tests.Nuqleon.DataModel.CompilerServices/FindEntityTypesTests.cs
+++ b/Nuqleon/Core/DataModel/Tests.Nuqleon.DataModel.CompilerServices/FindEntityTypesTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/DataModel/Tests.Nuqleon.DataModel.CompilerServices/GlobalSuppressions.cs
+++ b/Nuqleon/Core/DataModel/Tests.Nuqleon.DataModel.CompilerServices/GlobalSuppressions.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/DataModel/Tests.Nuqleon.DataModel.CompilerServices/Helpers/ExpressionComparator.cs
+++ b/Nuqleon/Core/DataModel/Tests.Nuqleon.DataModel.CompilerServices/Helpers/ExpressionComparator.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/DataModel/Tests.Nuqleon.DataModel.CompilerServices/Helpers/MemberComparator.cs
+++ b/Nuqleon/Core/DataModel/Tests.Nuqleon.DataModel.CompilerServices/Helpers/MemberComparator.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/DataModel/Tests.Nuqleon.DataModel.CompilerServices/Helpers/ObjectComparator.cs
+++ b/Nuqleon/Core/DataModel/Tests.Nuqleon.DataModel.CompilerServices/Helpers/ObjectComparator.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/DataModel/Tests.Nuqleon.DataModel.CompilerServices/Helpers/RecordTreeComparator.cs
+++ b/Nuqleon/Core/DataModel/Tests.Nuqleon.DataModel.CompilerServices/Helpers/RecordTreeComparator.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/DataModel/Tests.Nuqleon.DataModel.CompilerServices/Helpers/RecordizingBonsaiSerializer.cs
+++ b/Nuqleon/Core/DataModel/Tests.Nuqleon.DataModel.CompilerServices/Helpers/RecordizingBonsaiSerializer.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/DataModel/Tests.Nuqleon.DataModel.CompilerServices/Helpers/SerializationHelper.cs
+++ b/Nuqleon/Core/DataModel/Tests.Nuqleon.DataModel.CompilerServices/Helpers/SerializationHelper.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/DataModel/Tests.Nuqleon.DataModel.CompilerServices/Helpers/TypeComparator.cs
+++ b/Nuqleon/Core/DataModel/Tests.Nuqleon.DataModel.CompilerServices/Helpers/TypeComparator.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/DataModel/Tests.Nuqleon.DataModel.CompilerServices/KnownTypeBaseTests.cs
+++ b/Nuqleon/Core/DataModel/Tests.Nuqleon.DataModel.CompilerServices/KnownTypeBaseTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/DataModel/Tests.Nuqleon.DataModel.CompilerServices/NoEntityTypesRemainingChecker.cs
+++ b/Nuqleon/Core/DataModel/Tests.Nuqleon.DataModel.CompilerServices/NoEntityTypesRemainingChecker.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/DataModel/Tests.Nuqleon.DataModel.CompilerServices/TestClasses.cs
+++ b/Nuqleon/Core/DataModel/Tests.Nuqleon.DataModel.CompilerServices/TestClasses.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/DataModel/Tests.Nuqleon.DataModel.CompilerServices/TypeSystem/DataTypeCheckerTests.cs
+++ b/Nuqleon/Core/DataModel/Tests.Nuqleon.DataModel.CompilerServices/TypeSystem/DataTypeCheckerTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/DataModel/Tests.Nuqleon.DataModel.CompilerServices/TypeSystem/DataTypeExceptionTests.cs
+++ b/Nuqleon/Core/DataModel/Tests.Nuqleon.DataModel.CompilerServices/TypeSystem/DataTypeExceptionTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/DataModel/Tests.Nuqleon.DataModel.CompilerServices/TypeSystem/DataTypeObjectEqualityComparerTests.cs
+++ b/Nuqleon/Core/DataModel/Tests.Nuqleon.DataModel.CompilerServices/TypeSystem/DataTypeObjectEqualityComparerTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/DataModel/Tests.Nuqleon.DataModel.CompilerServices/TypeSystem/DataTypeTests.cs
+++ b/Nuqleon/Core/DataModel/Tests.Nuqleon.DataModel.CompilerServices/TypeSystem/DataTypeTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/DataModel/Tests.Nuqleon.DataModel.CompilerServices/TypeSystem/DataTypeVisitorTests.cs
+++ b/Nuqleon/Core/DataModel/Tests.Nuqleon.DataModel.CompilerServices/TypeSystem/DataTypeVisitorTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/DataModel/Tests.Nuqleon.DataModel.Serialization.Binary/ArrayPoolTests.cs
+++ b/Nuqleon/Core/DataModel/Tests.Nuqleon.DataModel.Serialization.Binary/ArrayPoolTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/DataModel/Tests.Nuqleon.DataModel.Serialization.Binary/DataModelSerializerFactory.TestCases.cs
+++ b/Nuqleon/Core/DataModel/Tests.Nuqleon.DataModel.Serialization.Binary/DataModelSerializerFactory.TestCases.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/DataModel/Tests.Nuqleon.DataModel.Serialization.Binary/DataModelSerializerFactoryParallelTests.cs
+++ b/Nuqleon/Core/DataModel/Tests.Nuqleon.DataModel.Serialization.Binary/DataModelSerializerFactoryParallelTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/DataModel/Tests.Nuqleon.DataModel.Serialization.Binary/DataModelSerializerFactoryTests.cs
+++ b/Nuqleon/Core/DataModel/Tests.Nuqleon.DataModel.Serialization.Binary/DataModelSerializerFactoryTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/DataModel/Tests.Nuqleon.DataModel.Serialization.Binary/DataTypeToCycleDetectorTests.cs
+++ b/Nuqleon/Core/DataModel/Tests.Nuqleon.DataModel.Serialization.Binary/DataTypeToCycleDetectorTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/DataModel/Tests.Nuqleon.DataModel.Serialization.Binary/GlobalSuppressions.cs
+++ b/Nuqleon/Core/DataModel/Tests.Nuqleon.DataModel.Serialization.Binary/GlobalSuppressions.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/DataModel/Tests.Nuqleon.DataModel.Serialization.Binary/SerializationTestCases.Generated.cs
+++ b/Nuqleon/Core/DataModel/Tests.Nuqleon.DataModel.Serialization.Binary/SerializationTestCases.Generated.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/DataModel/Tests.Nuqleon.DataModel.Serialization.Binary/StreamHelpersTests.Generated.cs
+++ b/Nuqleon/Core/DataModel/Tests.Nuqleon.DataModel.Serialization.Binary/StreamHelpersTests.Generated.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/DataModel/Tests.Nuqleon.DataModel.Serialization.Binary/StreamHelpersTests.cs
+++ b/Nuqleon/Core/DataModel/Tests.Nuqleon.DataModel.Serialization.Binary/StreamHelpersTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/DataModel/Tests.Nuqleon.DataModel.Serialization.Json/DataSerializerExceptionTests.cs
+++ b/Nuqleon/Core/DataModel/Tests.Nuqleon.DataModel.Serialization.Json/DataSerializerExceptionTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/DataModel/Tests.Nuqleon.DataModel.Serialization.Json/DataSerializerTests.Concurrency.cs
+++ b/Nuqleon/Core/DataModel/Tests.Nuqleon.DataModel.Serialization.Json/DataSerializerTests.Concurrency.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/DataModel/Tests.Nuqleon.DataModel.Serialization.Json/DataSerializerTests.More.cs
+++ b/Nuqleon/Core/DataModel/Tests.Nuqleon.DataModel.Serialization.Json/DataSerializerTests.More.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/DataModel/Tests.Nuqleon.DataModel.Serialization.Json/DataSerializerTests.cs
+++ b/Nuqleon/Core/DataModel/Tests.Nuqleon.DataModel.Serialization.Json/DataSerializerTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/DataModel/Tests.Nuqleon.DataModel.Serialization.Json/ExpressionJsonConverterTests.cs
+++ b/Nuqleon/Core/DataModel/Tests.Nuqleon.DataModel.Serialization.Json/ExpressionJsonConverterTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/DataModel/Tests.Nuqleon.DataModel.Serialization.Json/TestClasses.cs
+++ b/Nuqleon/Core/DataModel/Tests.Nuqleon.DataModel.Serialization.Json/TestClasses.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/DataModel/Tests.Nuqleon.DataModel/UnitTests.cs
+++ b/Nuqleon/Core/DataModel/Tests.Nuqleon.DataModel/UnitTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/JSON/Nuqleon.Json.Interop.Newtonsoft/GlobalSuppressions.cs
+++ b/Nuqleon/Core/JSON/Nuqleon.Json.Interop.Newtonsoft/GlobalSuppressions.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/JSON/Nuqleon.Json.Interop.Newtonsoft/JsonExpressionReader.cs
+++ b/Nuqleon/Core/JSON/Nuqleon.Json.Interop.Newtonsoft/JsonExpressionReader.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/JSON/Nuqleon.Json.Interop.Newtonsoft/JsonExpressionWriter.cs
+++ b/Nuqleon/Core/JSON/Nuqleon.Json.Interop.Newtonsoft/JsonExpressionWriter.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/JSON/Nuqleon.Json.Interop.Newtonsoft/JsonInteropResourcePool.cs
+++ b/Nuqleon/Core/JSON/Nuqleon.Json.Interop.Newtonsoft/JsonInteropResourcePool.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/JSON/Nuqleon.Json.Interop.Newtonsoft/Properties/AssemblyInfo.cs
+++ b/Nuqleon/Core/JSON/Nuqleon.Json.Interop.Newtonsoft/Properties/AssemblyInfo.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/JSON/Nuqleon.Json.Interop.Newtonsoft/Token.cs
+++ b/Nuqleon/Core/JSON/Nuqleon.Json.Interop.Newtonsoft/Token.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/JSON/Nuqleon.Json.Interop.Newtonsoft/TokenStack.cs
+++ b/Nuqleon/Core/JSON/Nuqleon.Json.Interop.Newtonsoft/TokenStack.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/JSON/Nuqleon.Json.Serialization/ArrayBuilder.cs
+++ b/Nuqleon/Core/JSON/Nuqleon.Json.Serialization/ArrayBuilder.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/JSON/Nuqleon.Json.Serialization/Compiler/CompiledTrie.cs
+++ b/Nuqleon/Core/JSON/Nuqleon.Json.Serialization/Compiler/CompiledTrie.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/JSON/Nuqleon.Json.Serialization/Compiler/EvalTrie.cs
+++ b/Nuqleon/Core/JSON/Nuqleon.Json.Serialization/Compiler/EvalTrie.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/JSON/Nuqleon.Json.Serialization/Compiler/ExpressionCache.cs
+++ b/Nuqleon/Core/JSON/Nuqleon.Json.Serialization/Compiler/ExpressionCache.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/JSON/Nuqleon.Json.Serialization/Compiler/ReflectionCache.cs
+++ b/Nuqleon/Core/JSON/Nuqleon.Json.Serialization/Compiler/ReflectionCache.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/JSON/Nuqleon.Json.Serialization/Compiler/SyntaxTrie.cs
+++ b/Nuqleon/Core/JSON/Nuqleon.Json.Serialization/Compiler/SyntaxTrie.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/JSON/Nuqleon.Json.Serialization/Compiler/SyntaxTrieNode.cs
+++ b/Nuqleon/Core/JSON/Nuqleon.Json.Serialization/Compiler/SyntaxTrieNode.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/JSON/Nuqleon.Json.Serialization/DefaultNameProvider.cs
+++ b/Nuqleon/Core/JSON/Nuqleon.Json.Serialization/DefaultNameProvider.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/JSON/Nuqleon.Json.Serialization/DefaultNameResolver.cs
+++ b/Nuqleon/Core/JSON/Nuqleon.Json.Serialization/DefaultNameResolver.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/JSON/Nuqleon.Json.Serialization/Emitter/EmitAction.cs
+++ b/Nuqleon/Core/JSON/Nuqleon.Json.Serialization/Emitter/EmitAction.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/JSON/Nuqleon.Json.Serialization/Emitter/Emitter.Any.cs
+++ b/Nuqleon/Core/JSON/Nuqleon.Json.Serialization/Emitter/Emitter.Any.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/JSON/Nuqleon.Json.Serialization/Emitter/Emitter.Boolean.cs
+++ b/Nuqleon/Core/JSON/Nuqleon.Json.Serialization/Emitter/Emitter.Boolean.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/JSON/Nuqleon.Json.Serialization/Emitter/Emitter.Char.cs
+++ b/Nuqleon/Core/JSON/Nuqleon.Json.Serialization/Emitter/Emitter.Char.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/JSON/Nuqleon.Json.Serialization/Emitter/Emitter.DateTime.cs
+++ b/Nuqleon/Core/JSON/Nuqleon.Json.Serialization/Emitter/Emitter.DateTime.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/JSON/Nuqleon.Json.Serialization/Emitter/Emitter.Integers.Generated.cs
+++ b/Nuqleon/Core/JSON/Nuqleon.Json.Serialization/Emitter/Emitter.Integers.Generated.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/JSON/Nuqleon.Json.Serialization/Emitter/Emitter.Nullable.Generated.cs
+++ b/Nuqleon/Core/JSON/Nuqleon.Json.Serialization/Emitter/Emitter.Nullable.Generated.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/JSON/Nuqleon.Json.Serialization/Emitter/Emitter.Reals.Generated.cs
+++ b/Nuqleon/Core/JSON/Nuqleon.Json.Serialization/Emitter/Emitter.Reals.Generated.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/JSON/Nuqleon.Json.Serialization/Emitter/Emitter.String.cs
+++ b/Nuqleon/Core/JSON/Nuqleon.Json.Serialization/Emitter/Emitter.String.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/JSON/Nuqleon.Json.Serialization/Emitter/Emitter.cs
+++ b/Nuqleon/Core/JSON/Nuqleon.Json.Serialization/Emitter/Emitter.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/JSON/Nuqleon.Json.Serialization/Emitter/EmitterContext.CycleDetection.cs
+++ b/Nuqleon/Core/JSON/Nuqleon.Json.Serialization/Emitter/EmitterContext.CycleDetection.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/JSON/Nuqleon.Json.Serialization/Emitter/EmitterContext.LateBinding.cs
+++ b/Nuqleon/Core/JSON/Nuqleon.Json.Serialization/Emitter/EmitterContext.LateBinding.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/JSON/Nuqleon.Json.Serialization/Emitter/EmitterContext.cs
+++ b/Nuqleon/Core/JSON/Nuqleon.Json.Serialization/Emitter/EmitterContext.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/JSON/Nuqleon.Json.Serialization/FastJsonConcurrencyMode.cs
+++ b/Nuqleon/Core/JSON/Nuqleon.Json.Serialization/FastJsonConcurrencyMode.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/JSON/Nuqleon.Json.Serialization/FastJsonSerializerFactory.Deserializer.cs
+++ b/Nuqleon/Core/JSON/Nuqleon.Json.Serialization/FastJsonSerializerFactory.Deserializer.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/JSON/Nuqleon.Json.Serialization/FastJsonSerializerFactory.DeserializerBase.cs
+++ b/Nuqleon/Core/JSON/Nuqleon.Json.Serialization/FastJsonSerializerFactory.DeserializerBase.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/JSON/Nuqleon.Json.Serialization/FastJsonSerializerFactory.EmitterStringBuilder.cs
+++ b/Nuqleon/Core/JSON/Nuqleon.Json.Serialization/FastJsonSerializerFactory.EmitterStringBuilder.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/JSON/Nuqleon.Json.Serialization/FastJsonSerializerFactory.EmitterWriterBuilder.cs
+++ b/Nuqleon/Core/JSON/Nuqleon.Json.Serialization/FastJsonSerializerFactory.EmitterWriterBuilder.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/JSON/Nuqleon.Json.Serialization/FastJsonSerializerFactory.ParserReaderBuilder.cs
+++ b/Nuqleon/Core/JSON/Nuqleon.Json.Serialization/FastJsonSerializerFactory.ParserReaderBuilder.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/JSON/Nuqleon.Json.Serialization/FastJsonSerializerFactory.ParserStringBuilder.cs
+++ b/Nuqleon/Core/JSON/Nuqleon.Json.Serialization/FastJsonSerializerFactory.ParserStringBuilder.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/JSON/Nuqleon.Json.Serialization/FastJsonSerializerFactory.SafeDeserializer.cs
+++ b/Nuqleon/Core/JSON/Nuqleon.Json.Serialization/FastJsonSerializerFactory.SafeDeserializer.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/JSON/Nuqleon.Json.Serialization/FastJsonSerializerFactory.SafeSerializer.cs
+++ b/Nuqleon/Core/JSON/Nuqleon.Json.Serialization/FastJsonSerializerFactory.SafeSerializer.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/JSON/Nuqleon.Json.Serialization/FastJsonSerializerFactory.Serializer.cs
+++ b/Nuqleon/Core/JSON/Nuqleon.Json.Serialization/FastJsonSerializerFactory.Serializer.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/JSON/Nuqleon.Json.Serialization/FastJsonSerializerFactory.SerializerBase.cs
+++ b/Nuqleon/Core/JSON/Nuqleon.Json.Serialization/FastJsonSerializerFactory.SerializerBase.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/JSON/Nuqleon.Json.Serialization/FastJsonSerializerFactory.cs
+++ b/Nuqleon/Core/JSON/Nuqleon.Json.Serialization/FastJsonSerializerFactory.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/JSON/Nuqleon.Json.Serialization/FastJsonSerializerSettings.cs
+++ b/Nuqleon/Core/JSON/Nuqleon.Json.Serialization/FastJsonSerializerSettings.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/JSON/Nuqleon.Json.Serialization/GlobalSuppressions.cs
+++ b/Nuqleon/Core/JSON/Nuqleon.Json.Serialization/GlobalSuppressions.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/JSON/Nuqleon.Json.Serialization/IFastJsonDeserializer.cs
+++ b/Nuqleon/Core/JSON/Nuqleon.Json.Serialization/IFastJsonDeserializer.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/JSON/Nuqleon.Json.Serialization/IFastJsonSerializer.cs
+++ b/Nuqleon/Core/JSON/Nuqleon.Json.Serialization/IFastJsonSerializer.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/JSON/Nuqleon.Json.Serialization/INameProvider.cs
+++ b/Nuqleon/Core/JSON/Nuqleon.Json.Serialization/INameProvider.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/JSON/Nuqleon.Json.Serialization/INameResolver.cs
+++ b/Nuqleon/Core/JSON/Nuqleon.Json.Serialization/INameResolver.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/JSON/Nuqleon.Json.Serialization/Parser/ConcurrentStringPool.cs
+++ b/Nuqleon/Core/JSON/Nuqleon.Json.Serialization/Parser/ConcurrentStringPool.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/JSON/Nuqleon.Json.Serialization/Parser/ParseFunc.cs
+++ b/Nuqleon/Core/JSON/Nuqleon.Json.Serialization/Parser/ParseFunc.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/JSON/Nuqleon.Json.Serialization/Parser/Parser.Any.cs
+++ b/Nuqleon/Core/JSON/Nuqleon.Json.Serialization/Parser/Parser.Any.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/JSON/Nuqleon.Json.Serialization/Parser/Parser.Boolean.cs
+++ b/Nuqleon/Core/JSON/Nuqleon.Json.Serialization/Parser/Parser.Boolean.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/JSON/Nuqleon.Json.Serialization/Parser/Parser.Char.cs
+++ b/Nuqleon/Core/JSON/Nuqleon.Json.Serialization/Parser/Parser.Char.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/JSON/Nuqleon.Json.Serialization/Parser/Parser.DateTime.cs
+++ b/Nuqleon/Core/JSON/Nuqleon.Json.Serialization/Parser/Parser.DateTime.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/JSON/Nuqleon.Json.Serialization/Parser/Parser.FastLexer.cs
+++ b/Nuqleon/Core/JSON/Nuqleon.Json.Serialization/Parser/Parser.FastLexer.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/JSON/Nuqleon.Json.Serialization/Parser/Parser.Integers.Generated.cs
+++ b/Nuqleon/Core/JSON/Nuqleon.Json.Serialization/Parser/Parser.Integers.Generated.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/JSON/Nuqleon.Json.Serialization/Parser/Parser.Nullable.Generated.cs
+++ b/Nuqleon/Core/JSON/Nuqleon.Json.Serialization/Parser/Parser.Nullable.Generated.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/JSON/Nuqleon.Json.Serialization/Parser/Parser.Reals.Generated.cs
+++ b/Nuqleon/Core/JSON/Nuqleon.Json.Serialization/Parser/Parser.Reals.Generated.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/JSON/Nuqleon.Json.Serialization/Parser/Parser.String.cs
+++ b/Nuqleon/Core/JSON/Nuqleon.Json.Serialization/Parser/Parser.String.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/JSON/Nuqleon.Json.Serialization/Parser/Parser.cs
+++ b/Nuqleon/Core/JSON/Nuqleon.Json.Serialization/Parser/Parser.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/JSON/Nuqleon.Json.Serialization/Parser/ParserContext.cs
+++ b/Nuqleon/Core/JSON/Nuqleon.Json.Serialization/Parser/ParserContext.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/JSON/Nuqleon.Json.Serialization/Parser/StringPool.cs
+++ b/Nuqleon/Core/JSON/Nuqleon.Json.Serialization/Parser/StringPool.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/JSON/Nuqleon.Json.Serialization/Properties/AssemblyInfo.cs
+++ b/Nuqleon/Core/JSON/Nuqleon.Json.Serialization/Properties/AssemblyInfo.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/JSON/Nuqleon.Json/Expressions/ArrayExpression.Generated.cs
+++ b/Nuqleon/Core/JSON/Nuqleon.Json/Expressions/ArrayExpression.Generated.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/JSON/Nuqleon.Json/Expressions/ArrayExpression.cs
+++ b/Nuqleon/Core/JSON/Nuqleon.Json/Expressions/ArrayExpression.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/JSON/Nuqleon.Json/Expressions/BooleanConstantExpression.cs
+++ b/Nuqleon/Core/JSON/Nuqleon.Json/Expressions/BooleanConstantExpression.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/JSON/Nuqleon.Json/Expressions/ConstantExpression.cs
+++ b/Nuqleon/Core/JSON/Nuqleon.Json/Expressions/ConstantExpression.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/JSON/Nuqleon.Json/Expressions/Expression.cs
+++ b/Nuqleon/Core/JSON/Nuqleon.Json/Expressions/Expression.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/JSON/Nuqleon.Json/Expressions/ExpressionType.cs
+++ b/Nuqleon/Core/JSON/Nuqleon.Json/Expressions/ExpressionType.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/JSON/Nuqleon.Json/Expressions/ExpressionVisitor.cs
+++ b/Nuqleon/Core/JSON/Nuqleon.Json/Expressions/ExpressionVisitor.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/JSON/Nuqleon.Json/Expressions/JsonPrinter.cs
+++ b/Nuqleon/Core/JSON/Nuqleon.Json/Expressions/JsonPrinter.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/JSON/Nuqleon.Json/Expressions/NullConstantExpression.cs
+++ b/Nuqleon/Core/JSON/Nuqleon.Json/Expressions/NullConstantExpression.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/JSON/Nuqleon.Json/Expressions/NumberConstantExpression.cs
+++ b/Nuqleon/Core/JSON/Nuqleon.Json/Expressions/NumberConstantExpression.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/JSON/Nuqleon.Json/Expressions/ObjectExpression.cs
+++ b/Nuqleon/Core/JSON/Nuqleon.Json/Expressions/ObjectExpression.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/JSON/Nuqleon.Json/Expressions/PrettyPrinter.cs
+++ b/Nuqleon/Core/JSON/Nuqleon.Json/Expressions/PrettyPrinter.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/JSON/Nuqleon.Json/Expressions/StringConstantExpression.cs
+++ b/Nuqleon/Core/JSON/Nuqleon.Json/Expressions/StringConstantExpression.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/JSON/Nuqleon.Json/GlobalSuppressions.cs
+++ b/Nuqleon/Core/JSON/Nuqleon.Json/GlobalSuppressions.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/JSON/Nuqleon.Json/Internal/Extensions.cs
+++ b/Nuqleon/Core/JSON/Nuqleon.Json/Internal/Extensions.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/JSON/Nuqleon.Json/Parser/ParseError.cs
+++ b/Nuqleon/Core/JSON/Nuqleon.Json/Parser/ParseError.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/JSON/Nuqleon.Json/Parser/ParseException.cs
+++ b/Nuqleon/Core/JSON/Nuqleon.Json/Parser/ParseException.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/JSON/Nuqleon.Json/Parser/Parser.cs
+++ b/Nuqleon/Core/JSON/Nuqleon.Json/Parser/Parser.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/JSON/Nuqleon.Json/Parser/Token.cs
+++ b/Nuqleon/Core/JSON/Nuqleon.Json/Parser/Token.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/JSON/Nuqleon.Json/Parser/TokenType.cs
+++ b/Nuqleon/Core/JSON/Nuqleon.Json/Parser/TokenType.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/JSON/Nuqleon.Json/Parser/Tokenizer.cs
+++ b/Nuqleon/Core/JSON/Nuqleon.Json/Parser/Tokenizer.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/JSON/Nuqleon.Json/Properties/AssemblyInfo.cs
+++ b/Nuqleon/Core/JSON/Nuqleon.Json/Properties/AssemblyInfo.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/JSON/Perf.Nuqleon.Json.Serialization/Benchmarks.cs
+++ b/Nuqleon/Core/JSON/Perf.Nuqleon.Json.Serialization/Benchmarks.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/JSON/Perf.Nuqleon.Json.Serialization/Program.cs
+++ b/Nuqleon/Core/JSON/Perf.Nuqleon.Json.Serialization/Program.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/JSON/Tests.Nuqleon.Json.Interop.Newtonsoft/BigTypes.cs
+++ b/Nuqleon/Core/JSON/Tests.Nuqleon.Json.Interop.Newtonsoft/BigTypes.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/JSON/Tests.Nuqleon.Json.Interop.Newtonsoft/JsonExpressionReaderTests.cs
+++ b/Nuqleon/Core/JSON/Tests.Nuqleon.Json.Interop.Newtonsoft/JsonExpressionReaderTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/JSON/Tests.Nuqleon.Json.Interop.Newtonsoft/JsonExpressionWriterTests.cs
+++ b/Nuqleon/Core/JSON/Tests.Nuqleon.Json.Interop.Newtonsoft/JsonExpressionWriterTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/JSON/Tests.Nuqleon.Json.Interop.Newtonsoft/TokenStackTests.cs
+++ b/Nuqleon/Core/JSON/Tests.Nuqleon.Json.Interop.Newtonsoft/TokenStackTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/JSON/Tests.Nuqleon.Json.Serialization/DefaultNameProviderTests.cs
+++ b/Nuqleon/Core/JSON/Tests.Nuqleon.Json.Serialization/DefaultNameProviderTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/JSON/Tests.Nuqleon.Json.Serialization/DefaultNameResolverTests.cs
+++ b/Nuqleon/Core/JSON/Tests.Nuqleon.Json.Serialization/DefaultNameResolverTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/JSON/Tests.Nuqleon.Json.Serialization/DeserializerTests.Integers.Generated.cs
+++ b/Nuqleon/Core/JSON/Tests.Nuqleon.Json.Serialization/DeserializerTests.Integers.Generated.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/JSON/Tests.Nuqleon.Json.Serialization/DeserializerTests.cs
+++ b/Nuqleon/Core/JSON/Tests.Nuqleon.Json.Serialization/DeserializerTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/JSON/Tests.Nuqleon.Json.Serialization/EmitterTests.Boolean.cs
+++ b/Nuqleon/Core/JSON/Tests.Nuqleon.Json.Serialization/EmitterTests.Boolean.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/JSON/Tests.Nuqleon.Json.Serialization/EmitterTests.Char.cs
+++ b/Nuqleon/Core/JSON/Tests.Nuqleon.Json.Serialization/EmitterTests.Char.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/JSON/Tests.Nuqleon.Json.Serialization/EmitterTests.DateTime.cs
+++ b/Nuqleon/Core/JSON/Tests.Nuqleon.Json.Serialization/EmitterTests.DateTime.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/JSON/Tests.Nuqleon.Json.Serialization/EmitterTests.Integers.Generated.cs
+++ b/Nuqleon/Core/JSON/Tests.Nuqleon.Json.Serialization/EmitterTests.Integers.Generated.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/JSON/Tests.Nuqleon.Json.Serialization/EmitterTests.Reals.cs
+++ b/Nuqleon/Core/JSON/Tests.Nuqleon.Json.Serialization/EmitterTests.Reals.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/JSON/Tests.Nuqleon.Json.Serialization/EmitterTests.String.cs
+++ b/Nuqleon/Core/JSON/Tests.Nuqleon.Json.Serialization/EmitterTests.String.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/JSON/Tests.Nuqleon.Json.Serialization/EmitterTests.cs
+++ b/Nuqleon/Core/JSON/Tests.Nuqleon.Json.Serialization/EmitterTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/JSON/Tests.Nuqleon.Json.Serialization/ParserTests.Boolean.cs
+++ b/Nuqleon/Core/JSON/Tests.Nuqleon.Json.Serialization/ParserTests.Boolean.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/JSON/Tests.Nuqleon.Json.Serialization/ParserTests.Char.cs
+++ b/Nuqleon/Core/JSON/Tests.Nuqleon.Json.Serialization/ParserTests.Char.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/JSON/Tests.Nuqleon.Json.Serialization/ParserTests.DateTime.cs
+++ b/Nuqleon/Core/JSON/Tests.Nuqleon.Json.Serialization/ParserTests.DateTime.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/JSON/Tests.Nuqleon.Json.Serialization/ParserTests.FastLexer.cs
+++ b/Nuqleon/Core/JSON/Tests.Nuqleon.Json.Serialization/ParserTests.FastLexer.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/JSON/Tests.Nuqleon.Json.Serialization/ParserTests.Integers.Generated.cs
+++ b/Nuqleon/Core/JSON/Tests.Nuqleon.Json.Serialization/ParserTests.Integers.Generated.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/JSON/Tests.Nuqleon.Json.Serialization/ParserTests.Reals.cs
+++ b/Nuqleon/Core/JSON/Tests.Nuqleon.Json.Serialization/ParserTests.Reals.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/JSON/Tests.Nuqleon.Json.Serialization/ParserTests.String.cs
+++ b/Nuqleon/Core/JSON/Tests.Nuqleon.Json.Serialization/ParserTests.String.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/JSON/Tests.Nuqleon.Json.Serialization/ParserTests.cs
+++ b/Nuqleon/Core/JSON/Tests.Nuqleon.Json.Serialization/ParserTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/JSON/Tests.Nuqleon.Json.Serialization/SerializerTests.Integers.Generated.cs
+++ b/Nuqleon/Core/JSON/Tests.Nuqleon.Json.Serialization/SerializerTests.Integers.Generated.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/JSON/Tests.Nuqleon.Json.Serialization/SerializerTests.cs
+++ b/Nuqleon/Core/JSON/Tests.Nuqleon.Json.Serialization/SerializerTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/JSON/Tests.Nuqleon.Json.Serialization/SyntaxTrieTests.cs
+++ b/Nuqleon/Core/JSON/Tests.Nuqleon.Json.Serialization/SyntaxTrieTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/JSON/Tests.Nuqleon.Json/ExpressionVisitorTests.cs
+++ b/Nuqleon/Core/JSON/Tests.Nuqleon.Json/ExpressionVisitorTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/JSON/Tests.Nuqleon.Json/Json.cs
+++ b/Nuqleon/Core/JSON/Tests.Nuqleon.Json/Json.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/JSON/Tests.Nuqleon.Json/ParseExceptionTests.cs
+++ b/Nuqleon/Core/JSON/Tests.Nuqleon.Json/ParseExceptionTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/JSON/Tests.Nuqleon.Json/ParserTests.cs
+++ b/Nuqleon/Core/JSON/Tests.Nuqleon.Json/ParserTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/JSON/Tests.Nuqleon.Json/PrettyPrinterTests.cs
+++ b/Nuqleon/Core/JSON/Tests.Nuqleon.Json/PrettyPrinterTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/JSON/Tests.Nuqleon.Json/TokenizerTests.cs
+++ b/Nuqleon/Core/JSON/Tests.Nuqleon.Json/TokenizerTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/JSON/Tests.Nuqleon.Json/VisitorTests.cs
+++ b/Nuqleon/Core/JSON/Tests.Nuqleon.Json/VisitorTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices.Optimizers/Converters/EnumerableToQueryTreeConverter.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices.Optimizers/Converters/EnumerableToQueryTreeConverter.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices.Optimizers/Converters/MethodCallBasedOperatorToQueryTreeConverter.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices.Optimizers/Converters/MethodCallBasedOperatorToQueryTreeConverter.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices.Optimizers/Converters/QueryableToQueryTreeConverter.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices.Optimizers/Converters/QueryableToQueryTreeConverter.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices.Optimizers/Converters/ToQueryTreeConverter.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices.Optimizers/Converters/ToQueryTreeConverter.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices.Optimizers/DefaultQueryExpressionFactory.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices.Optimizers/DefaultQueryExpressionFactory.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices.Optimizers/IQueryExpressionFactory.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices.Optimizers/IQueryExpressionFactory.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices.Optimizers/Internal/TrueReadOnlyCollection.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices.Optimizers/Internal/TrueReadOnlyCollection.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices.Optimizers/Optimizers/CoalescingOptimizer.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices.Optimizers/Optimizers/CoalescingOptimizer.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices.Optimizers/Optimizers/IOptimizer.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices.Optimizers/Optimizers/IOptimizer.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices.Optimizers/Optimizers/LetCoalescingOptimizer.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices.Optimizers/Optimizers/LetCoalescingOptimizer.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices.Optimizers/Optimizers/NopOptimizer.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices.Optimizers/Optimizers/NopOptimizer.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices.Optimizers/Optimizers/Optimizer.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices.Optimizers/Optimizers/Optimizer.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices.Optimizers/Properties/AssemblyInfo.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices.Optimizers/Properties/AssemblyInfo.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices.Optimizers/QueryExpressionEqualityComparator.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices.Optimizers/QueryExpressionEqualityComparator.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices.Optimizers/QueryExpressionEqualityComparer.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices.Optimizers/QueryExpressionEqualityComparer.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices.Optimizers/QueryExpressionFactoryBase.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices.Optimizers/QueryExpressionFactoryBase.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices.Optimizers/QueryNodes/FirstOperator.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices.Optimizers/QueryNodes/FirstOperator.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices.Optimizers/QueryNodes/FirstPredicateOperator.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices.Optimizers/QueryNodes/FirstPredicateOperator.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices.Optimizers/QueryNodes/LambdaAbstraction.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices.Optimizers/QueryNodes/LambdaAbstraction.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices.Optimizers/QueryNodes/MonadAbstraction.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices.Optimizers/QueryNodes/MonadAbstraction.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices.Optimizers/QueryNodes/MonadMember.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices.Optimizers/QueryNodes/MonadMember.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices.Optimizers/QueryNodes/OperatorType.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices.Optimizers/QueryNodes/OperatorType.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices.Optimizers/QueryNodes/QueryNodeType.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices.Optimizers/QueryNodes/QueryNodeType.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices.Optimizers/QueryNodes/QueryOperator.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices.Optimizers/QueryNodes/QueryOperator.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices.Optimizers/QueryNodes/QueryTree.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices.Optimizers/QueryNodes/QueryTree.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices.Optimizers/QueryNodes/SelectOperator.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices.Optimizers/QueryNodes/SelectOperator.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices.Optimizers/QueryNodes/TakeOperator.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices.Optimizers/QueryNodes/TakeOperator.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices.Optimizers/QueryNodes/WhereOperator.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices.Optimizers/QueryNodes/WhereOperator.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices.Optimizers/UnsafeQueryExpressionFactory.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices.Optimizers/UnsafeQueryExpressionFactory.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices.Optimizers/Visitors/QueryDebugger.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices.Optimizers/Visitors/QueryDebugger.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices.Optimizers/Visitors/QueryVisitor.Generic.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices.Optimizers/Visitors/QueryVisitor.Generic.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices.Optimizers/Visitors/QueryVisitor.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices.Optimizers/Visitors/QueryVisitor.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices.Optimizers/Visitors/QueryVisitorWithReflection.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices.Optimizers/Visitors/QueryVisitorWithReflection.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices.Optimizers/Visitors/ReplacementVisitor.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices.Optimizers/Visitors/ReplacementVisitor.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices.Optimizers/Visitors/TypeSubstitutionQueryVisitor.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices.Optimizers/Visitors/TypeSubstitutionQueryVisitor.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices/CollectionExtensions.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices/CollectionExtensions.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices/Collections/ITree.Generic.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices/Collections/ITree.Generic.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices/Collections/ITree.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices/Collections/ITree.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices/Collections/ITreeVisitor.Generic.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices/Collections/ITreeVisitor.Generic.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices/Collections/ITreeVisitor.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices/Collections/ITreeVisitor.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices/Collections/Indexed.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices/Collections/Indexed.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices/Collections/ScopedSymbolTable.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices/Collections/ScopedSymbolTable.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices/Collections/SyntaxTrie.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices/Collections/SyntaxTrie.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices/Collections/Tree.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices/Collections/Tree.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices/Collections/TreeEqualityComparer.Generic.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices/Collections/TreeEqualityComparer.Generic.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices/Collections/TreeEqualityComparer.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices/Collections/TreeEqualityComparer.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices/Collections/TreeVisitor.Generic.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices/Collections/TreeVisitor.Generic.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices/Collections/TreeVisitor.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices/Collections/TreeVisitor.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices/Constants.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices/Constants.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices/Expressions/Analysis/ExpressionMemberAllowListScanner.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices/Expressions/Analysis/ExpressionMemberAllowListScanner.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices/Expressions/Analysis/ExpressionMemberAllowListScannerBase.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices/Expressions/Analysis/ExpressionMemberAllowListScannerBase.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices/Expressions/Analysis/ExpressionTypeAllowListScanner.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices/Expressions/Analysis/ExpressionTypeAllowListScanner.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices/Expressions/Analysis/ExpressionTypeAllowListScannerBase.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices/Expressions/Analysis/ExpressionTypeAllowListScannerBase.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices/Expressions/Analysis/FreeVariableScanner.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices/Expressions/Analysis/FreeVariableScanner.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices/Expressions/Diagnostics/CSharpExpression.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices/Expressions/Diagnostics/CSharpExpression.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices/Expressions/Diagnostics/ExpressionCSharpPrinter.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices/Expressions/Diagnostics/ExpressionCSharpPrinter.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices/Expressions/Evaluation/CacheEventArgs.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices/Expressions/Evaluation/CacheEventArgs.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices/Expressions/Evaluation/CachedLambdaCompiler.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices/Expressions/Evaluation/CachedLambdaCompiler.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices/Expressions/Evaluation/ICompiledDelegateCache.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices/Expressions/Evaluation/ICompiledDelegateCache.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices/Expressions/Evaluation/LeastRecentlyUsedCompiledDelegateCache.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices/Expressions/Evaluation/LeastRecentlyUsedCompiledDelegateCache.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices/Expressions/Evaluation/SimpleCompiledDelegateCache.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices/Expressions/Evaluation/SimpleCompiledDelegateCache.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices/Expressions/Evaluation/VoidCompiledDelegateCache.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices/Expressions/Evaluation/VoidCompiledDelegateCache.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices/Expressions/ExpressionEqualityComparator.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices/Expressions/ExpressionEqualityComparator.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices/Expressions/ExpressionEqualityComparer.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices/Expressions/ExpressionEqualityComparer.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices/Expressions/ExpressionExtensions.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices/Expressions/ExpressionExtensions.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices/Expressions/ExpressionFactory.generated.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices/Expressions/ExpressionFactory.generated.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices/Expressions/ExpressionHelpers.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices/Expressions/ExpressionHelpers.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices/Expressions/ExpressionTree.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices/Expressions/ExpressionTree.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices/Expressions/ExpressionTreeConversion.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices/Expressions/ExpressionTreeConversion.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices/Expressions/ExpressionTreeNode.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices/Expressions/ExpressionTreeNode.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices/Expressions/ExpressionUnsafe.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices/Expressions/ExpressionUnsafe.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices/Expressions/ExpressionUnsafeFactory.generated.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices/Expressions/ExpressionUnsafeFactory.generated.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices/Expressions/FuncletExpression.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices/Expressions/FuncletExpression.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices/Expressions/IExpressionFactory.generated.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices/Expressions/IExpressionFactory.generated.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices/Expressions/Optimization/DelegateInvocationInliner.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices/Expressions/Optimization/DelegateInvocationInliner.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices/Expressions/Optimization/Interning/ExpressionInterning.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices/Expressions/Optimization/Interning/ExpressionInterning.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices/Expressions/Optimization/Interning/ExpressionInterningCache.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices/Expressions/Optimization/Interning/ExpressionInterningCache.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices/Expressions/Optimization/Interning/ExpressionToHashedExpressionTreeConverter.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices/Expressions/Optimization/Interning/ExpressionToHashedExpressionTreeConverter.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices/Expressions/Optimization/Interning/HashedNode.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices/Expressions/Optimization/Interning/HashedNode.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices/Expressions/Optimization/Interning/IExpressionInterningCache.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices/Expressions/Optimization/Interning/IExpressionInterningCache.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices/Expressions/Rewriters/BURS/BottomUpExpressionRewriter.FallbackCollection.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices/Expressions/Rewriters/BURS/BottomUpExpressionRewriter.FallbackCollection.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices/Expressions/Rewriters/BURS/BottomUpExpressionRewriter.LeafCollection.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices/Expressions/Rewriters/BURS/BottomUpExpressionRewriter.LeafCollection.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices/Expressions/Rewriters/BURS/BottomUpExpressionRewriter.RuleCollection.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices/Expressions/Rewriters/BURS/BottomUpExpressionRewriter.RuleCollection.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices/Expressions/Rewriters/BURS/BottomUpExpressionRewriter.Utils.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices/Expressions/Rewriters/BURS/BottomUpExpressionRewriter.Utils.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices/Expressions/Rewriters/BURS/BottomUpExpressionRewriter.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices/Expressions/Rewriters/BURS/BottomUpExpressionRewriter.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices/Expressions/Rewriters/BURS/ExpressionTreeConversionWithDeBruijn.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices/Expressions/Rewriters/BURS/ExpressionTreeConversionWithDeBruijn.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices/Expressions/Rewriters/BURS/ExpressionTreeWildcard.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices/Expressions/Rewriters/BURS/ExpressionTreeWildcard.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices/Expressions/Rewriters/BURS/ExpressionTreeWildcardFactory.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices/Expressions/Rewriters/BURS/ExpressionTreeWildcardFactory.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices/Expressions/Rewriters/BURS/ShallowExpressionTreeNodeEqualityComparer.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices/Expressions/Rewriters/BURS/ShallowExpressionTreeNodeEqualityComparer.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices/Expressions/Rewriters/CPS/ClassicCpsRewriter.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices/Expressions/Rewriters/CPS/ClassicCpsRewriter.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices/Expressions/Rewriters/CPS/ClassicCpsRewriterWithErrorPropagation.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices/Expressions/Rewriters/CPS/ClassicCpsRewriterWithErrorPropagation.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices/Expressions/Rewriters/CPS/CpsRewriterBase.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices/Expressions/Rewriters/CPS/CpsRewriterBase.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices/Expressions/Rewriters/CPS/UseAsyncMethodAttribute.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices/Expressions/Rewriters/CPS/UseAsyncMethodAttribute.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices/Expressions/Rewriters/LambdaCalculus/AlphaRenamer.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices/Expressions/Rewriters/LambdaCalculus/AlphaRenamer.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices/Expressions/Rewriters/LambdaCalculus/BetaReducer.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices/Expressions/Rewriters/LambdaCalculus/BetaReducer.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices/Expressions/Rewriters/LambdaCalculus/EtaConverter.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices/Expressions/Rewriters/LambdaCalculus/EtaConverter.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices/Expressions/Rewriters/Misc/Binding.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices/Expressions/Rewriters/Misc/Binding.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices/Expressions/Rewriters/Misc/CompilerGeneratedNameEliminator.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices/Expressions/Rewriters/Misc/CompilerGeneratedNameEliminator.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices/Expressions/Rewriters/Misc/ConstantHoister.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices/Expressions/Rewriters/Misc/ConstantHoister.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices/Expressions/Rewriters/Misc/ExpressionTupletizer.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices/Expressions/Rewriters/Misc/ExpressionTupletizer.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices/Expressions/Rewriters/Misc/ExpressionWithEnvironment.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices/Expressions/Rewriters/Misc/ExpressionWithEnvironment.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices/Expressions/Rewriters/Misc/IConstantHoister.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices/Expressions/Rewriters/Misc/IConstantHoister.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices/Expressions/Rewriters/Misc/IExpressionWithEnvironment.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices/Expressions/Rewriters/Misc/IExpressionWithEnvironment.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices/Expressions/Rewriters/TypeSystem/AnonymousTypeTupletizer.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices/Expressions/Rewriters/TypeSystem/AnonymousTypeTupletizer.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices/Expressions/Rewriters/TypeSystem/StructuralTypeSubstitutionExpressionVisitor.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices/Expressions/Rewriters/TypeSystem/StructuralTypeSubstitutionExpressionVisitor.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices/Expressions/Rewriters/TypeSystem/TypeBasedExpressionRewriter.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices/Expressions/Rewriters/TypeSystem/TypeBasedExpressionRewriter.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices/Expressions/Rewriters/TypeSystem/TypeSubstitutionExpressionVisitor.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices/Expressions/Rewriters/TypeSystem/TypeSubstitutionExpressionVisitor.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices/Expressions/UnboundParameterException.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices/Expressions/UnboundParameterException.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices/Expressions/Visitors/CooperativeExpressionVisitor.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices/Expressions/Visitors/CooperativeExpressionVisitor.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices/Expressions/Visitors/ExpressionVisitor.Generic.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices/Expressions/Visitors/ExpressionVisitor.Generic.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices/Expressions/Visitors/ExpressionVisitorBase.Generic.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices/Expressions/Visitors/ExpressionVisitorBase.Generic.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices/Expressions/Visitors/ExpressionVisitorNarrow.Generic.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices/Expressions/Visitors/ExpressionVisitorNarrow.Generic.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices/Expressions/Visitors/ExpressionVisitorWithReflection.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices/Expressions/Visitors/ExpressionVisitorWithReflection.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices/Expressions/Visitors/IRecursiveExpressionVisitor.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices/Expressions/Visitors/IRecursiveExpressionVisitor.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices/Expressions/Visitors/PartialExpressionVisitor.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices/Expressions/Visitors/PartialExpressionVisitor.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices/Expressions/Visitors/ScopedExpressionVisitor.Generic.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices/Expressions/Visitors/ScopedExpressionVisitor.Generic.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices/Expressions/Visitors/ScopedExpressionVisitor.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices/Expressions/Visitors/ScopedExpressionVisitor.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices/Expressions/Visitors/ScopedExpressionVisitorBase.Generic.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices/Expressions/Visitors/ScopedExpressionVisitorBase.Generic.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices/Expressions/Visitors/ScopedExpressionVisitorBase.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices/Expressions/Visitors/ScopedExpressionVisitorBase.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices/Expressions/Visitors/VisitorAttribute.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices/Expressions/Visitors/VisitorAttribute.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices/GlobalSuppressions.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices/GlobalSuppressions.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices/HashHelpers.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices/HashHelpers.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices/Internal/Compatibility.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices/Internal/Compatibility.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices/Internal/EnumerableEx.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices/Internal/EnumerableEx.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices/Internal/Errors.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices/Internal/Errors.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices/Internal/FormattingHelpers.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices/Internal/FormattingHelpers.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices/Internal/Invariant.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices/Internal/Invariant.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices/ObjectExtensions.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices/ObjectExtensions.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices/Properties/AssemblyInfo.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices/Properties/AssemblyInfo.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices/ReferenceEqualityComparer.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices/ReferenceEqualityComparer.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices/Reflection/ConstructorInfoExtensions.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices/Reflection/ConstructorInfoExtensions.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices/Reflection/Emit/AssemblyBuilder.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices/Reflection/Emit/AssemblyBuilder.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices/Reflection/Emit/AssemblyBuilderAccess.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices/Reflection/Emit/AssemblyBuilderAccess.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices/Reflection/Emit/CustomAttributeBuilder.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices/Reflection/Emit/CustomAttributeBuilder.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices/Reflection/Emit/CustomAttributeDeclaration.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices/Reflection/Emit/CustomAttributeDeclaration.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices/Reflection/Emit/ILGenerator.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices/Reflection/Emit/ILGenerator.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices/Reflection/Emit/Label.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices/Reflection/Emit/Label.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices/Reflection/Emit/LocalBuilder.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices/Reflection/Emit/LocalBuilder.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices/Reflection/Emit/ModuleBuilder.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices/Reflection/Emit/ModuleBuilder.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices/Reflection/Emit/RuntimeCompiler.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices/Reflection/Emit/RuntimeCompiler.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices/Reflection/Emit/StructuralFieldDeclaration.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices/Reflection/Emit/StructuralFieldDeclaration.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices/Reflection/EventInfoExtensions.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices/Reflection/EventInfoExtensions.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices/Reflection/FieldInfoExtensions.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices/Reflection/FieldInfoExtensions.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices/Reflection/MemberInfoEqualityComparer.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices/Reflection/MemberInfoEqualityComparer.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices/Reflection/MemberInfoExtensions.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices/Reflection/MemberInfoExtensions.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices/Reflection/MethodInfoExtensions.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices/Reflection/MethodInfoExtensions.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices/Reflection/PropertyInfoExtensions.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices/Reflection/PropertyInfoExtensions.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices/Reflection/ReflectionHelpers.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices/Reflection/ReflectionHelpers.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices/Reflection/StructuralMemberInfoEqualityComparator.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices/Reflection/StructuralMemberInfoEqualityComparator.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices/Reflection/StructuralMemberInfoEqualityComparer.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices/Reflection/StructuralMemberInfoEqualityComparer.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices/Tools/BURS/BottomUpOptimizer.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices/Tools/BURS/BottomUpOptimizer.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices/Tools/BURS/BottomUpRewriter.Fallback.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices/Tools/BURS/BottomUpRewriter.Fallback.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices/Tools/BURS/BottomUpRewriter.FallbackCollection.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices/Tools/BURS/BottomUpRewriter.FallbackCollection.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices/Tools/BURS/BottomUpRewriter.Leaf.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices/Tools/BURS/BottomUpRewriter.Leaf.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices/Tools/BURS/BottomUpRewriter.LeafCollection.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices/Tools/BURS/BottomUpRewriter.LeafCollection.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices/Tools/BURS/BottomUpRewriter.Rule.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices/Tools/BURS/BottomUpRewriter.Rule.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices/Tools/BURS/BottomUpRewriter.RuleBase.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices/Tools/BURS/BottomUpRewriter.RuleBase.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices/Tools/BURS/BottomUpRewriter.RuleCollection.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices/Tools/BURS/BottomUpRewriter.RuleCollection.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices/Tools/BURS/BottomUpRewriter.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices/Tools/BURS/BottomUpRewriter.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices/Tools/BURS/EqualityComparerByType.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices/Tools/BURS/EqualityComparerByType.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices/Tools/BURS/IWildcardFactory.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices/Tools/BURS/IWildcardFactory.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices/Tools/BURS/Label.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices/Tools/BURS/Label.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices/Tools/BURS/LabeledTree.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices/Tools/BURS/LabeledTree.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices/Tools/BURS/Match.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices/Tools/BURS/Match.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices/Tools/BURS/NAryMap.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices/Tools/BURS/NAryMap.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices/Tools/BURS/WildcardTraversal.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices/Tools/BURS/WildcardTraversal.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices/Tools/BURS/WildcardTraversalMap.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices/Tools/BURS/WildcardTraversalMap.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices/TypeSystem/ClrType.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices/TypeSystem/ClrType.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices/TypeSystem/IType.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices/TypeSystem/IType.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices/TypeSystem/ITyped.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices/TypeSystem/ITyped.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices/TypeSystem/StructuralSubstitutingTypeComparator.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices/TypeSystem/StructuralSubstitutingTypeComparator.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices/TypeSystem/StructuralTypeEqualityComparator.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices/TypeSystem/StructuralTypeEqualityComparator.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices/TypeSystem/StructuralTypeEqualityComparer.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices/TypeSystem/StructuralTypeEqualityComparer.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices/TypeSystem/TypeEqualityComparer.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices/TypeSystem/TypeEqualityComparer.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices/TypeSystem/TypeExtensions.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices/TypeSystem/TypeExtensions.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices/TypeSystem/TypeSubstitutor.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices/TypeSystem/TypeSubstitutor.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices/TypeSystem/TypeVisitor.Generic.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices/TypeSystem/TypeVisitor.Generic.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices/TypeSystem/TypeVisitor.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices/TypeSystem/TypeVisitor.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices/TypeSystem/TypeWildcards.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices/TypeSystem/TypeWildcards.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices/TypeSystem/Types.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices/TypeSystem/Types.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices/Visibility.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices/Visibility.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Bonsai.Hashing/GlobalSuppressions.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Bonsai.Hashing/GlobalSuppressions.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Bonsai.Hashing/Properties/AssemblyInfo.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Bonsai.Hashing/Properties/AssemblyInfo.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Bonsai.Hashing/System/Linq/Expressions/ExpressionSlimHasher.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Bonsai.Hashing/System/Linq/Expressions/ExpressionSlimHasher.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Bonsai.Hashing/System/Linq/Expressions/ExpressionSlimHashingExtensions.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Bonsai.Hashing/System/Linq/Expressions/ExpressionSlimHashingExtensions.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Bonsai.Hashing/System/Linq/Expressions/ReferenceEqualityComparer.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Bonsai.Hashing/System/Linq/Expressions/ReferenceEqualityComparer.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Bonsai.Hashing/System/Linq/Expressions/StableExpressionSlimHashingOptions.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Bonsai.Hashing/System/Linq/Expressions/StableExpressionSlimHashingOptions.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Bonsai.Serialization/BonsaiExpressionSerializer.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Bonsai.Serialization/BonsaiExpressionSerializer.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Bonsai.Serialization/BonsaiParseException.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Bonsai.Serialization/BonsaiParseException.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Bonsai.Serialization/BonsaiToExpressionSlimConverter.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Bonsai.Serialization/BonsaiToExpressionSlimConverter.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Bonsai.Serialization/Context/DeserializationState.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Bonsai.Serialization/Context/DeserializationState.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Bonsai.Serialization/Context/Domain.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Bonsai.Serialization/Context/Domain.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Bonsai.Serialization/Context/SerializationState.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Bonsai.Serialization/Context/SerializationState.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Bonsai.Serialization/Discriminators.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Bonsai.Serialization/Discriminators.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Bonsai.Serialization/ExpressionSlimBonsaiSerializer.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Bonsai.Serialization/ExpressionSlimBonsaiSerializer.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Bonsai.Serialization/ExpressionSlimToBonsaiConverter.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Bonsai.Serialization/ExpressionSlimToBonsaiConverter.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Bonsai.Serialization/GlobalSuppressions.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Bonsai.Serialization/GlobalSuppressions.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Bonsai.Serialization/Helpers.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Bonsai.Serialization/Helpers.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Bonsai.Serialization/ObjectSerializer.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Bonsai.Serialization/ObjectSerializer.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Bonsai.Serialization/Properties/AssemblyInfo.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Bonsai.Serialization/Properties/AssemblyInfo.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Bonsai.Serialization/TypeSystem/ArrayTypeDef.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Bonsai.Serialization/TypeSystem/ArrayTypeDef.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Bonsai.Serialization/TypeSystem/ClosedGenericMethodDef.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Bonsai.Serialization/TypeSystem/ClosedGenericMethodDef.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Bonsai.Serialization/TypeSystem/ConstructorDef.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Bonsai.Serialization/TypeSystem/ConstructorDef.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Bonsai.Serialization/TypeSystem/DeclaredMemberDef.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Bonsai.Serialization/TypeSystem/DeclaredMemberDef.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Bonsai.Serialization/TypeSystem/FieldDef.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Bonsai.Serialization/TypeSystem/FieldDef.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Bonsai.Serialization/TypeSystem/GenericParameterTypeDef.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Bonsai.Serialization/TypeSystem/GenericParameterTypeDef.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Bonsai.Serialization/TypeSystem/GenericTypeDef.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Bonsai.Serialization/TypeSystem/GenericTypeDef.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Bonsai.Serialization/TypeSystem/MemberDef.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Bonsai.Serialization/TypeSystem/MemberDef.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Bonsai.Serialization/TypeSystem/MethodDef.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Bonsai.Serialization/TypeSystem/MethodDef.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Bonsai.Serialization/TypeSystem/OpenGenericMethodDef.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Bonsai.Serialization/TypeSystem/OpenGenericMethodDef.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Bonsai.Serialization/TypeSystem/PropertyDef.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Bonsai.Serialization/TypeSystem/PropertyDef.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Bonsai.Serialization/TypeSystem/SimpleMethodDef.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Bonsai.Serialization/TypeSystem/SimpleMethodDef.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Bonsai.Serialization/TypeSystem/SimpleTypeDef.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Bonsai.Serialization/TypeSystem/SimpleTypeDef.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Bonsai.Serialization/TypeSystem/StructuralTypeDef.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Bonsai.Serialization/TypeSystem/StructuralTypeDef.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Bonsai.Serialization/TypeSystem/StructuralTypeRef.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Bonsai.Serialization/TypeSystem/StructuralTypeRef.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Bonsai.Serialization/TypeSystem/TypeDef.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Bonsai.Serialization/TypeSystem/TypeDef.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Bonsai.Serialization/TypeSystem/TypeRef.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Bonsai.Serialization/TypeSystem/TypeRef.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Bonsai.Serialization/Versioning.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Bonsai.Serialization/Versioning.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Bonsai/CompilerServices/Invariant.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Bonsai/CompilerServices/Invariant.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Bonsai/CompilerServices/Reflection/SlimReflectionHelpers.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Bonsai/CompilerServices/Reflection/SlimReflectionHelpers.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Bonsai/CompilerServices/TypeSystem/TypeSlimDerivationVisitor.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Bonsai/CompilerServices/TypeSystem/TypeSlimDerivationVisitor.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Bonsai/GlobalSuppressions.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Bonsai/GlobalSuppressions.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Bonsai/Properties/AssemblyInfo.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Bonsai/Properties/AssemblyInfo.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Bonsai/System/Linq/Expressions/BinaryExpressionSlim.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Bonsai/System/Linq/Expressions/BinaryExpressionSlim.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Bonsai/System/Linq/Expressions/BlockExpressionSlim.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Bonsai/System/Linq/Expressions/BlockExpressionSlim.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Bonsai/System/Linq/Expressions/CatchBlockSlim.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Bonsai/System/Linq/Expressions/CatchBlockSlim.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Bonsai/System/Linq/Expressions/ConditionalExpressionSlim.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Bonsai/System/Linq/Expressions/ConditionalExpressionSlim.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Bonsai/System/Linq/Expressions/ConstantExpressionSlim.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Bonsai/System/Linq/Expressions/ConstantExpressionSlim.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Bonsai/System/Linq/Expressions/DefaultExpressionSlim.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Bonsai/System/Linq/Expressions/DefaultExpressionSlim.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Bonsai/System/Linq/Expressions/ElementInitSlim.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Bonsai/System/Linq/Expressions/ElementInitSlim.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Bonsai/System/Linq/Expressions/ExpressionSlim.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Bonsai/System/Linq/Expressions/ExpressionSlim.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Bonsai/System/Linq/Expressions/ExpressionSlimCSharpPrinter.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Bonsai/System/Linq/Expressions/ExpressionSlimCSharpPrinter.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Bonsai/System/Linq/Expressions/ExpressionSlimExtensions.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Bonsai/System/Linq/Expressions/ExpressionSlimExtensions.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Bonsai/System/Linq/Expressions/ExpressionSlimFactory.generated.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Bonsai/System/Linq/Expressions/ExpressionSlimFactory.generated.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Bonsai/System/Linq/Expressions/ExpressionSlimPrettyPrinter.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Bonsai/System/Linq/Expressions/ExpressionSlimPrettyPrinter.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Bonsai/System/Linq/Expressions/ExpressionSlimToExpressionConverter.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Bonsai/System/Linq/Expressions/ExpressionSlimToExpressionConverter.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Bonsai/System/Linq/Expressions/ExpressionSlimUnsafe.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Bonsai/System/Linq/Expressions/ExpressionSlimUnsafe.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Bonsai/System/Linq/Expressions/ExpressionSlimUnsafeFactory.generated.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Bonsai/System/Linq/Expressions/ExpressionSlimUnsafeFactory.generated.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Bonsai/System/Linq/Expressions/ExpressionSlimVisitor.Generic.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Bonsai/System/Linq/Expressions/ExpressionSlimVisitor.Generic.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Bonsai/System/Linq/Expressions/ExpressionSlimVisitor.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Bonsai/System/Linq/Expressions/ExpressionSlimVisitor.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Bonsai/System/Linq/Expressions/ExpressionToExpressionSlimConverter.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Bonsai/System/Linq/Expressions/ExpressionToExpressionSlimConverter.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Bonsai/System/Linq/Expressions/GotoExpressionSlim.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Bonsai/System/Linq/Expressions/GotoExpressionSlim.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Bonsai/System/Linq/Expressions/IArgumentProviderSlim.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Bonsai/System/Linq/Expressions/IArgumentProviderSlim.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Bonsai/System/Linq/Expressions/IExpressionSerializer.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Bonsai/System/Linq/Expressions/IExpressionSerializer.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Bonsai/System/Linq/Expressions/IExpressionSlimFactory.generated.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Bonsai/System/Linq/Expressions/IExpressionSlimFactory.generated.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Bonsai/System/Linq/Expressions/IndexExpressionSlim.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Bonsai/System/Linq/Expressions/IndexExpressionSlim.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Bonsai/System/Linq/Expressions/InvocationExpressionSlim.Generated.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Bonsai/System/Linq/Expressions/InvocationExpressionSlim.Generated.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Bonsai/System/Linq/Expressions/InvocationExpressionSlim.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Bonsai/System/Linq/Expressions/InvocationExpressionSlim.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Bonsai/System/Linq/Expressions/LabelExpressionSlim.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Bonsai/System/Linq/Expressions/LabelExpressionSlim.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Bonsai/System/Linq/Expressions/LabelTargetSlim.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Bonsai/System/Linq/Expressions/LabelTargetSlim.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Bonsai/System/Linq/Expressions/LambdaExpressionSlim.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Bonsai/System/Linq/Expressions/LambdaExpressionSlim.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Bonsai/System/Linq/Expressions/ListArgumentProvider.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Bonsai/System/Linq/Expressions/ListArgumentProvider.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Bonsai/System/Linq/Expressions/ListInitExpressionSlim.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Bonsai/System/Linq/Expressions/ListInitExpressionSlim.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Bonsai/System/Linq/Expressions/LoopExpressionSlim.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Bonsai/System/Linq/Expressions/LoopExpressionSlim.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Bonsai/System/Linq/Expressions/MemberAssignmentSlim.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Bonsai/System/Linq/Expressions/MemberAssignmentSlim.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Bonsai/System/Linq/Expressions/MemberBindingSlim.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Bonsai/System/Linq/Expressions/MemberBindingSlim.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Bonsai/System/Linq/Expressions/MemberExpressionSlim.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Bonsai/System/Linq/Expressions/MemberExpressionSlim.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Bonsai/System/Linq/Expressions/MemberInitExpressionSlim.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Bonsai/System/Linq/Expressions/MemberInitExpressionSlim.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Bonsai/System/Linq/Expressions/MemberListBindingSlim.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Bonsai/System/Linq/Expressions/MemberListBindingSlim.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Bonsai/System/Linq/Expressions/MemberMemberBindingSlim.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Bonsai/System/Linq/Expressions/MemberMemberBindingSlim.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Bonsai/System/Linq/Expressions/MethodCallExpressionSlim.Generated.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Bonsai/System/Linq/Expressions/MethodCallExpressionSlim.Generated.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Bonsai/System/Linq/Expressions/MethodCallExpressionSlim.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Bonsai/System/Linq/Expressions/MethodCallExpressionSlim.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Bonsai/System/Linq/Expressions/NewArrayExpressionSlim.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Bonsai/System/Linq/Expressions/NewArrayExpressionSlim.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Bonsai/System/Linq/Expressions/NewExpressionSlim.Generated.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Bonsai/System/Linq/Expressions/NewExpressionSlim.Generated.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Bonsai/System/Linq/Expressions/NewExpressionSlim.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Bonsai/System/Linq/Expressions/NewExpressionSlim.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Bonsai/System/Linq/Expressions/ParameterExpressionSlim.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Bonsai/System/Linq/Expressions/ParameterExpressionSlim.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Bonsai/System/Linq/Expressions/SwitchCaseSlim.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Bonsai/System/Linq/Expressions/SwitchCaseSlim.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Bonsai/System/Linq/Expressions/SwitchExpressionSlim.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Bonsai/System/Linq/Expressions/SwitchExpressionSlim.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Bonsai/System/Linq/Expressions/TryExpressionSlim.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Bonsai/System/Linq/Expressions/TryExpressionSlim.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Bonsai/System/Linq/Expressions/TypeBinaryExpressionSlim.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Bonsai/System/Linq/Expressions/TypeBinaryExpressionSlim.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Bonsai/System/Linq/Expressions/UnaryExpressionSlim.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Bonsai/System/Linq/Expressions/UnaryExpressionSlim.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Bonsai/System/ObjectSlim.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Bonsai/System/ObjectSlim.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Bonsai/System/Reflection/ArrayTypeSlim.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Bonsai/System/Reflection/ArrayTypeSlim.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Bonsai/System/Reflection/AssemblySlim.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Bonsai/System/Reflection/AssemblySlim.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Bonsai/System/Reflection/ConstructorInfoSlim.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Bonsai/System/Reflection/ConstructorInfoSlim.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Bonsai/System/Reflection/FieldInfoSlim.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Bonsai/System/Reflection/FieldInfoSlim.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Bonsai/System/Reflection/FreeVariableScannerSlim.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Bonsai/System/Reflection/FreeVariableScannerSlim.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Bonsai/System/Reflection/GenericDefinitionMethodInfoSlim.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Bonsai/System/Reflection/GenericDefinitionMethodInfoSlim.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Bonsai/System/Reflection/GenericDefinitionTypeSlim.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Bonsai/System/Reflection/GenericDefinitionTypeSlim.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Bonsai/System/Reflection/GenericMethodInfoSlim.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Bonsai/System/Reflection/GenericMethodInfoSlim.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Bonsai/System/Reflection/GenericParameterTypeSlim.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Bonsai/System/Reflection/GenericParameterTypeSlim.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Bonsai/System/Reflection/GenericTypeSlim.Generated.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Bonsai/System/Reflection/GenericTypeSlim.Generated.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Bonsai/System/Reflection/GenericTypeSlim.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Bonsai/System/Reflection/GenericTypeSlim.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Bonsai/System/Reflection/InvertedTypeSpace.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Bonsai/System/Reflection/InvertedTypeSpace.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Bonsai/System/Reflection/MemberInfoSlim.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Bonsai/System/Reflection/MemberInfoSlim.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Bonsai/System/Reflection/MemberInfoSlimEqualityComparer.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Bonsai/System/Reflection/MemberInfoSlimEqualityComparer.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Bonsai/System/Reflection/MemberInfoSlimPrettyPrinter.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Bonsai/System/Reflection/MemberInfoSlimPrettyPrinter.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Bonsai/System/Reflection/MemberInfoSlimVisitor.Generic.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Bonsai/System/Reflection/MemberInfoSlimVisitor.Generic.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Bonsai/System/Reflection/MemberInfoSlimVisitor.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Bonsai/System/Reflection/MemberInfoSlimVisitor.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Bonsai/System/Reflection/MethodInfoSlim.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Bonsai/System/Reflection/MethodInfoSlim.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Bonsai/System/Reflection/MethodInfoSlimKind.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Bonsai/System/Reflection/MethodInfoSlimKind.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Bonsai/System/Reflection/PropertyInfoSlim.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Bonsai/System/Reflection/PropertyInfoSlim.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Bonsai/System/Reflection/SimpleMethodInfoSlim.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Bonsai/System/Reflection/SimpleMethodInfoSlim.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Bonsai/System/Reflection/SimpleMethodInfoSlimBase.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Bonsai/System/Reflection/SimpleMethodInfoSlimBase.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Bonsai/System/Reflection/SimpleTypeSlim.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Bonsai/System/Reflection/SimpleTypeSlim.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Bonsai/System/Reflection/SimpleTypeSlimBase.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Bonsai/System/Reflection/SimpleTypeSlimBase.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Bonsai/System/Reflection/StructuralTypeSlim.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Bonsai/System/Reflection/StructuralTypeSlim.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Bonsai/System/Reflection/StructuralTypeSlimKind.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Bonsai/System/Reflection/StructuralTypeSlimKind.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Bonsai/System/Reflection/StructuralTypeSlimReference.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Bonsai/System/Reflection/StructuralTypeSlimReference.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Bonsai/System/Reflection/TypeSlimCSharpPrinter.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Bonsai/System/Reflection/TypeSlimCSharpPrinter.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Bonsai/System/Reflection/TypeSlimEqualityComparator.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Bonsai/System/Reflection/TypeSlimEqualityComparator.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Bonsai/System/Reflection/TypeSlimEqualityComparer.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Bonsai/System/Reflection/TypeSlimEqualityComparer.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Bonsai/System/Reflection/TypeSlimExtensions.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Bonsai/System/Reflection/TypeSlimExtensions.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Bonsai/System/Reflection/TypeSlimKind.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Bonsai/System/Reflection/TypeSlimKind.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Bonsai/System/Reflection/TypeSlimPrettyPrinter.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Bonsai/System/Reflection/TypeSlimPrettyPrinter.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Bonsai/System/Reflection/TypeSlimToTypeConverter.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Bonsai/System/Reflection/TypeSlimToTypeConverter.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Bonsai/System/Reflection/TypeSlimVisitor.Generic.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Bonsai/System/Reflection/TypeSlimVisitor.Generic.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Bonsai/System/Reflection/TypeSlimVisitor.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Bonsai/System/Reflection/TypeSlimVisitor.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Bonsai/System/Reflection/TypeSpace.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Bonsai/System/Reflection/TypeSpace.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Bonsai/System/Reflection/TypeToTypeSlimConverter.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Bonsai/System/Reflection/TypeToTypeSlimConverter.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Bonsai/System/Reflection/TypeUnifier.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Bonsai/System/Reflection/TypeUnifier.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Optimizers/Properties/AssemblyInfo.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Optimizers/Properties/AssemblyInfo.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Optimizers/System/HashHelpers.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Optimizers/System/HashHelpers.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Optimizers/System/Linq/Expressions/AssignmentAnalyzer.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Optimizers/System/Linq/Expressions/AssignmentAnalyzer.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Optimizers/System/Linq/Expressions/ConstParameterCatalog.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Optimizers/System/Linq/Expressions/ConstParameterCatalog.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Optimizers/System/Linq/Expressions/DefaultEvaluatorFactory.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Optimizers/System/Linq/Expressions/DefaultEvaluatorFactory.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Optimizers/System/Linq/Expressions/DefaultSemanticProvider.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Optimizers/System/Linq/Expressions/DefaultSemanticProvider.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Optimizers/System/Linq/Expressions/ExpressionOptimizer.Binary.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Optimizers/System/Linq/Expressions/ExpressionOptimizer.Binary.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Optimizers/System/Linq/Expressions/ExpressionOptimizer.Block.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Optimizers/System/Linq/Expressions/ExpressionOptimizer.Block.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Optimizers/System/Linq/Expressions/ExpressionOptimizer.Call.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Optimizers/System/Linq/Expressions/ExpressionOptimizer.Call.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Optimizers/System/Linq/Expressions/ExpressionOptimizer.CatchBlock.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Optimizers/System/Linq/Expressions/ExpressionOptimizer.CatchBlock.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Optimizers/System/Linq/Expressions/ExpressionOptimizer.Conditional.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Optimizers/System/Linq/Expressions/ExpressionOptimizer.Conditional.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Optimizers/System/Linq/Expressions/ExpressionOptimizer.Const.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Optimizers/System/Linq/Expressions/ExpressionOptimizer.Const.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Optimizers/System/Linq/Expressions/ExpressionOptimizer.Evaluate.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Optimizers/System/Linq/Expressions/ExpressionOptimizer.Evaluate.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Optimizers/System/Linq/Expressions/ExpressionOptimizer.Factories.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Optimizers/System/Linq/Expressions/ExpressionOptimizer.Factories.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Optimizers/System/Linq/Expressions/ExpressionOptimizer.Index.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Optimizers/System/Linq/Expressions/ExpressionOptimizer.Index.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Optimizers/System/Linq/Expressions/ExpressionOptimizer.Is.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Optimizers/System/Linq/Expressions/ExpressionOptimizer.Is.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Optimizers/System/Linq/Expressions/ExpressionOptimizer.Member.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Optimizers/System/Linq/Expressions/ExpressionOptimizer.Member.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Optimizers/System/Linq/Expressions/ExpressionOptimizer.New.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Optimizers/System/Linq/Expressions/ExpressionOptimizer.New.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Optimizers/System/Linq/Expressions/ExpressionOptimizer.NewArray.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Optimizers/System/Linq/Expressions/ExpressionOptimizer.NewArray.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Optimizers/System/Linq/Expressions/ExpressionOptimizer.Switch.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Optimizers/System/Linq/Expressions/ExpressionOptimizer.Switch.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Optimizers/System/Linq/Expressions/ExpressionOptimizer.Try.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Optimizers/System/Linq/Expressions/ExpressionOptimizer.Try.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Optimizers/System/Linq/Expressions/ExpressionOptimizer.TypeBinary.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Optimizers/System/Linq/Expressions/ExpressionOptimizer.TypeBinary.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Optimizers/System/Linq/Expressions/ExpressionOptimizer.Unary.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Optimizers/System/Linq/Expressions/ExpressionOptimizer.Unary.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Optimizers/System/Linq/Expressions/ExpressionOptimizer.Utils.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Optimizers/System/Linq/Expressions/ExpressionOptimizer.Utils.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Optimizers/System/Linq/Expressions/ExpressionOptimizer.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Optimizers/System/Linq/Expressions/ExpressionOptimizer.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Optimizers/System/Linq/Expressions/FreeVariableFinder.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Optimizers/System/Linq/Expressions/FreeVariableFinder.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Optimizers/System/Linq/Expressions/IEvaluatorFactory.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Optimizers/System/Linq/Expressions/IEvaluatorFactory.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Optimizers/System/Linq/Expressions/ISemanticProvider.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Optimizers/System/Linq/Expressions/ISemanticProvider.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Optimizers/System/Linq/Expressions/ImmutableTypeCatalog.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Optimizers/System/Linq/Expressions/ImmutableTypeCatalog.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Optimizers/System/Linq/Expressions/LvalExpressionVisitor.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Optimizers/System/Linq/Expressions/LvalExpressionVisitor.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Optimizers/System/Linq/Expressions/MemberTable.Generated.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Optimizers/System/Linq/Expressions/MemberTable.Generated.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Optimizers/System/Linq/Expressions/MemberTable.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Optimizers/System/Linq/Expressions/MemberTable.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Optimizers/System/Linq/Expressions/MemoizingEvaluatorFactory.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Optimizers/System/Linq/Expressions/MemoizingEvaluatorFactory.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Optimizers/System/Linq/Expressions/MetadataSemanticProvider.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Optimizers/System/Linq/Expressions/MetadataSemanticProvider.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Optimizers/System/Linq/Expressions/ParameterTable.Generated.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Optimizers/System/Linq/Expressions/ParameterTable.Generated.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Optimizers/System/Linq/Expressions/PureMemberCatalog.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Optimizers/System/Linq/Expressions/PureMemberCatalog.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Optimizers/System/Linq/Expressions/SafeExpressionVisitor.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Optimizers/System/Linq/Expressions/SafeExpressionVisitor.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Optimizers/System/Linq/Expressions/TypeTable.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Optimizers/System/Linq/Expressions/TypeTable.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Optimizers/System/Linq/Expressions/Utils.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Optimizers/System/Linq/Expressions/Utils.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Optimizers/System/Linq/Expressions/VariableDefaultValueSubstitutor.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Optimizers/System/Linq/Expressions/VariableDefaultValueSubstitutor.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Optimizers/System/TypeExtensions.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Optimizers/System/TypeExtensions.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Optimizers/System/TypeUtils.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Optimizers/System/TypeUtils.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/SampleTrees/Arith.cs
+++ b/Nuqleon/Core/LINQ/SampleTrees/Arith.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/SampleTrees/Logic.cs
+++ b/Nuqleon/Core/LINQ/SampleTrees/Logic.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/SampleTrees/Num.cs
+++ b/Nuqleon/Core/LINQ/SampleTrees/Num.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/SampleTrees/Properties/AssemblyInfo.cs
+++ b/Nuqleon/Core/LINQ/SampleTrees/Properties/AssemblyInfo.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/SampleTrees/Query.cs
+++ b/Nuqleon/Core/LINQ/SampleTrees/Query.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.CompilerServices.Optimizers/GlobalSuppressions.cs
+++ b/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.CompilerServices.Optimizers/GlobalSuppressions.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.CompilerServices.Optimizers/LetOptimizerTests.cs
+++ b/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.CompilerServices.Optimizers/LetOptimizerTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.CompilerServices.Optimizers/LetOptimizerTests.generated.cs
+++ b/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.CompilerServices.Optimizers/LetOptimizerTests.generated.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.CompilerServices.Optimizers/OptimizerCombinatorTests.cs
+++ b/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.CompilerServices.Optimizers/OptimizerCombinatorTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.CompilerServices.Optimizers/OptimizerTests.cs
+++ b/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.CompilerServices.Optimizers/OptimizerTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.CompilerServices.Optimizers/QueryExpressionEqualityComparerTests.cs
+++ b/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.CompilerServices.Optimizers/QueryExpressionEqualityComparerTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.CompilerServices.Optimizers/QueryExpressionFactoryTests.cs
+++ b/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.CompilerServices.Optimizers/QueryExpressionFactoryTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.CompilerServices.Optimizers/QueryExpressionToStringTests.cs
+++ b/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.CompilerServices.Optimizers/QueryExpressionToStringTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.CompilerServices.Optimizers/QueryTreeEnumerableConverterTests.cs
+++ b/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.CompilerServices.Optimizers/QueryTreeEnumerableConverterTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.CompilerServices.Optimizers/QueryTreeTests.cs
+++ b/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.CompilerServices.Optimizers/QueryTreeTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.CompilerServices.Optimizers/QueryVisitorTests.cs
+++ b/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.CompilerServices.Optimizers/QueryVisitorTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.CompilerServices/ClonedExpressionEqualityComparator.cs
+++ b/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.CompilerServices/ClonedExpressionEqualityComparator.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.CompilerServices/Collections/IndexedTests.cs
+++ b/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.CompilerServices/Collections/IndexedTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.CompilerServices/Collections/ScopedSymbolTableTests.cs
+++ b/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.CompilerServices/Collections/ScopedSymbolTableTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.CompilerServices/Collections/SyntaxTrieTests.cs
+++ b/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.CompilerServices/Collections/SyntaxTrieTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.CompilerServices/Collections/TreeEqualityComparerTests.cs
+++ b/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.CompilerServices/Collections/TreeEqualityComparerTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.CompilerServices/Collections/TreeTests.cs
+++ b/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.CompilerServices/Collections/TreeTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.CompilerServices/Collections/TreeVisitorTests.cs
+++ b/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.CompilerServices/Collections/TreeVisitorTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.CompilerServices/Evaluation/EvaluationTests.cs
+++ b/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.CompilerServices/Evaluation/EvaluationTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.CompilerServices/Expressions/Analysis/ExpressionMemberAllowListScannerBaseTests.cs
+++ b/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.CompilerServices/Expressions/Analysis/ExpressionMemberAllowListScannerBaseTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.CompilerServices/Expressions/Analysis/ExpressionMemberAllowListScannerTests.cs
+++ b/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.CompilerServices/Expressions/Analysis/ExpressionMemberAllowListScannerTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.CompilerServices/Expressions/Analysis/ExpressionTypeAllowListScannerBaseTests.cs
+++ b/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.CompilerServices/Expressions/Analysis/ExpressionTypeAllowListScannerBaseTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.CompilerServices/Expressions/Analysis/ExpressionTypeAllowListScannerTests.cs
+++ b/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.CompilerServices/Expressions/Analysis/ExpressionTypeAllowListScannerTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.CompilerServices/Expressions/Analysis/FreeVariableScannerTests.cs
+++ b/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.CompilerServices/Expressions/Analysis/FreeVariableScannerTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.CompilerServices/Expressions/ExpressionExtensionsTests.cs
+++ b/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.CompilerServices/Expressions/ExpressionExtensionsTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.CompilerServices/Expressions/ExpressionHelpersTests.cs
+++ b/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.CompilerServices/Expressions/ExpressionHelpersTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.CompilerServices/Expressions/ExpressionTreeTests.cs
+++ b/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.CompilerServices/Expressions/ExpressionTreeTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.CompilerServices/Expressions/FuncletExpressionTests.cs
+++ b/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.CompilerServices/Expressions/FuncletExpressionTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.CompilerServices/Expressions/Rewriters/BURS/BottomUpExpressionRewriterTests.cs
+++ b/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.CompilerServices/Expressions/Rewriters/BURS/BottomUpExpressionRewriterTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.CompilerServices/Expressions/Rewriters/CPS/ClassicCpsRewriterTests.cs
+++ b/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.CompilerServices/Expressions/Rewriters/CPS/ClassicCpsRewriterTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.CompilerServices/Expressions/Rewriters/CPS/ClassicCpsRewriterWithErrorPropagationTests.cs
+++ b/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.CompilerServices/Expressions/Rewriters/CPS/ClassicCpsRewriterWithErrorPropagationTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.CompilerServices/Expressions/Rewriters/CPS/CpsRewriterBaseTests.cs
+++ b/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.CompilerServices/Expressions/Rewriters/CPS/CpsRewriterBaseTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.CompilerServices/Expressions/Rewriters/LambdaCalculus/AlphaRenamerTests.cs
+++ b/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.CompilerServices/Expressions/Rewriters/LambdaCalculus/AlphaRenamerTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.CompilerServices/Expressions/Rewriters/LambdaCalculus/BetaReducerTests.cs
+++ b/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.CompilerServices/Expressions/Rewriters/LambdaCalculus/BetaReducerTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.CompilerServices/Expressions/Rewriters/LambdaCalculus/EtaConverterTests.cs
+++ b/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.CompilerServices/Expressions/Rewriters/LambdaCalculus/EtaConverterTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.CompilerServices/Expressions/Rewriters/Misc/BindingTests.cs
+++ b/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.CompilerServices/Expressions/Rewriters/Misc/BindingTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.CompilerServices/Expressions/Rewriters/Misc/CompilerGeneratedNameEliminatorTests.cs
+++ b/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.CompilerServices/Expressions/Rewriters/Misc/CompilerGeneratedNameEliminatorTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.CompilerServices/Expressions/Rewriters/Misc/ConstantHoisterTests.cs
+++ b/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.CompilerServices/Expressions/Rewriters/Misc/ConstantHoisterTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.CompilerServices/Expressions/Rewriters/Optimization/DelegateInvocationInlinerTests.cs
+++ b/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.CompilerServices/Expressions/Rewriters/Optimization/DelegateInvocationInlinerTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.CompilerServices/Expressions/Rewriters/Optimization/Interning/ExpressionInterningTests.cs
+++ b/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.CompilerServices/Expressions/Rewriters/Optimization/Interning/ExpressionInterningTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.CompilerServices/Expressions/Rewriters/TypeSystem/AnonymousTypeTupletizerTests.cs
+++ b/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.CompilerServices/Expressions/Rewriters/TypeSystem/AnonymousTypeTupletizerTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.CompilerServices/Expressions/Rewriters/TypeSystem/TypeBasedScopedExpressionRewriterTests.cs
+++ b/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.CompilerServices/Expressions/Rewriters/TypeSystem/TypeBasedScopedExpressionRewriterTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.CompilerServices/Expressions/Rewriters/TypeSystem/TypeSubstitutionExpressionVisitorTests.cs
+++ b/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.CompilerServices/Expressions/Rewriters/TypeSystem/TypeSubstitutionExpressionVisitorTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.CompilerServices/Expressions/UnboundParameterExceptionTests.cs
+++ b/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.CompilerServices/Expressions/UnboundParameterExceptionTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.CompilerServices/Expressions/Visitors/CooperativeExpressionVisitorTests.cs
+++ b/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.CompilerServices/Expressions/Visitors/CooperativeExpressionVisitorTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.CompilerServices/Expressions/Visitors/ExpressionVisitorGenericTests.cs
+++ b/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.CompilerServices/Expressions/Visitors/ExpressionVisitorGenericTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.CompilerServices/Expressions/Visitors/ExpressionVisitorNarrowGenericTests.cs
+++ b/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.CompilerServices/Expressions/Visitors/ExpressionVisitorNarrowGenericTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.CompilerServices/Expressions/Visitors/ExpressionVisitorWithReflectionTests.cs
+++ b/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.CompilerServices/Expressions/Visitors/ExpressionVisitorWithReflectionTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.CompilerServices/Expressions/Visitors/PartialExpressionVisitorTests.cs
+++ b/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.CompilerServices/Expressions/Visitors/PartialExpressionVisitorTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.CompilerServices/Expressions/Visitors/ScopedExpressionVisitorTests.cs
+++ b/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.CompilerServices/Expressions/Visitors/ScopedExpressionVisitorTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.CompilerServices/GlobalSuppressions.cs
+++ b/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.CompilerServices/GlobalSuppressions.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.CompilerServices/Internal/EnumerableExTests.cs
+++ b/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.CompilerServices/Internal/EnumerableExTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.CompilerServices/ObjectExtensionsTests.cs
+++ b/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.CompilerServices/ObjectExtensionsTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.CompilerServices/Reflection/ConstructorInfoExtensions.cs
+++ b/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.CompilerServices/Reflection/ConstructorInfoExtensions.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.CompilerServices/Reflection/Emit/RuntimeCompilerTests.cs
+++ b/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.CompilerServices/Reflection/Emit/RuntimeCompilerTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.CompilerServices/Reflection/EventInfoExtensions.cs
+++ b/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.CompilerServices/Reflection/EventInfoExtensions.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.CompilerServices/Reflection/FieldInfoExtensions.cs
+++ b/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.CompilerServices/Reflection/FieldInfoExtensions.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.CompilerServices/Reflection/MemberInfoEqualityComparerTests.cs
+++ b/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.CompilerServices/Reflection/MemberInfoEqualityComparerTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.CompilerServices/Reflection/MemberInfoExtensions.cs
+++ b/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.CompilerServices/Reflection/MemberInfoExtensions.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.CompilerServices/Reflection/MethodInfoExtensions.cs
+++ b/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.CompilerServices/Reflection/MethodInfoExtensions.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.CompilerServices/Reflection/PropertyInfoExtensions.cs
+++ b/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.CompilerServices/Reflection/PropertyInfoExtensions.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.CompilerServices/Reflection/ReflectionHelpersTests.cs
+++ b/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.CompilerServices/Reflection/ReflectionHelpersTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.CompilerServices/TestHelpers.cs
+++ b/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.CompilerServices/TestHelpers.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.CompilerServices/Tools/BURS/BottomUp.Bar.cs
+++ b/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.CompilerServices/Tools/BURS/BottomUp.Bar.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.CompilerServices/Tools/BURS/BottomUp.Num.cs
+++ b/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.CompilerServices/Tools/BURS/BottomUp.Num.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.CompilerServices/Tools/BURS/BottomUp.Str.cs
+++ b/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.CompilerServices/Tools/BURS/BottomUp.Str.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.CompilerServices/Tools/BURS/BottomUpOptimizerTests.Academic.cs
+++ b/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.CompilerServices/Tools/BURS/BottomUpOptimizerTests.Academic.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.CompilerServices/Tools/BURS/BottomUpOptimizerTests.cs
+++ b/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.CompilerServices/Tools/BURS/BottomUpOptimizerTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.CompilerServices/Tools/BURS/BottomUpRewriterTests.Academic.cs
+++ b/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.CompilerServices/Tools/BURS/BottomUpRewriterTests.Academic.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.CompilerServices/Tools/BURS/BottomUpRewriterTests.cs
+++ b/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.CompilerServices/Tools/BURS/BottomUpRewriterTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.CompilerServices/Tools/BURS/_LabeledTreeTests.cs
+++ b/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.CompilerServices/Tools/BURS/_LabeledTreeTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.CompilerServices/Tools/BURS/_NAryMapTests.cs
+++ b/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.CompilerServices/Tools/BURS/_NAryMapTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.CompilerServices/Tools/BURS/_WildcardTraversalMapTests.cs
+++ b/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.CompilerServices/Tools/BURS/_WildcardTraversalMapTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.CompilerServices/TypeSystem/ClrTypeTests.cs
+++ b/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.CompilerServices/TypeSystem/ClrTypeTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.CompilerServices/TypeSystem/StructuralTypeEqualityComparerTests.cs
+++ b/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.CompilerServices/TypeSystem/StructuralTypeEqualityComparerTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.CompilerServices/TypeSystem/TypeEqualityComparerTests.cs
+++ b/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.CompilerServices/TypeSystem/TypeEqualityComparerTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.CompilerServices/TypeSystem/TypeExtensionsTests.cs
+++ b/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.CompilerServices/TypeSystem/TypeExtensionsTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.CompilerServices/TypeSystem/TypeSubstitutorTests.cs
+++ b/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.CompilerServices/TypeSystem/TypeSubstitutorTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.CompilerServices/TypeSystem/TypeVisitorGenericTests.cs
+++ b/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.CompilerServices/TypeSystem/TypeVisitorGenericTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.CompilerServices/TypeSystem/TypeVisitorTests.cs
+++ b/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.CompilerServices/TypeSystem/TypeVisitorTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.CompilerServices/TypeSystem/TypeWildcardTests.cs
+++ b/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.CompilerServices/TypeSystem/TypeWildcardTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.CompilerServices/TypeSystem/TypesTests.cs
+++ b/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.CompilerServices/TypeSystem/TypesTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.Expressions.Bonsai.Hashing.Catalog/TestCases.cs
+++ b/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.Expressions.Bonsai.Hashing.Catalog/TestCases.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.Expressions.Bonsai.Hashing/StableExpressionSlimHasherTests.cs
+++ b/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.Expressions.Bonsai.Hashing/StableExpressionSlimHasherTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.Expressions.Bonsai.Serialization/BonsaiExpressionSerializerTests.cs
+++ b/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.Expressions.Bonsai.Serialization/BonsaiExpressionSerializerTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.Expressions.Bonsai.Serialization/BonsaiParseException.cs
+++ b/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.Expressions.Bonsai.Serialization/BonsaiParseException.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.Expressions.Bonsai.Serialization/BonsaiToExpressionSlimConverter.cs
+++ b/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.Expressions.Bonsai.Serialization/BonsaiToExpressionSlimConverter.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.Expressions.Bonsai.Serialization/Domain.cs
+++ b/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.Expressions.Bonsai.Serialization/Domain.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.Expressions.Bonsai.Serialization/GlobalSuppressions.cs
+++ b/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.Expressions.Bonsai.Serialization/GlobalSuppressions.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.Expressions.Bonsai.Serialization/HelpersTests.cs
+++ b/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.Expressions.Bonsai.Serialization/HelpersTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.Expressions.Bonsai.Serialization/ObjectSerializer.cs
+++ b/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.Expressions.Bonsai.Serialization/ObjectSerializer.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.Expressions.Bonsai.Serialization/Tests.Concurrency.cs
+++ b/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.Expressions.Bonsai.Serialization/Tests.Concurrency.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.Expressions.Bonsai.Serialization/Tests.Generated.cs
+++ b/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.Expressions.Bonsai.Serialization/Tests.Generated.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.Expressions.Bonsai.Serialization/Tests.cs
+++ b/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.Expressions.Bonsai.Serialization/Tests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.Expressions.Bonsai/CompilerServices/Expressions/Rewriters/TypeSystem/TypeSubstitutionExpressionSlimVisitor.cs
+++ b/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.Expressions.Bonsai/CompilerServices/Expressions/Rewriters/TypeSystem/TypeSubstitutionExpressionSlimVisitor.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.Expressions.Bonsai/CompilerServices/Expressions/Visitors/ExpressionSlimVisitorWithReflection.cs
+++ b/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.Expressions.Bonsai/CompilerServices/Expressions/Visitors/ExpressionSlimVisitorWithReflection.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.Expressions.Bonsai/CompilerServices/Expressions/Visitors/ScopedExpressionSlimVisitor.cs
+++ b/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.Expressions.Bonsai/CompilerServices/Expressions/Visitors/ScopedExpressionSlimVisitor.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.Expressions.Bonsai/CompilerServices/Reflection/SlimReflectionHelpersTests.cs
+++ b/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.Expressions.Bonsai/CompilerServices/Reflection/SlimReflectionHelpersTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.Expressions.Bonsai/CompilerServices/TypeSystem/TypeSlimDerivationVisitor.cs
+++ b/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.Expressions.Bonsai/CompilerServices/TypeSystem/TypeSlimDerivationVisitor.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.Expressions.Bonsai/CompilerServices/TypeSystem/TypeSlimSubstitutor.cs
+++ b/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.Expressions.Bonsai/CompilerServices/TypeSystem/TypeSlimSubstitutor.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.Expressions.Bonsai/CompilerServices/TypeSystem/TypeToTypeSlimConverterTests.cs
+++ b/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.Expressions.Bonsai/CompilerServices/TypeSystem/TypeToTypeSlimConverterTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.Expressions.Bonsai/GlobalSuppressions.cs
+++ b/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.Expressions.Bonsai/GlobalSuppressions.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.Expressions.Bonsai/System/Linq/Expressions/Bonsai/ExpressionSlimCSharpPrinterTest.cs
+++ b/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.Expressions.Bonsai/System/Linq/Expressions/Bonsai/ExpressionSlimCSharpPrinterTest.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.Expressions.Bonsai/System/Linq/Expressions/ConstantExpressionSlim.cs
+++ b/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.Expressions.Bonsai/System/Linq/Expressions/ConstantExpressionSlim.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.Expressions.Bonsai/System/Linq/Expressions/ExpressionSlim.cs
+++ b/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.Expressions.Bonsai/System/Linq/Expressions/ExpressionSlim.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.Expressions.Bonsai/System/Linq/Expressions/ExpressionSlimExtensions.cs
+++ b/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.Expressions.Bonsai/System/Linq/Expressions/ExpressionSlimExtensions.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.Expressions.Bonsai/System/Linq/Expressions/ExpressionSlimToExpressionConverter.cs
+++ b/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.Expressions.Bonsai/System/Linq/Expressions/ExpressionSlimToExpressionConverter.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.Expressions.Bonsai/System/Linq/Expressions/ExpressionSlimVisitor.cs
+++ b/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.Expressions.Bonsai/System/Linq/Expressions/ExpressionSlimVisitor.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.Expressions.Bonsai/System/Linq/Expressions/ExpressionToExpressionSlimConverter.cs
+++ b/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.Expressions.Bonsai/System/Linq/Expressions/ExpressionToExpressionSlimConverter.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.Expressions.Bonsai/System/Linq/Expressions/ListArgumentProviderSlimTests.cs
+++ b/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.Expressions.Bonsai/System/Linq/Expressions/ListArgumentProviderSlimTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.Expressions.Bonsai/System/Linq/Expressions/Tests.cs
+++ b/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.Expressions.Bonsai/System/Linq/Expressions/Tests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.Expressions.Bonsai/System/ObjectSlim.cs
+++ b/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.Expressions.Bonsai/System/ObjectSlim.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.Expressions.Bonsai/System/Reflection/ArrayTypeSlim.cs
+++ b/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.Expressions.Bonsai/System/Reflection/ArrayTypeSlim.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.Expressions.Bonsai/System/Reflection/AssemblySlim.cs
+++ b/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.Expressions.Bonsai/System/Reflection/AssemblySlim.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.Expressions.Bonsai/System/Reflection/ConstructorInfoSlim.cs
+++ b/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.Expressions.Bonsai/System/Reflection/ConstructorInfoSlim.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.Expressions.Bonsai/System/Reflection/FieldInfoSlim.cs
+++ b/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.Expressions.Bonsai/System/Reflection/FieldInfoSlim.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.Expressions.Bonsai/System/Reflection/FreeVariableScannerSlim.cs
+++ b/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.Expressions.Bonsai/System/Reflection/FreeVariableScannerSlim.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.Expressions.Bonsai/System/Reflection/GenericDefinitionMethodInfoSlim.cs
+++ b/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.Expressions.Bonsai/System/Reflection/GenericDefinitionMethodInfoSlim.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.Expressions.Bonsai/System/Reflection/GenericMethodInfoSlim.cs
+++ b/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.Expressions.Bonsai/System/Reflection/GenericMethodInfoSlim.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.Expressions.Bonsai/System/Reflection/GenericParameterTypeSlim.cs
+++ b/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.Expressions.Bonsai/System/Reflection/GenericParameterTypeSlim.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.Expressions.Bonsai/System/Reflection/GenericTypeSlim.cs
+++ b/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.Expressions.Bonsai/System/Reflection/GenericTypeSlim.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.Expressions.Bonsai/System/Reflection/InvertedTypeSpace.cs
+++ b/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.Expressions.Bonsai/System/Reflection/InvertedTypeSpace.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.Expressions.Bonsai/System/Reflection/MemberInfoSlim.cs
+++ b/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.Expressions.Bonsai/System/Reflection/MemberInfoSlim.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.Expressions.Bonsai/System/Reflection/MemberInfoSlimEqualityComparer.cs
+++ b/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.Expressions.Bonsai/System/Reflection/MemberInfoSlimEqualityComparer.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.Expressions.Bonsai/System/Reflection/MemberInfoSlimVisitor.cs
+++ b/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.Expressions.Bonsai/System/Reflection/MemberInfoSlimVisitor.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.Expressions.Bonsai/System/Reflection/PropertyInfoSlim.cs
+++ b/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.Expressions.Bonsai/System/Reflection/PropertyInfoSlim.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.Expressions.Bonsai/System/Reflection/SimpleMethodInfoSlimBase.cs
+++ b/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.Expressions.Bonsai/System/Reflection/SimpleMethodInfoSlimBase.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.Expressions.Bonsai/System/Reflection/SimpleTypeSlimBase.cs
+++ b/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.Expressions.Bonsai/System/Reflection/SimpleTypeSlimBase.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.Expressions.Bonsai/System/Reflection/StructuralTypeSlim.cs
+++ b/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.Expressions.Bonsai/System/Reflection/StructuralTypeSlim.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.Expressions.Bonsai/System/Reflection/StructuralTypeSlimReference.cs
+++ b/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.Expressions.Bonsai/System/Reflection/StructuralTypeSlimReference.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.Expressions.Bonsai/System/Reflection/TypeSlim.cs
+++ b/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.Expressions.Bonsai/System/Reflection/TypeSlim.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.Expressions.Bonsai/System/Reflection/TypeSlimEqualityComparer.cs
+++ b/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.Expressions.Bonsai/System/Reflection/TypeSlimEqualityComparer.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.Expressions.Bonsai/System/Reflection/TypeSlimExtensions.cs
+++ b/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.Expressions.Bonsai/System/Reflection/TypeSlimExtensions.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.Expressions.Bonsai/System/Reflection/TypeSlimToTypeConverter.cs
+++ b/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.Expressions.Bonsai/System/Reflection/TypeSlimToTypeConverter.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.Expressions.Bonsai/System/Reflection/TypeSlimVisitor.cs
+++ b/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.Expressions.Bonsai/System/Reflection/TypeSlimVisitor.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.Expressions.Bonsai/System/Reflection/TypeSpace.cs
+++ b/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.Expressions.Bonsai/System/Reflection/TypeSpace.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.Expressions.Bonsai/System/Reflection/TypeToTypeSlimConverter.cs
+++ b/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.Expressions.Bonsai/System/Reflection/TypeToTypeSlimConverter.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.Expressions.Bonsai/System/Reflection/TypeUnifier.cs
+++ b/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.Expressions.Bonsai/System/Reflection/TypeUnifier.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.Expressions.Bonsai/TestBase.cs
+++ b/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.Expressions.Bonsai/TestBase.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.Expressions.Optimizers/AssignmentAnalyzerTests.cs
+++ b/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.Expressions.Optimizers/AssignmentAnalyzerTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.Expressions.Optimizers/EvaluatorFactoryTests.cs
+++ b/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.Expressions.Optimizers/EvaluatorFactoryTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.Expressions.Optimizers/ExpressionOptimizerTests.Binary.Algebraic.cs
+++ b/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.Expressions.Optimizers/ExpressionOptimizerTests.Binary.Algebraic.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.Expressions.Optimizers/ExpressionOptimizerTests.Binary.Generated.cs
+++ b/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.Expressions.Optimizers/ExpressionOptimizerTests.Binary.Generated.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.Expressions.Optimizers/ExpressionOptimizerTests.Binary.cs
+++ b/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.Expressions.Optimizers/ExpressionOptimizerTests.Binary.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.Expressions.Optimizers/ExpressionOptimizerTests.Block.cs
+++ b/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.Expressions.Optimizers/ExpressionOptimizerTests.Block.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.Expressions.Optimizers/ExpressionOptimizerTests.Call.cs
+++ b/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.Expressions.Optimizers/ExpressionOptimizerTests.Call.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.Expressions.Optimizers/ExpressionOptimizerTests.Conditional.cs
+++ b/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.Expressions.Optimizers/ExpressionOptimizerTests.Conditional.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.Expressions.Optimizers/ExpressionOptimizerTests.Index.cs
+++ b/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.Expressions.Optimizers/ExpressionOptimizerTests.Index.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.Expressions.Optimizers/ExpressionOptimizerTests.Member.cs
+++ b/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.Expressions.Optimizers/ExpressionOptimizerTests.Member.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.Expressions.Optimizers/ExpressionOptimizerTests.New.cs
+++ b/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.Expressions.Optimizers/ExpressionOptimizerTests.New.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.Expressions.Optimizers/ExpressionOptimizerTests.Switch.cs
+++ b/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.Expressions.Optimizers/ExpressionOptimizerTests.Switch.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.Expressions.Optimizers/ExpressionOptimizerTests.Try.cs
+++ b/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.Expressions.Optimizers/ExpressionOptimizerTests.Try.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.Expressions.Optimizers/ExpressionOptimizerTests.TypeBinary.cs
+++ b/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.Expressions.Optimizers/ExpressionOptimizerTests.TypeBinary.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.Expressions.Optimizers/ExpressionOptimizerTests.Unary.Algebraic.cs
+++ b/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.Expressions.Optimizers/ExpressionOptimizerTests.Unary.Algebraic.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.Expressions.Optimizers/ExpressionOptimizerTests.Unary.Convert.Generated.cs
+++ b/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.Expressions.Optimizers/ExpressionOptimizerTests.Unary.Convert.Generated.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.Expressions.Optimizers/ExpressionOptimizerTests.Unary.Generated.cs
+++ b/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.Expressions.Optimizers/ExpressionOptimizerTests.Unary.Generated.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.Expressions.Optimizers/ExpressionOptimizerTests.Unary.cs
+++ b/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.Expressions.Optimizers/ExpressionOptimizerTests.Unary.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.Expressions.Optimizers/GlobalSuppressions.cs
+++ b/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.Expressions.Optimizers/GlobalSuppressions.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.Expressions.Optimizers/MemberTableTests.Generated.cs
+++ b/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.Expressions.Optimizers/MemberTableTests.Generated.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.Expressions.Optimizers/PureMemberCatalogTests.cs
+++ b/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.Expressions.Optimizers/PureMemberCatalogTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.Expressions.Optimizers/VariableDefaultValueSubstitutorTests.cs
+++ b/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.Expressions.Optimizers/VariableDefaultValueSubstitutorTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Museum/Nuqleon.Linq.Expressions.Serialization/Context/ExpressionJsonSerializationContext.cs
+++ b/Nuqleon/Museum/Nuqleon.Linq.Expressions.Serialization/Context/ExpressionJsonSerializationContext.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Museum/Nuqleon.Linq.Expressions.Serialization/Context/Heap.cs
+++ b/Nuqleon/Museum/Nuqleon.Linq.Expressions.Serialization/Context/Heap.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Museum/Nuqleon.Linq.Expressions.Serialization/Context/Labels.cs
+++ b/Nuqleon/Museum/Nuqleon.Linq.Expressions.Serialization/Context/Labels.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Museum/Nuqleon.Linq.Expressions.Serialization/Context/Scope.cs
+++ b/Nuqleon/Museum/Nuqleon.Linq.Expressions.Serialization/Context/Scope.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Museum/Nuqleon.Linq.Expressions.Serialization/ExpressionJsonSerializer.cs
+++ b/Nuqleon/Museum/Nuqleon.Linq.Expressions.Serialization/ExpressionJsonSerializer.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Museum/Nuqleon.Linq.Expressions.Serialization/GlobalSuppressions.cs
+++ b/Nuqleon/Museum/Nuqleon.Linq.Expressions.Serialization/GlobalSuppressions.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Museum/Nuqleon.Linq.Expressions.Serialization/Helpers.cs
+++ b/Nuqleon/Museum/Nuqleon.Linq.Expressions.Serialization/Helpers.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Museum/Nuqleon.Linq.Expressions.Serialization/JsonSerializer.cs
+++ b/Nuqleon/Museum/Nuqleon.Linq.Expressions.Serialization/JsonSerializer.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Museum/Nuqleon.Linq.Expressions.Serialization/Properties/AssemblyInfo.cs
+++ b/Nuqleon/Museum/Nuqleon.Linq.Expressions.Serialization/Properties/AssemblyInfo.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Museum/Nuqleon.Linq.Expressions.Serialization/Rules/CSharpDynamicRuleTable.cs
+++ b/Nuqleon/Museum/Nuqleon.Linq.Expressions.Serialization/Rules/CSharpDynamicRuleTable.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Museum/Nuqleon.Linq.Expressions.Serialization/Rules/ClosureRuleTable.cs
+++ b/Nuqleon/Museum/Nuqleon.Linq.Expressions.Serialization/Rules/ClosureRuleTable.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Museum/Nuqleon.Linq.Expressions.Serialization/Rules/ExpressionTreeRuleTable.cs
+++ b/Nuqleon/Museum/Nuqleon.Linq.Expressions.Serialization/Rules/ExpressionTreeRuleTable.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Museum/Nuqleon.Linq.Expressions.Serialization/Rules/JsonRuleTable.cs
+++ b/Nuqleon/Museum/Nuqleon.Linq.Expressions.Serialization/Rules/JsonRuleTable.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Museum/Nuqleon.Linq.Expressions.Serialization/Rules/RuleConfiguration.cs
+++ b/Nuqleon/Museum/Nuqleon.Linq.Expressions.Serialization/Rules/RuleConfiguration.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Museum/Nuqleon.Linq.Expressions.Serialization/Rules/RuleOptions.cs
+++ b/Nuqleon/Museum/Nuqleon.Linq.Expressions.Serialization/Rules/RuleOptions.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Museum/Nuqleon.Linq.Expressions.Serialization/Rules/StatementTreeRuleTable.cs
+++ b/Nuqleon/Museum/Nuqleon.Linq.Expressions.Serialization/Rules/StatementTreeRuleTable.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Museum/Nuqleon.Linq.Expressions.Serialization/TypeSystem/TypeDef.cs
+++ b/Nuqleon/Museum/Nuqleon.Linq.Expressions.Serialization/TypeSystem/TypeDef.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Museum/Nuqleon.Linq.Expressions.Serialization/TypeSystem/TypeRef.cs
+++ b/Nuqleon/Museum/Nuqleon.Linq.Expressions.Serialization/TypeSystem/TypeRef.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Museum/Nuqleon.Linq.Expressions.Serialization/TypeSystem/TypeSpace.cs
+++ b/Nuqleon/Museum/Nuqleon.Linq.Expressions.Serialization/TypeSystem/TypeSpace.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Museum/Nuqleon.Runtime.ExceptionServices.Extensions/Tests.Nuqleon.Runtime.ExceptionServices.Extensions.CSharp.cs
+++ b/Nuqleon/Museum/Nuqleon.Runtime.ExceptionServices.Extensions/Tests.Nuqleon.Runtime.ExceptionServices.Extensions.CSharp.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Museum/Nuqleon.Serialization/Contextual.cs
+++ b/Nuqleon/Museum/Nuqleon.Serialization/Contextual.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Museum/Nuqleon.Serialization/GlobalSuppressions.cs
+++ b/Nuqleon/Museum/Nuqleon.Serialization/GlobalSuppressions.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Museum/Nuqleon.Serialization/Properties/AssemblyInfo.cs
+++ b/Nuqleon/Museum/Nuqleon.Serialization/Properties/AssemblyInfo.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Museum/Nuqleon.Serialization/Rule.cs
+++ b/Nuqleon/Museum/Nuqleon.Serialization/Rule.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Museum/Nuqleon.Serialization/RuleTable.cs
+++ b/Nuqleon/Museum/Nuqleon.Serialization/RuleTable.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Museum/Nuqleon.Serialization/RuleTableBase.cs
+++ b/Nuqleon/Museum/Nuqleon.Serialization/RuleTableBase.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Museum/Nuqleon.Serialization/RuleTableExtensions.cs
+++ b/Nuqleon/Museum/Nuqleon.Serialization/RuleTableExtensions.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Museum/Nuqleon.Serialization/SerializationPair.cs
+++ b/Nuqleon/Museum/Nuqleon.Serialization/SerializationPair.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Museum/Nuqleon.Serialization/Serializer.cs
+++ b/Nuqleon/Museum/Nuqleon.Serialization/Serializer.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Museum/Nuqleon.Serialization/TaggedByRule.cs
+++ b/Nuqleon/Museum/Nuqleon.Serialization/TaggedByRule.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Museum/Tests.Nuqleon.Linq.Expressions.Serialization/ExpressionJsonSerializer.cs
+++ b/Nuqleon/Museum/Tests.Nuqleon.Linq.Expressions.Serialization/ExpressionJsonSerializer.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Museum/Tests.Nuqleon.Linq.Expressions.Serialization/TestBase.cs
+++ b/Nuqleon/Museum/Tests.Nuqleon.Linq.Expressions.Serialization/TestBase.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Museum/Tests.Nuqleon.Linq.Expressions.Serialization/Tests.cs
+++ b/Nuqleon/Museum/Tests.Nuqleon.Linq.Expressions.Serialization/Tests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Museum/Tests.Nuqleon.Serialization/RuleTableTests.cs
+++ b/Nuqleon/Museum/Tests.Nuqleon.Serialization/RuleTableTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Museum/Tests.Nuqleon.Serialization/RuleTests.cs
+++ b/Nuqleon/Museum/Tests.Nuqleon.Serialization/RuleTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Museum/Tests.Nuqleon.Serialization/Serializer.cs
+++ b/Nuqleon/Museum/Tests.Nuqleon.Serialization/Serializer.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Pearls/BCL/ProjectJohnnie/Nuqleon.Memory.Diagnostics/Properties/AssemblyInfo.cs
+++ b/Nuqleon/Pearls/BCL/ProjectJohnnie/Nuqleon.Memory.Diagnostics/Properties/AssemblyInfo.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Pearls/BCL/ProjectJohnnie/Nuqleon.Memory.Diagnostics/System/Collections/Generic/BitHelpers.cs
+++ b/Nuqleon/Pearls/BCL/ProjectJohnnie/Nuqleon.Memory.Diagnostics/System/Collections/Generic/BitHelpers.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Pearls/BCL/ProjectJohnnie/Nuqleon.Memory.Diagnostics/System/Collections/Generic/HashHelpers.cs
+++ b/Nuqleon/Pearls/BCL/ProjectJohnnie/Nuqleon.Memory.Diagnostics/System/Collections/Generic/HashHelpers.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Pearls/BCL/ProjectJohnnie/Nuqleon.Memory.Diagnostics/System/Collections/Generic/ObjectSet.cs
+++ b/Nuqleon/Pearls/BCL/ProjectJohnnie/Nuqleon.Memory.Diagnostics/System/Collections/Generic/ObjectSet.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Pearls/BCL/ProjectJohnnie/Nuqleon.Memory.Diagnostics/System/Collections/Generic/ReferenceEqualityComparer.cs
+++ b/Nuqleon/Pearls/BCL/ProjectJohnnie/Nuqleon.Memory.Diagnostics/System/Collections/Generic/ReferenceEqualityComparer.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Pearls/BCL/ProjectJohnnie/Nuqleon.Memory.Diagnostics/System/Memory/Diagnostics/Access.cs
+++ b/Nuqleon/Pearls/BCL/ProjectJohnnie/Nuqleon.Memory.Diagnostics/System/Memory/Diagnostics/Access.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Pearls/BCL/ProjectJohnnie/Nuqleon.Memory.Diagnostics/System/Memory/Diagnostics/AccessType.cs
+++ b/Nuqleon/Pearls/BCL/ProjectJohnnie/Nuqleon.Memory.Diagnostics/System/Memory/Diagnostics/AccessType.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Pearls/BCL/ProjectJohnnie/Nuqleon.Memory.Diagnostics/System/Memory/Diagnostics/CompositeAccess.cs
+++ b/Nuqleon/Pearls/BCL/ProjectJohnnie/Nuqleon.Memory.Diagnostics/System/Memory/Diagnostics/CompositeAccess.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Pearls/BCL/ProjectJohnnie/Nuqleon.Memory.Diagnostics/System/Memory/Diagnostics/Edge.cs
+++ b/Nuqleon/Pearls/BCL/ProjectJohnnie/Nuqleon.Memory.Diagnostics/System/Memory/Diagnostics/Edge.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Pearls/BCL/ProjectJohnnie/Nuqleon.Memory.Diagnostics/System/Memory/Diagnostics/Edge`1.cs
+++ b/Nuqleon/Pearls/BCL/ProjectJohnnie/Nuqleon.Memory.Diagnostics/System/Memory/Diagnostics/Edge`1.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Pearls/BCL/ProjectJohnnie/Nuqleon.Memory.Diagnostics/System/Memory/Diagnostics/FastHeapReferenceWalker.cs
+++ b/Nuqleon/Pearls/BCL/ProjectJohnnie/Nuqleon.Memory.Diagnostics/System/Memory/Diagnostics/FastHeapReferenceWalker.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Pearls/BCL/ProjectJohnnie/Nuqleon.Memory.Diagnostics/System/Memory/Diagnostics/FieldAccess.cs
+++ b/Nuqleon/Pearls/BCL/ProjectJohnnie/Nuqleon.Memory.Diagnostics/System/Memory/Diagnostics/FieldAccess.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Pearls/BCL/ProjectJohnnie/Nuqleon.Memory.Diagnostics/System/Memory/Diagnostics/HeapAnalysisOptions.cs
+++ b/Nuqleon/Pearls/BCL/ProjectJohnnie/Nuqleon.Memory.Diagnostics/System/Memory/Diagnostics/HeapAnalysisOptions.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Pearls/BCL/ProjectJohnnie/Nuqleon.Memory.Diagnostics/System/Memory/Diagnostics/HeapEditor.cs
+++ b/Nuqleon/Pearls/BCL/ProjectJohnnie/Nuqleon.Memory.Diagnostics/System/Memory/Diagnostics/HeapEditor.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Pearls/BCL/ProjectJohnnie/Nuqleon.Memory.Diagnostics/System/Memory/Diagnostics/HeapPartition.cs
+++ b/Nuqleon/Pearls/BCL/ProjectJohnnie/Nuqleon.Memory.Diagnostics/System/Memory/Diagnostics/HeapPartition.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Pearls/BCL/ProjectJohnnie/Nuqleon.Memory.Diagnostics/System/Memory/Diagnostics/HeapStats.cs
+++ b/Nuqleon/Pearls/BCL/ProjectJohnnie/Nuqleon.Memory.Diagnostics/System/Memory/Diagnostics/HeapStats.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Pearls/BCL/ProjectJohnnie/Nuqleon.Memory.Diagnostics/System/Memory/Diagnostics/HeapUsageAnalysis.cs
+++ b/Nuqleon/Pearls/BCL/ProjectJohnnie/Nuqleon.Memory.Diagnostics/System/Memory/Diagnostics/HeapUsageAnalysis.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Pearls/BCL/ProjectJohnnie/Nuqleon.Memory.Diagnostics/System/Memory/Diagnostics/HeapUsageAnalyzer.cs
+++ b/Nuqleon/Pearls/BCL/ProjectJohnnie/Nuqleon.Memory.Diagnostics/System/Memory/Diagnostics/HeapUsageAnalyzer.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Pearls/BCL/ProjectJohnnie/Nuqleon.Memory.Diagnostics/System/Memory/Diagnostics/IEdge.cs
+++ b/Nuqleon/Pearls/BCL/ProjectJohnnie/Nuqleon.Memory.Diagnostics/System/Memory/Diagnostics/IEdge.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Pearls/BCL/ProjectJohnnie/Nuqleon.Memory.Diagnostics/System/Memory/Diagnostics/IEdge`1.cs
+++ b/Nuqleon/Pearls/BCL/ProjectJohnnie/Nuqleon.Memory.Diagnostics/System/Memory/Diagnostics/IEdge`1.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Pearls/BCL/ProjectJohnnie/Nuqleon.Memory.Diagnostics/System/Memory/Diagnostics/IObjectVisitor`1.cs
+++ b/Nuqleon/Pearls/BCL/ProjectJohnnie/Nuqleon.Memory.Diagnostics/System/Memory/Diagnostics/IObjectVisitor`1.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Pearls/BCL/ProjectJohnnie/Nuqleon.Memory.Diagnostics/System/Memory/Diagnostics/IObjectWalker`1.cs
+++ b/Nuqleon/Pearls/BCL/ProjectJohnnie/Nuqleon.Memory.Diagnostics/System/Memory/Diagnostics/IObjectWalker`1.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Pearls/BCL/ProjectJohnnie/Nuqleon.Memory.Diagnostics/System/Memory/Diagnostics/IVisit`1.cs
+++ b/Nuqleon/Pearls/BCL/ProjectJohnnie/Nuqleon.Memory.Diagnostics/System/Memory/Diagnostics/IVisit`1.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Pearls/BCL/ProjectJohnnie/Nuqleon.Memory.Diagnostics/System/Memory/Diagnostics/MultidimensionalArrayElementAccess.cs
+++ b/Nuqleon/Pearls/BCL/ProjectJohnnie/Nuqleon.Memory.Diagnostics/System/Memory/Diagnostics/MultidimensionalArrayElementAccess.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Pearls/BCL/ProjectJohnnie/Nuqleon.Memory.Diagnostics/System/Memory/Diagnostics/VectorElementAccess.cs
+++ b/Nuqleon/Pearls/BCL/ProjectJohnnie/Nuqleon.Memory.Diagnostics/System/Memory/Diagnostics/VectorElementAccess.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Pearls/BCL/ProjectJohnnie/Nuqleon.Memory.Diagnostics/System/Memory/Diagnostics/Visit`1.cs
+++ b/Nuqleon/Pearls/BCL/ProjectJohnnie/Nuqleon.Memory.Diagnostics/System/Memory/Diagnostics/Visit`1.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Pearls/BCL/ProjectJohnnie/Nuqleon.Memory.Diagnostics/System/Memory/HeapOptimizer.cs
+++ b/Nuqleon/Pearls/BCL/ProjectJohnnie/Nuqleon.Memory.Diagnostics/System/Memory/HeapOptimizer.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Pearls/BCL/ProjectJohnnie/Nuqleon.Memory.Diagnostics/System/Runtime/CompilerServices/TypeHelpers.cs
+++ b/Nuqleon/Pearls/BCL/ProjectJohnnie/Nuqleon.Memory.Diagnostics/System/Runtime/CompilerServices/TypeHelpers.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Pearls/BCL/ProjectJohnnie/Perf.Nuqleon.Memory.Diagnostics/Program.cs
+++ b/Nuqleon/Pearls/BCL/ProjectJohnnie/Perf.Nuqleon.Memory.Diagnostics/Program.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Pearls/BCL/ProjectJohnnie/ProjectJohnnie/MyHeapOptimizer.cs
+++ b/Nuqleon/Pearls/BCL/ProjectJohnnie/ProjectJohnnie/MyHeapOptimizer.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Pearls/BCL/ProjectJohnnie/ProjectJohnnie/Program.cs
+++ b/Nuqleon/Pearls/BCL/ProjectJohnnie/ProjectJohnnie/Program.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Pearls/BCL/ProjectJohnnie/ProjectJohnnie/Utils/HashHelpers.cs
+++ b/Nuqleon/Pearls/BCL/ProjectJohnnie/ProjectJohnnie/Utils/HashHelpers.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Pearls/BCL/ProjectJohnnie/ProjectJohnnie/Utils/TupleEqualityComparers.Generated.cs
+++ b/Nuqleon/Pearls/BCL/ProjectJohnnie/ProjectJohnnie/Utils/TupleEqualityComparers.Generated.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Pearls/BCL/ProjectJohnnie/ProjectJohnnie/Utils/TupleEqualityComparers.cs
+++ b/Nuqleon/Pearls/BCL/ProjectJohnnie/ProjectJohnnie/Utils/TupleEqualityComparers.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Pearls/BCL/ProjectJohnnie/Tests.Nuqleon.Memory.Diagnostics/ReferenceEqualityComparerTests.cs
+++ b/Nuqleon/Pearls/BCL/ProjectJohnnie/Tests.Nuqleon.Memory.Diagnostics/ReferenceEqualityComparerTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Pearls/BCL/ProjectJohnnie/Tests.Nuqleon.Memory.Diagnostics/TypeHelpersTests.cs
+++ b/Nuqleon/Pearls/BCL/ProjectJohnnie/Tests.Nuqleon.Memory.Diagnostics/TypeHelpersTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Pearls/LINQ/BinaryExpressionSerialization/BinaryExpressionSerialization/Benchmarks.cs
+++ b/Nuqleon/Pearls/LINQ/BinaryExpressionSerialization/BinaryExpressionSerialization/Benchmarks.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Pearls/LINQ/BinaryExpressionSerialization/BinaryExpressionSerialization/Program.cs
+++ b/Nuqleon/Pearls/LINQ/BinaryExpressionSerialization/BinaryExpressionSerialization/Program.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Pearls/LINQ/BinaryExpressionSerialization/Library/ArrayPool.cs
+++ b/Nuqleon/Pearls/LINQ/BinaryExpressionSerialization/Library/ArrayPool.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Pearls/LINQ/BinaryExpressionSerialization/Library/BinaryObjectSerializer.cs
+++ b/Nuqleon/Pearls/LINQ/BinaryExpressionSerialization/Library/BinaryObjectSerializer.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Pearls/LINQ/BinaryExpressionSerialization/Library/ExpressionSerializer.Deserializer.cs
+++ b/Nuqleon/Pearls/LINQ/BinaryExpressionSerialization/Library/ExpressionSerializer.Deserializer.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Pearls/LINQ/BinaryExpressionSerialization/Library/ExpressionSerializer.Serializer.cs
+++ b/Nuqleon/Pearls/LINQ/BinaryExpressionSerialization/Library/ExpressionSerializer.Serializer.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Pearls/LINQ/BinaryExpressionSerialization/Library/ExpressionSerializer.cs
+++ b/Nuqleon/Pearls/LINQ/BinaryExpressionSerialization/Library/ExpressionSerializer.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Pearls/LINQ/BinaryExpressionSerialization/Library/Helpers.cs
+++ b/Nuqleon/Pearls/LINQ/BinaryExpressionSerialization/Library/Helpers.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Pearls/LINQ/BinaryExpressionSerialization/Library/IObjectSerializer.cs
+++ b/Nuqleon/Pearls/LINQ/BinaryExpressionSerialization/Library/IObjectSerializer.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Pearls/LINQ/BinaryExpressionSerialization/Library/PooledTypeSlimEqualityComparer.cs
+++ b/Nuqleon/Pearls/LINQ/BinaryExpressionSerialization/Library/PooledTypeSlimEqualityComparer.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Pearls/LINQ/BinaryExpressionSerialization/Library/Properties/AssemblyInfo.cs
+++ b/Nuqleon/Pearls/LINQ/BinaryExpressionSerialization/Library/Properties/AssemblyInfo.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Pearls/LINQ/BinaryExpressionSerialization/Library/Protocol.cs
+++ b/Nuqleon/Pearls/LINQ/BinaryExpressionSerialization/Library/Protocol.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Pearls/LINQ/BinaryExpressionSerialization/Library/Reflection.cs
+++ b/Nuqleon/Pearls/LINQ/BinaryExpressionSerialization/Library/Reflection.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Pearls/LINQ/BinaryExpressionSerialization/Library/StreamHelpers.cs
+++ b/Nuqleon/Pearls/LINQ/BinaryExpressionSerialization/Library/StreamHelpers.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Pearls/LINQ/BinaryExpressionSerialization/Tests/Tests.cs
+++ b/Nuqleon/Pearls/LINQ/BinaryExpressionSerialization/Tests/Tests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Pearls/LINQ/ExpressionJit/ExpressionJit/Debugger/ExpressionEvaluationTracer.cs
+++ b/Nuqleon/Pearls/LINQ/ExpressionJit/ExpressionJit/Debugger/ExpressionEvaluationTracer.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Pearls/LINQ/ExpressionJit/ExpressionJit/Debugger/ExpressionInstrumenter.cs
+++ b/Nuqleon/Pearls/LINQ/ExpressionJit/ExpressionJit/Debugger/ExpressionInstrumenter.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Pearls/LINQ/ExpressionJit/ExpressionJit/ILReader/DynamicMethodILProvider.cs
+++ b/Nuqleon/Pearls/LINQ/ExpressionJit/ExpressionJit/ILReader/DynamicMethodILProvider.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Pearls/LINQ/ExpressionJit/ExpressionJit/ILReader/DynamicScopeTokenResolver.cs
+++ b/Nuqleon/Pearls/LINQ/ExpressionJit/ExpressionJit/ILReader/DynamicScopeTokenResolver.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Pearls/LINQ/ExpressionJit/ExpressionJit/ILReader/FormatProvider.cs
+++ b/Nuqleon/Pearls/LINQ/ExpressionJit/ExpressionJit/ILReader/FormatProvider.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Pearls/LINQ/ExpressionJit/ExpressionJit/ILReader/ILInstruction.cs
+++ b/Nuqleon/Pearls/LINQ/ExpressionJit/ExpressionJit/ILReader/ILInstruction.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Pearls/LINQ/ExpressionJit/ExpressionJit/ILReader/ILPrinter.cs
+++ b/Nuqleon/Pearls/LINQ/ExpressionJit/ExpressionJit/ILReader/ILPrinter.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Pearls/LINQ/ExpressionJit/ExpressionJit/ILReader/ILProvider.cs
+++ b/Nuqleon/Pearls/LINQ/ExpressionJit/ExpressionJit/ILReader/ILProvider.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Pearls/LINQ/ExpressionJit/ExpressionJit/ILReader/ILReader.cs
+++ b/Nuqleon/Pearls/LINQ/ExpressionJit/ExpressionJit/ILReader/ILReader.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Pearls/LINQ/ExpressionJit/ExpressionJit/ILReader/ILReaderFactory.cs
+++ b/Nuqleon/Pearls/LINQ/ExpressionJit/ExpressionJit/ILReader/ILReaderFactory.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Pearls/LINQ/ExpressionJit/ExpressionJit/ILReader/ITypeFactory.cs
+++ b/Nuqleon/Pearls/LINQ/ExpressionJit/ExpressionJit/ILReader/ITypeFactory.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Pearls/LINQ/ExpressionJit/ExpressionJit/ILReader/LocalsSignatureParser.cs
+++ b/Nuqleon/Pearls/LINQ/ExpressionJit/ExpressionJit/ILReader/LocalsSignatureParser.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Pearls/LINQ/ExpressionJit/ExpressionJit/ILReader/PrivateReflectionHelpers.cs
+++ b/Nuqleon/Pearls/LINQ/ExpressionJit/ExpressionJit/ILReader/PrivateReflectionHelpers.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Pearls/LINQ/ExpressionJit/ExpressionJit/ILReader/ReadableILStringVisitor.cs
+++ b/Nuqleon/Pearls/LINQ/ExpressionJit/ExpressionJit/ILReader/ReadableILStringVisitor.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Pearls/LINQ/ExpressionJit/ExpressionJit/ILReader/SigParser.cs
+++ b/Nuqleon/Pearls/LINQ/ExpressionJit/ExpressionJit/ILReader/SigParser.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Pearls/LINQ/ExpressionJit/ExpressionJit/ILReader/TokenResolver.cs
+++ b/Nuqleon/Pearls/LINQ/ExpressionJit/ExpressionJit/ILReader/TokenResolver.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Pearls/LINQ/ExpressionJit/Nuqleon.Linq.Expressions.Jit/Properties/AssemblyInfo.cs
+++ b/Nuqleon/Pearls/LINQ/ExpressionJit/Nuqleon.Linq.Expressions.Jit/Properties/AssemblyInfo.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Pearls/LINQ/ExpressionJit/Nuqleon.Linq.Expressions.Jit/System/ArrayExtensions.cs
+++ b/Nuqleon/Pearls/LINQ/ExpressionJit/Nuqleon.Linq.Expressions.Jit/System/ArrayExtensions.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Pearls/LINQ/ExpressionJit/Nuqleon.Linq.Expressions.Jit/System/Collections/ObjectModel/ReadOnlyCollectionExtensions.cs
+++ b/Nuqleon/Pearls/LINQ/ExpressionJit/Nuqleon.Linq.Expressions.Jit/System/Collections/ObjectModel/ReadOnlyCollectionExtensions.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Pearls/LINQ/ExpressionJit/Nuqleon.Linq.Expressions.Jit/System/Invariant.cs
+++ b/Nuqleon/Pearls/LINQ/ExpressionJit/Nuqleon.Linq.Expressions.Jit/System/Invariant.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Pearls/LINQ/ExpressionJit/Nuqleon.Linq.Expressions.Jit/System/Linq/Expressions/BetterExpressionVisitor.cs
+++ b/Nuqleon/Pearls/LINQ/ExpressionJit/Nuqleon.Linq.Expressions.Jit/System/Linq/Expressions/BetterExpressionVisitor.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Pearls/LINQ/ExpressionJit/Nuqleon.Linq.Expressions.Jit/System/Linq/Expressions/CompilationOptions.cs
+++ b/Nuqleon/Pearls/LINQ/ExpressionJit/Nuqleon.Linq.Expressions.Jit/System/Linq/Expressions/CompilationOptions.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Pearls/LINQ/ExpressionJit/Nuqleon.Linq.Expressions.Jit/System/Linq/Expressions/Jit/Analyzer.cs
+++ b/Nuqleon/Pearls/LINQ/ExpressionJit/Nuqleon.Linq.Expressions.Jit/System/Linq/Expressions/Jit/Analyzer.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Pearls/LINQ/ExpressionJit/Nuqleon.Linq.Expressions.Jit/System/Linq/Expressions/Jit/ClosureFieldInfo.cs
+++ b/Nuqleon/Pearls/LINQ/ExpressionJit/Nuqleon.Linq.Expressions.Jit/System/Linq/Expressions/Jit/ClosureFieldInfo.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Pearls/LINQ/ExpressionJit/Nuqleon.Linq.Expressions.Jit/System/Linq/Expressions/Jit/ClosureGenerator.cs
+++ b/Nuqleon/Pearls/LINQ/ExpressionJit/Nuqleon.Linq.Expressions.Jit/System/Linq/Expressions/Jit/ClosureGenerator.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Pearls/LINQ/ExpressionJit/Nuqleon.Linq.Expressions.Jit/System/Linq/Expressions/Jit/ClosureInfo.cs
+++ b/Nuqleon/Pearls/LINQ/ExpressionJit/Nuqleon.Linq.Expressions.Jit/System/Linq/Expressions/Jit/ClosureInfo.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Pearls/LINQ/ExpressionJit/Nuqleon.Linq.Expressions.Jit/System/Linq/Expressions/Jit/HoistedLocals.cs
+++ b/Nuqleon/Pearls/LINQ/ExpressionJit/Nuqleon.Linq.Expressions.Jit/System/Linq/Expressions/Jit/HoistedLocals.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Pearls/LINQ/ExpressionJit/Nuqleon.Linq.Expressions.Jit/System/Linq/Expressions/Jit/JitCompilationInfo.cs
+++ b/Nuqleon/Pearls/LINQ/ExpressionJit/Nuqleon.Linq.Expressions.Jit/System/Linq/Expressions/Jit/JitCompilationInfo.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Pearls/LINQ/ExpressionJit/Nuqleon.Linq.Expressions.Jit/System/Linq/Expressions/Jit/JitCompiler.cs
+++ b/Nuqleon/Pearls/LINQ/ExpressionJit/Nuqleon.Linq.Expressions.Jit/System/Linq/Expressions/Jit/JitCompiler.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Pearls/LINQ/ExpressionJit/Nuqleon.Linq.Expressions.Jit/System/Linq/Expressions/Jit/Reducer.cs
+++ b/Nuqleon/Pearls/LINQ/ExpressionJit/Nuqleon.Linq.Expressions.Jit/System/Linq/Expressions/Jit/Reducer.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Pearls/LINQ/ExpressionJit/Nuqleon.Linq.Expressions.Jit/System/Linq/Expressions/Jit/Scope.cs
+++ b/Nuqleon/Pearls/LINQ/ExpressionJit/Nuqleon.Linq.Expressions.Jit/System/Linq/Expressions/Jit/Scope.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Pearls/LINQ/ExpressionJit/Nuqleon.Linq.Expressions.Jit/System/Linq/Expressions/Jit/StorageKind.cs
+++ b/Nuqleon/Pearls/LINQ/ExpressionJit/Nuqleon.Linq.Expressions.Jit/System/Linq/Expressions/Jit/StorageKind.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Pearls/LINQ/ExpressionJit/Nuqleon.Linq.Expressions.Jit/System/Linq/Expressions/LambdaExpressionExtensions.cs
+++ b/Nuqleon/Pearls/LINQ/ExpressionJit/Nuqleon.Linq.Expressions.Jit/System/Linq/Expressions/LambdaExpressionExtensions.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Pearls/LINQ/ExpressionJit/Nuqleon.Linq.Expressions.Jit/System/Linq/Expressions/Optimizations.cs
+++ b/Nuqleon/Pearls/LINQ/ExpressionJit/Nuqleon.Linq.Expressions.Jit/System/Linq/Expressions/Optimizations.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Pearls/LINQ/ExpressionJit/Nuqleon.Linq.Expressions.Jit/System/Linq/Expressions/Optimizer.cs
+++ b/Nuqleon/Pearls/LINQ/ExpressionJit/Nuqleon.Linq.Expressions.Jit/System/Linq/Expressions/Optimizer.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Pearls/LINQ/ExpressionJit/Nuqleon.Linq.Expressions.Jit/System/Linq/Expressions/UnboundVariableScanner.cs
+++ b/Nuqleon/Pearls/LINQ/ExpressionJit/Nuqleon.Linq.Expressions.Jit/System/Linq/Expressions/UnboundVariableScanner.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Pearls/LINQ/ExpressionJit/Nuqleon.Linq.Expressions.Jit/System/Reflection/Emit/ILGeneratorExtensions.cs
+++ b/Nuqleon/Pearls/LINQ/ExpressionJit/Nuqleon.Linq.Expressions.Jit/System/Reflection/Emit/ILGeneratorExtensions.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Pearls/LINQ/ExpressionJit/Nuqleon.Linq.Expressions.Jit/System/Runtime/CompilerServices/ClosureFactory.cs
+++ b/Nuqleon/Pearls/LINQ/ExpressionJit/Nuqleon.Linq.Expressions.Jit/System/Runtime/CompilerServices/ClosureFactory.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Pearls/LINQ/ExpressionJit/Nuqleon.Linq.Expressions.Jit/System/Runtime/CompilerServices/Closures.Generated.cs
+++ b/Nuqleon/Pearls/LINQ/ExpressionJit/Nuqleon.Linq.Expressions.Jit/System/Runtime/CompilerServices/Closures.Generated.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Pearls/LINQ/ExpressionJit/Nuqleon.Linq.Expressions.Jit/System/Runtime/CompilerServices/Closures.cs
+++ b/Nuqleon/Pearls/LINQ/ExpressionJit/Nuqleon.Linq.Expressions.Jit/System/Runtime/CompilerServices/Closures.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Pearls/LINQ/ExpressionJit/Nuqleon.Linq.Expressions.Jit/System/Runtime/CompilerServices/CompilingThunkFactory.cs
+++ b/Nuqleon/Pearls/LINQ/ExpressionJit/Nuqleon.Linq.Expressions.Jit/System/Runtime/CompilerServices/CompilingThunkFactory.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Pearls/LINQ/ExpressionJit/Nuqleon.Linq.Expressions.Jit/System/Runtime/CompilerServices/Dispatcher.cs
+++ b/Nuqleon/Pearls/LINQ/ExpressionJit/Nuqleon.Linq.Expressions.Jit/System/Runtime/CompilerServices/Dispatcher.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Pearls/LINQ/ExpressionJit/Nuqleon.Linq.Expressions.Jit/System/Runtime/CompilerServices/FunctionContext.cs
+++ b/Nuqleon/Pearls/LINQ/ExpressionJit/Nuqleon.Linq.Expressions.Jit/System/Runtime/CompilerServices/FunctionContext.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Pearls/LINQ/ExpressionJit/Nuqleon.Linq.Expressions.Jit/System/Runtime/CompilerServices/IThunkFactory.cs
+++ b/Nuqleon/Pearls/LINQ/ExpressionJit/Nuqleon.Linq.Expressions.Jit/System/Runtime/CompilerServices/IThunkFactory.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Pearls/LINQ/ExpressionJit/Nuqleon.Linq.Expressions.Jit/System/Runtime/CompilerServices/InterpretingThunkFactory.cs
+++ b/Nuqleon/Pearls/LINQ/ExpressionJit/Nuqleon.Linq.Expressions.Jit/System/Runtime/CompilerServices/InterpretingThunkFactory.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Pearls/LINQ/ExpressionJit/Nuqleon.Linq.Expressions.Jit/System/Runtime/CompilerServices/JitConstants.cs
+++ b/Nuqleon/Pearls/LINQ/ExpressionJit/Nuqleon.Linq.Expressions.Jit/System/Runtime/CompilerServices/JitConstants.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Pearls/LINQ/ExpressionJit/Nuqleon.Linq.Expressions.Jit/System/Runtime/CompilerServices/MethodTable.cs
+++ b/Nuqleon/Pearls/LINQ/ExpressionJit/Nuqleon.Linq.Expressions.Jit/System/Runtime/CompilerServices/MethodTable.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Pearls/LINQ/ExpressionJit/Nuqleon.Linq.Expressions.Jit/System/Runtime/CompilerServices/RuntimeOps.cs
+++ b/Nuqleon/Pearls/LINQ/ExpressionJit/Nuqleon.Linq.Expressions.Jit/System/Runtime/CompilerServices/RuntimeOps.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 #if NET5_0

--- a/Nuqleon/Pearls/LINQ/ExpressionJit/Nuqleon.Linq.Expressions.Jit/System/Runtime/CompilerServices/RuntimeOpsEx.ExpressionQuoter.cs
+++ b/Nuqleon/Pearls/LINQ/ExpressionJit/Nuqleon.Linq.Expressions.Jit/System/Runtime/CompilerServices/RuntimeOpsEx.ExpressionQuoter.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Pearls/LINQ/ExpressionJit/Nuqleon.Linq.Expressions.Jit/System/Runtime/CompilerServices/RuntimeOpsEx.RuntimeVariableList.cs
+++ b/Nuqleon/Pearls/LINQ/ExpressionJit/Nuqleon.Linq.Expressions.Jit/System/Runtime/CompilerServices/RuntimeOpsEx.RuntimeVariableList.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Pearls/LINQ/ExpressionJit/Nuqleon.Linq.Expressions.Jit/System/Runtime/CompilerServices/RuntimeOpsEx.RuntimeVariables.cs
+++ b/Nuqleon/Pearls/LINQ/ExpressionJit/Nuqleon.Linq.Expressions.Jit/System/Runtime/CompilerServices/RuntimeOpsEx.RuntimeVariables.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Pearls/LINQ/ExpressionJit/Nuqleon.Linq.Expressions.Jit/System/Runtime/CompilerServices/RuntimeOpsEx.cs
+++ b/Nuqleon/Pearls/LINQ/ExpressionJit/Nuqleon.Linq.Expressions.Jit/System/Runtime/CompilerServices/RuntimeOpsEx.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Pearls/LINQ/ExpressionJit/Nuqleon.Linq.Expressions.Jit/System/Runtime/CompilerServices/Thunk.cs
+++ b/Nuqleon/Pearls/LINQ/ExpressionJit/Nuqleon.Linq.Expressions.Jit/System/Runtime/CompilerServices/Thunk.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Pearls/LINQ/ExpressionJit/Nuqleon.Linq.Expressions.Jit/System/Runtime/CompilerServices/ThunkBehavior.cs
+++ b/Nuqleon/Pearls/LINQ/ExpressionJit/Nuqleon.Linq.Expressions.Jit/System/Runtime/CompilerServices/ThunkBehavior.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Pearls/LINQ/ExpressionJit/Nuqleon.Linq.Expressions.Jit/System/Runtime/CompilerServices/ThunkFactory.cs
+++ b/Nuqleon/Pearls/LINQ/ExpressionJit/Nuqleon.Linq.Expressions.Jit/System/Runtime/CompilerServices/ThunkFactory.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Pearls/LINQ/ExpressionJit/Nuqleon.Linq.Expressions.Jit/System/Runtime/CompilerServices/ThunkFactoryBase.cs
+++ b/Nuqleon/Pearls/LINQ/ExpressionJit/Nuqleon.Linq.Expressions.Jit/System/Runtime/CompilerServices/ThunkFactoryBase.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Pearls/LINQ/ExpressionJit/Nuqleon.Linq.Expressions.Jit/System/Runtime/CompilerServices/Thunks.Generated.cs
+++ b/Nuqleon/Pearls/LINQ/ExpressionJit/Nuqleon.Linq.Expressions.Jit/System/Runtime/CompilerServices/Thunks.Generated.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Pearls/LINQ/ExpressionJit/Nuqleon.Linq.Expressions.Jit/System/Runtime/CompilerServices/TieredCompilationThunkFactory.cs
+++ b/Nuqleon/Pearls/LINQ/ExpressionJit/Nuqleon.Linq.Expressions.Jit/System/Runtime/CompilerServices/TieredCompilationThunkFactory.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Pearls/LINQ/ExpressionJit/Nuqleon.Linq.Expressions.Jit/System/TypeUtils.cs
+++ b/Nuqleon/Pearls/LINQ/ExpressionJit/Nuqleon.Linq.Expressions.Jit/System/TypeUtils.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Pearls/LINQ/ExpressionJit/Nuqleon.Linq.Expressions.Jit/Visibility.cs
+++ b/Nuqleon/Pearls/LINQ/ExpressionJit/Nuqleon.Linq.Expressions.Jit/Visibility.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Pearls/LINQ/ExpressionJit/Tests.Nuqleon.Linq.Expressions.Jit/Data.cs
+++ b/Nuqleon/Pearls/LINQ/ExpressionJit/Tests.Nuqleon.Linq.Expressions.Jit/Data.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Pearls/LINQ/ExpressionJit/Tests.Nuqleon.Linq.Expressions.Jit/System/ArrayExtensionsTests.cs
+++ b/Nuqleon/Pearls/LINQ/ExpressionJit/Tests.Nuqleon.Linq.Expressions.Jit/System/ArrayExtensionsTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Pearls/LINQ/ExpressionJit/Tests.Nuqleon.Linq.Expressions.Jit/System/Collections/ObjectModel/ReadOnlyCollectionExtensionsTests.cs
+++ b/Nuqleon/Pearls/LINQ/ExpressionJit/Tests.Nuqleon.Linq.Expressions.Jit/System/Collections/ObjectModel/ReadOnlyCollectionExtensionsTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Pearls/LINQ/ExpressionJit/Tests.Nuqleon.Linq.Expressions.Jit/System/InvariantTests.cs
+++ b/Nuqleon/Pearls/LINQ/ExpressionJit/Tests.Nuqleon.Linq.Expressions.Jit/System/InvariantTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Pearls/LINQ/ExpressionJit/Tests.Nuqleon.Linq.Expressions.Jit/System/Linq/Expressions/BetterExpressionVisitorTests.cs
+++ b/Nuqleon/Pearls/LINQ/ExpressionJit/Tests.Nuqleon.Linq.Expressions.Jit/System/Linq/Expressions/BetterExpressionVisitorTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Pearls/LINQ/ExpressionJit/Tests.Nuqleon.Linq.Expressions.Jit/System/Linq/Expressions/Jit/AnalyzerTests.cs
+++ b/Nuqleon/Pearls/LINQ/ExpressionJit/Tests.Nuqleon.Linq.Expressions.Jit/System/Linq/Expressions/Jit/AnalyzerTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Pearls/LINQ/ExpressionJit/Tests.Nuqleon.Linq.Expressions.Jit/System/Linq/Expressions/Jit/ClosureGeneratorTests.cs
+++ b/Nuqleon/Pearls/LINQ/ExpressionJit/Tests.Nuqleon.Linq.Expressions.Jit/System/Linq/Expressions/Jit/ClosureGeneratorTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Pearls/LINQ/ExpressionJit/Tests.Nuqleon.Linq.Expressions.Jit/System/Linq/Expressions/Jit/ReducerTests.cs
+++ b/Nuqleon/Pearls/LINQ/ExpressionJit/Tests.Nuqleon.Linq.Expressions.Jit/System/Linq/Expressions/Jit/ReducerTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Pearls/LINQ/ExpressionJit/Tests.Nuqleon.Linq.Expressions.Jit/System/Linq/Expressions/OptimizerTests.cs
+++ b/Nuqleon/Pearls/LINQ/ExpressionJit/Tests.Nuqleon.Linq.Expressions.Jit/System/Linq/Expressions/OptimizerTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Pearls/LINQ/ExpressionJit/Tests.Nuqleon.Linq.Expressions.Jit/System/Linq/Expressions/UnboundVariableScannerTests.cs
+++ b/Nuqleon/Pearls/LINQ/ExpressionJit/Tests.Nuqleon.Linq.Expressions.Jit/System/Linq/Expressions/UnboundVariableScannerTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Pearls/LINQ/ExpressionJit/Tests.Nuqleon.Linq.Expressions.Jit/System/Runtime/CompilerServices/ClosureFactoryTests.cs
+++ b/Nuqleon/Pearls/LINQ/ExpressionJit/Tests.Nuqleon.Linq.Expressions.Jit/System/Runtime/CompilerServices/ClosureFactoryTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Pearls/LINQ/ExpressionJit/Tests.Nuqleon.Linq.Expressions.Jit/System/TypeUtilsTests.cs
+++ b/Nuqleon/Pearls/LINQ/ExpressionJit/Tests.Nuqleon.Linq.Expressions.Jit/System/TypeUtilsTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Pearls/LINQ/PartialExpressionEvaluator/Library/PartialExpressionEvaluatorBase.cs
+++ b/Nuqleon/Pearls/LINQ/PartialExpressionEvaluator/Library/PartialExpressionEvaluatorBase.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Pearls/LINQ/PartialExpressionEvaluator/Library/Properties/AssemblyInfo.cs
+++ b/Nuqleon/Pearls/LINQ/PartialExpressionEvaluator/Library/Properties/AssemblyInfo.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Pearls/LINQ/PartialExpressionEvaluator/PartialTreeEvaluator/Program.cs
+++ b/Nuqleon/Pearls/LINQ/PartialExpressionEvaluator/PartialTreeEvaluator/Program.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Nuqleon/Pearls/LINQ/PartialExpressionEvaluator/Test/Tests.cs
+++ b/Nuqleon/Pearls/LINQ/PartialExpressionEvaluator/Test/Tests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Reaqtive.Core/EventMetadata.Generated.cs
+++ b/Reaqtive/Core/Reaqtive.Core/EventMetadata.Generated.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Reaqtive.Core/Properties/AssemblyInfo.cs
+++ b/Reaqtive/Core/Reaqtive.Core/Properties/AssemblyInfo.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Reaqtive.Core/Reaqtive/Helpers/CollectionExtensions.cs
+++ b/Reaqtive/Core/Reaqtive.Core/Reaqtive/Helpers/CollectionExtensions.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Reaqtive.Core/Reaqtive/Helpers/Sentinels.cs
+++ b/Reaqtive/Core/Reaqtive.Core/Reaqtive/Helpers/Sentinels.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Reaqtive.Core/Reaqtive/ObservableExtensions.cs
+++ b/Reaqtive/Core/Reaqtive.Core/Reaqtive/ObservableExtensions.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Reaqtive.Core/Reaqtive/Observers/FaultObserver.cs
+++ b/Reaqtive/Core/Reaqtive.Core/Reaqtive/Observers/FaultObserver.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Reaqtive.Core/Reaqtive/Observers/ListObserver.cs
+++ b/Reaqtive/Core/Reaqtive.Core/Reaqtive/Observers/ListObserver.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Reaqtive.Core/Reaqtive/Observers/NopObserver.cs
+++ b/Reaqtive/Core/Reaqtive.Core/Reaqtive/Observers/NopObserver.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Reaqtive.Core/Reaqtive/Observers/Observer.cs
+++ b/Reaqtive/Core/Reaqtive.Core/Reaqtive/Observers/Observer.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Reaqtive.Core/Reaqtive/Observers/ObserverBase.cs
+++ b/Reaqtive/Core/Reaqtive.Core/Reaqtive/Observers/ObserverBase.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Reaqtive.Core/Reaqtive/Observers/SimpleObserver.cs
+++ b/Reaqtive/Core/Reaqtive.Core/Reaqtive/Observers/SimpleObserver.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Reaqtive.Core/Reaqtive/Observers/StatefulObserver.cs
+++ b/Reaqtive/Core/Reaqtive.Core/Reaqtive/Observers/StatefulObserver.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Reaqtive.Core/Reaqtive/Observers/VersionedObserver.cs
+++ b/Reaqtive/Core/Reaqtive.Core/Reaqtive/Observers/VersionedObserver.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Reaqtive.Core/Reaqtive/OperatorContext.cs
+++ b/Reaqtive/Core/Reaqtive.Core/Reaqtive/OperatorContext.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Reaqtive.Core/Reaqtive/Operators/ContextSwitchOperator.cs
+++ b/Reaqtive/Core/Reaqtive.Core/Reaqtive/Operators/ContextSwitchOperator.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Reaqtive.Core/Reaqtive/Operators/StatefulOperator.cs
+++ b/Reaqtive/Core/Reaqtive.Core/Reaqtive/Operators/StatefulOperator.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Reaqtive.Core/Reaqtive/Operators/StatefulUnaryOperator.cs
+++ b/Reaqtive/Core/Reaqtive.Core/Reaqtive/Operators/StatefulUnaryOperator.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Reaqtive.Core/Reaqtive/Operators/ToSubscribable.cs
+++ b/Reaqtive/Core/Reaqtive.Core/Reaqtive/Operators/ToSubscribable.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Reaqtive.Core/Reaqtive/Operators/UnaryOperator.cs
+++ b/Reaqtive/Core/Reaqtive.Core/Reaqtive/Operators/UnaryOperator.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Reaqtive.Core/Reaqtive/Operators/VersionedOperator.cs
+++ b/Reaqtive/Core/Reaqtive.Core/Reaqtive/Operators/VersionedOperator.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Reaqtive.Core/Reaqtive/Operators/VersionedUnaryOperator.cs
+++ b/Reaqtive/Core/Reaqtive.Core/Reaqtive/Operators/VersionedUnaryOperator.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Reaqtive.Core/Reaqtive/StateChangedManager.cs
+++ b/Reaqtive/Core/Reaqtive.Core/Reaqtive/StateChangedManager.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Reaqtive.Core/Reaqtive/StateManager.cs
+++ b/Reaqtive/Core/Reaqtive.Core/Reaqtive/StateManager.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Reaqtive.Core/Reaqtive/Subjects/MultiSubject.cs
+++ b/Reaqtive/Core/Reaqtive.Core/Reaqtive/Subjects/MultiSubject.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Reaqtive.Core/Reaqtive/Subjects/MultiSubjectBase.cs
+++ b/Reaqtive/Core/Reaqtive.Core/Reaqtive/Subjects/MultiSubjectBase.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Reaqtive.Core/Reaqtive/Subjects/SimpleSubject.cs
+++ b/Reaqtive/Core/Reaqtive.Core/Reaqtive/Subjects/SimpleSubject.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Reaqtive.Core/Reaqtive/Subjects/StatefulMultiSubjectBase.cs
+++ b/Reaqtive/Core/Reaqtive.Core/Reaqtive/Subjects/StatefulMultiSubjectBase.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Reaqtive.Core/Reaqtive/Subjects/ToTypedMultiSubject.cs
+++ b/Reaqtive/Core/Reaqtive.Core/Reaqtive/Subjects/ToTypedMultiSubject.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Reaqtive.Core/Reaqtive/Subjects/VersionedMultiSubjectBase.cs
+++ b/Reaqtive/Core/Reaqtive.Core/Reaqtive/Subjects/VersionedMultiSubjectBase.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Reaqtive.Core/Reaqtive/Subscribables/SubscribableBase.cs
+++ b/Reaqtive/Core/Reaqtive.Core/Reaqtive/Subscribables/SubscribableBase.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Reaqtive.Core/Reaqtive/Subscriptions/CompositeSubscription.cs
+++ b/Reaqtive/Core/Reaqtive.Core/Reaqtive/Subscriptions/CompositeSubscription.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Reaqtive.Core/Reaqtive/Subscriptions/NopSubscription.cs
+++ b/Reaqtive/Core/Reaqtive.Core/Reaqtive/Subscriptions/NopSubscription.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Reaqtive.Core/Reaqtive/Subscriptions/SerialSubscription.cs
+++ b/Reaqtive/Core/Reaqtive.Core/Reaqtive/Subscriptions/SerialSubscription.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Reaqtive.Core/Reaqtive/Subscriptions/SingleAssignmentSubscription.cs
+++ b/Reaqtive/Core/Reaqtive.Core/Reaqtive/Subscriptions/SingleAssignmentSubscription.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Reaqtive.Core/Reaqtive/Subscriptions/StableCompositeSubscription.cs
+++ b/Reaqtive/Core/Reaqtive.Core/Reaqtive/Subscriptions/StableCompositeSubscription.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Reaqtive.Core/Reaqtive/Subscriptions/StaticCompositeSubscription.cs
+++ b/Reaqtive/Core/Reaqtive.Core/Reaqtive/Subscriptions/StaticCompositeSubscription.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Reaqtive.Core/Reaqtive/Subscriptions/StaticCompositeSubscriptionBase.cs
+++ b/Reaqtive/Core/Reaqtive.Core/Reaqtive/Subscriptions/StaticCompositeSubscriptionBase.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Reaqtive.Core/Reaqtive/Subscriptions/SubscriptionInitializeVisitor.cs
+++ b/Reaqtive/Core/Reaqtive.Core/Reaqtive/Subscriptions/SubscriptionInitializeVisitor.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Reaqtive.Core/Reaqtive/Subscriptions/SubscriptionStateVisitor.cs
+++ b/Reaqtive/Core/Reaqtive.Core/Reaqtive/Subscriptions/SubscriptionStateVisitor.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Reaqtive.Core/Reaqtive/Subscriptions/SubscriptionVisitor.cs
+++ b/Reaqtive/Core/Reaqtive.Core/Reaqtive/Subscriptions/SubscriptionVisitor.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Reaqtive.Core/Reaqtive/Subscriptions/SubscriptionVisitorBuilder.cs
+++ b/Reaqtive/Core/Reaqtive.Core/Reaqtive/Subscriptions/SubscriptionVisitorBuilder.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Reaqtive.Core/Reaqtive/Tasks/ActionTask.Generic.cs
+++ b/Reaqtive/Core/Reaqtive.Core/Reaqtive/Tasks/ActionTask.Generic.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Reaqtive.Core/Reaqtive/Tasks/ActionTask.cs
+++ b/Reaqtive/Core/Reaqtive.Core/Reaqtive/Tasks/ActionTask.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Reaqtive.Core/Reaqtive/Tasks/IItemProcessor.cs
+++ b/Reaqtive/Core/Reaqtive.Core/Reaqtive/Tasks/IItemProcessor.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Reaqtive.Core/Reaqtive/Tasks/IYieldableItemProcessor.cs
+++ b/Reaqtive/Core/Reaqtive.Core/Reaqtive/Tasks/IYieldableItemProcessor.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Reaqtive.Core/Reaqtive/Tasks/ItemProcessingTask.cs
+++ b/Reaqtive/Core/Reaqtive.Core/Reaqtive/Tasks/ItemProcessingTask.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Reaqtive.Core/Reaqtive/Tasks/YieldableActionTask.Generic.cs
+++ b/Reaqtive/Core/Reaqtive.Core/Reaqtive/Tasks/YieldableActionTask.Generic.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Reaqtive.Core/Reaqtive/Tasks/YieldableActionTask.cs
+++ b/Reaqtive/Core/Reaqtive.Core/Reaqtive/Tasks/YieldableActionTask.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Reaqtive.Core/Reaqtive/Tasks/YieldableItemProcessingTask.cs
+++ b/Reaqtive/Core/Reaqtive.Core/Reaqtive/Tasks/YieldableItemProcessingTask.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Reaqtive.Core/Versioning.cs
+++ b/Reaqtive/Core/Reaqtive.Core/Versioning.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Reaqtive.Interfaces/Properties/AssemblyInfo.cs
+++ b/Reaqtive/Core/Reaqtive.Interfaces/Properties/AssemblyInfo.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Reaqtive.Interfaces/Reaqtive/Expressions/IGroupedQubscribable.cs
+++ b/Reaqtive/Core/Reaqtive.Interfaces/Reaqtive/Expressions/IGroupedQubscribable.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Reaqtive.Interfaces/Reaqtive/Expressions/IMultiQubject.cs
+++ b/Reaqtive/Core/Reaqtive.Interfaces/Reaqtive/Expressions/IMultiQubject.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Reaqtive.Interfaces/Reaqtive/Expressions/IQubscribable.cs
+++ b/Reaqtive/Core/Reaqtive.Interfaces/Reaqtive/Expressions/IQubscribable.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Reaqtive.Interfaces/Reaqtive/IExecutionEnvironment.cs
+++ b/Reaqtive/Core/Reaqtive.Interfaces/Reaqtive/IExecutionEnvironment.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Reaqtive.Interfaces/Reaqtive/IHigherOrderExecutionEnvironment.cs
+++ b/Reaqtive/Core/Reaqtive.Interfaces/Reaqtive/IHigherOrderExecutionEnvironment.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Reaqtive.Interfaces/Reaqtive/IMonitorableQueue.cs
+++ b/Reaqtive/Core/Reaqtive.Interfaces/Reaqtive/IMonitorableQueue.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Reaqtive.Interfaces/Reaqtive/IOperatorContext.cs
+++ b/Reaqtive/Core/Reaqtive.Interfaces/Reaqtive/IOperatorContext.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Reaqtive.Interfaces/Reaqtive/ISealable.cs
+++ b/Reaqtive/Core/Reaqtive.Interfaces/Reaqtive/ISealable.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Reaqtive.Interfaces/Reaqtive/IVersioned.cs
+++ b/Reaqtive/Core/Reaqtive.Interfaces/Reaqtive/IVersioned.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Reaqtive.Interfaces/Reaqtive/Operators/IDependencyOperator.cs
+++ b/Reaqtive/Core/Reaqtive.Interfaces/Reaqtive/Operators/IDependencyOperator.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Reaqtive.Interfaces/Reaqtive/Operators/IOperator.cs
+++ b/Reaqtive/Core/Reaqtive.Interfaces/Reaqtive/Operators/IOperator.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Reaqtive.Interfaces/Reaqtive/Operators/IStatefulOperator.cs
+++ b/Reaqtive/Core/Reaqtive.Interfaces/Reaqtive/Operators/IStatefulOperator.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Reaqtive.Interfaces/Reaqtive/Operators/ITransitioningOperator.cs
+++ b/Reaqtive/Core/Reaqtive.Interfaces/Reaqtive/Operators/ITransitioningOperator.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Reaqtive.Interfaces/Reaqtive/Operators/IUnaryOperator.cs
+++ b/Reaqtive/Core/Reaqtive.Interfaces/Reaqtive/Operators/IUnaryOperator.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Reaqtive.Interfaces/Reaqtive/Operators/IUnloadableOperator.cs
+++ b/Reaqtive/Core/Reaqtive.Interfaces/Reaqtive/Operators/IUnloadableOperator.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Reaqtive.Interfaces/Reaqtive/Operators/Persistence/IOperatorStateReader.cs
+++ b/Reaqtive/Core/Reaqtive.Interfaces/Reaqtive/Operators/Persistence/IOperatorStateReader.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Reaqtive.Interfaces/Reaqtive/Operators/Persistence/IOperatorStateReaderFactory.cs
+++ b/Reaqtive/Core/Reaqtive.Interfaces/Reaqtive/Operators/Persistence/IOperatorStateReaderFactory.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Reaqtive.Interfaces/Reaqtive/Operators/Persistence/IOperatorStateWriter.cs
+++ b/Reaqtive/Core/Reaqtive.Interfaces/Reaqtive/Operators/Persistence/IOperatorStateWriter.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Reaqtive.Interfaces/Reaqtive/Operators/Persistence/IOperatorStateWriterFactory.cs
+++ b/Reaqtive/Core/Reaqtive.Interfaces/Reaqtive/Operators/Persistence/IOperatorStateWriterFactory.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Reaqtive.Interfaces/Reaqtive/Scheduler/IScheduler.cs
+++ b/Reaqtive/Core/Reaqtive.Interfaces/Reaqtive/Scheduler/IScheduler.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Reaqtive.Interfaces/Reaqtive/Scheduler/ISchedulerTask.cs
+++ b/Reaqtive/Core/Reaqtive.Interfaces/Reaqtive/Scheduler/ISchedulerTask.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Reaqtive.Interfaces/Reaqtive/Scheduler/IYieldTokenSource.cs
+++ b/Reaqtive/Core/Reaqtive.Interfaces/Reaqtive/Scheduler/IYieldTokenSource.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Reaqtive.Interfaces/Reaqtive/Scheduler/IYieldableSchedulerTask.cs
+++ b/Reaqtive/Core/Reaqtive.Interfaces/Reaqtive/Scheduler/IYieldableSchedulerTask.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Reaqtive.Interfaces/Reaqtive/Scheduler/SchedulerUnhandledExceptionEventArgs.cs
+++ b/Reaqtive/Core/Reaqtive.Interfaces/Reaqtive/Scheduler/SchedulerUnhandledExceptionEventArgs.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Reaqtive.Interfaces/Reaqtive/Scheduler/YieldToken.cs
+++ b/Reaqtive/Core/Reaqtive.Interfaces/Reaqtive/Scheduler/YieldToken.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Reaqtive.Interfaces/Reaqtive/Subjects/IGroupedMultiSubject.cs
+++ b/Reaqtive/Core/Reaqtive.Interfaces/Reaqtive/Subjects/IGroupedMultiSubject.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Reaqtive.Interfaces/Reaqtive/Subjects/IMultiSubject.cs
+++ b/Reaqtive/Core/Reaqtive.Interfaces/Reaqtive/Subjects/IMultiSubject.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Reaqtive.Interfaces/Reaqtive/Subscribables/IGroupedSubscribable.cs
+++ b/Reaqtive/Core/Reaqtive.Interfaces/Reaqtive/Subscribables/IGroupedSubscribable.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Reaqtive.Interfaces/Reaqtive/Subscribables/ISubscribable.cs
+++ b/Reaqtive/Core/Reaqtive.Interfaces/Reaqtive/Subscribables/ISubscribable.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Reaqtive.Interfaces/Reaqtive/Subscriptions/ICompositeSubscription.cs
+++ b/Reaqtive/Core/Reaqtive.Interfaces/Reaqtive/Subscriptions/ICompositeSubscription.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Reaqtive.Interfaces/Reaqtive/Subscriptions/IFutureSubscription.cs
+++ b/Reaqtive/Core/Reaqtive.Interfaces/Reaqtive/Subscriptions/IFutureSubscription.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Reaqtive.Interfaces/Reaqtive/Subscriptions/ISubscription.cs
+++ b/Reaqtive/Core/Reaqtive.Interfaces/Reaqtive/Subscriptions/ISubscription.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Reaqtive.Interfaces/Reaqtive/Subscriptions/ISubscriptionVisitor.cs
+++ b/Reaqtive/Core/Reaqtive.Interfaces/Reaqtive/Subscriptions/ISubscriptionVisitor.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Reaqtive.Linq/EventMetadata.Generated.cs
+++ b/Reaqtive/Core/Reaqtive.Linq/EventMetadata.Generated.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Reaqtive.Linq/GlobalSuppressions.cs
+++ b/Reaqtive/Core/Reaqtive.Linq/GlobalSuppressions.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Reaqtive.Linq/Properties/AssemblyInfo.cs
+++ b/Reaqtive/Core/Reaqtive.Linq/Properties/AssemblyInfo.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Reaqtive.Linq/Reaqtive/Correlation.cs
+++ b/Reaqtive/Core/Reaqtive.Linq/Reaqtive/Correlation.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Reaqtive.Linq/Reaqtive/HigherOrder/HigherOrderInputStatefulOperator.cs
+++ b/Reaqtive/Core/Reaqtive.Linq/Reaqtive/HigherOrder/HigherOrderInputStatefulOperator.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Reaqtive.Linq/Reaqtive/HigherOrder/HigherOrderOutputStatefulOperator.cs
+++ b/Reaqtive/Core/Reaqtive.Linq/Reaqtive/HigherOrder/HigherOrderOutputStatefulOperator.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Reaqtive.Linq/Reaqtive/IOperatorContextExtensions.cs
+++ b/Reaqtive/Core/Reaqtive.Linq/Reaqtive/IOperatorContextExtensions.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Reaqtive.Linq/Reaqtive/Operators/Aggregate.cs
+++ b/Reaqtive/Core/Reaqtive.Linq/Reaqtive/Operators/Aggregate.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Reaqtive.Linq/Reaqtive/Operators/All.cs
+++ b/Reaqtive/Core/Reaqtive.Linq/Reaqtive/Operators/All.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Reaqtive.Linq/Reaqtive/Operators/Any.cs
+++ b/Reaqtive/Core/Reaqtive.Linq/Reaqtive/Operators/Any.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Reaqtive.Linq/Reaqtive/Operators/Average.Generated.cs
+++ b/Reaqtive/Core/Reaqtive.Linq/Reaqtive/Operators/Average.Generated.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Reaqtive.Linq/Reaqtive/Operators/Buffer.cs
+++ b/Reaqtive/Core/Reaqtive.Linq/Reaqtive/Operators/Buffer.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Reaqtive.Linq/Reaqtive/Operators/CombineLatest.Generated.cs
+++ b/Reaqtive/Core/Reaqtive.Linq/Reaqtive/Operators/CombineLatest.Generated.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Reaqtive.Linq/Reaqtive/Operators/Count.cs
+++ b/Reaqtive/Core/Reaqtive.Linq/Reaqtive/Operators/Count.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Reaqtive.Linq/Reaqtive/Operators/DelaySubscription.cs
+++ b/Reaqtive/Core/Reaqtive.Linq/Reaqtive/Operators/DelaySubscription.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Reaqtive.Linq/Reaqtive/Operators/DistinctUntilChanged.cs
+++ b/Reaqtive/Core/Reaqtive.Linq/Reaqtive/Operators/DistinctUntilChanged.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Reaqtive.Linq/Reaqtive/Operators/Do.cs
+++ b/Reaqtive/Core/Reaqtive.Linq/Reaqtive/Operators/Do.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Reaqtive.Linq/Reaqtive/Operators/Empty.cs
+++ b/Reaqtive/Core/Reaqtive.Linq/Reaqtive/Operators/Empty.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Reaqtive.Linq/Reaqtive/Operators/Finally.cs
+++ b/Reaqtive/Core/Reaqtive.Linq/Reaqtive/Operators/Finally.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Reaqtive.Linq/Reaqtive/Operators/FirstAsync.cs
+++ b/Reaqtive/Core/Reaqtive.Linq/Reaqtive/Operators/FirstAsync.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Reaqtive.Linq/Reaqtive/Operators/GroupBy.cs
+++ b/Reaqtive/Core/Reaqtive.Linq/Reaqtive/Operators/GroupBy.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Reaqtive.Linq/Reaqtive/Operators/LongCount.cs
+++ b/Reaqtive/Core/Reaqtive.Linq/Reaqtive/Operators/LongCount.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Reaqtive.Linq/Reaqtive/Operators/Max.cs
+++ b/Reaqtive/Core/Reaqtive.Linq/Reaqtive/Operators/Max.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Reaqtive.Linq/Reaqtive/Operators/Merge.cs
+++ b/Reaqtive/Core/Reaqtive.Linq/Reaqtive/Operators/Merge.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Reaqtive.Linq/Reaqtive/Operators/Min.cs
+++ b/Reaqtive/Core/Reaqtive.Linq/Reaqtive/Operators/Min.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Reaqtive.Linq/Reaqtive/Operators/MinMax.Generated.cs
+++ b/Reaqtive/Core/Reaqtive.Linq/Reaqtive/Operators/MinMax.Generated.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Reaqtive.Linq/Reaqtive/Operators/Never.cs
+++ b/Reaqtive/Core/Reaqtive.Linq/Reaqtive/Operators/Never.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Reaqtive.Linq/Reaqtive/Operators/Retry.cs
+++ b/Reaqtive/Core/Reaqtive.Linq/Reaqtive/Operators/Retry.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Reaqtive.Linq/Reaqtive/Operators/Return.cs
+++ b/Reaqtive/Core/Reaqtive.Linq/Reaqtive/Operators/Return.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Reaqtive.Linq/Reaqtive/Operators/Sample.cs
+++ b/Reaqtive/Core/Reaqtive.Linq/Reaqtive/Operators/Sample.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Reaqtive.Linq/Reaqtive/Operators/Scan.cs
+++ b/Reaqtive/Core/Reaqtive.Linq/Reaqtive/Operators/Scan.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Reaqtive.Linq/Reaqtive/Operators/Select.cs
+++ b/Reaqtive/Core/Reaqtive.Linq/Reaqtive/Operators/Select.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Reaqtive.Linq/Reaqtive/Operators/SequenceEqual.cs
+++ b/Reaqtive/Core/Reaqtive.Linq/Reaqtive/Operators/SequenceEqual.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Reaqtive.Linq/Reaqtive/Operators/Skip.cs
+++ b/Reaqtive/Core/Reaqtive.Linq/Reaqtive/Operators/Skip.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Reaqtive.Linq/Reaqtive/Operators/SkipUntil.cs
+++ b/Reaqtive/Core/Reaqtive.Linq/Reaqtive/Operators/SkipUntil.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Reaqtive.Linq/Reaqtive/Operators/SkipWhile.cs
+++ b/Reaqtive/Core/Reaqtive.Linq/Reaqtive/Operators/SkipWhile.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Reaqtive.Linq/Reaqtive/Operators/StartWith.cs
+++ b/Reaqtive/Core/Reaqtive.Linq/Reaqtive/Operators/StartWith.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Reaqtive.Linq/Reaqtive/Operators/Sum.Generated.cs
+++ b/Reaqtive/Core/Reaqtive.Linq/Reaqtive/Operators/Sum.Generated.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Reaqtive.Linq/Reaqtive/Operators/Switch.cs
+++ b/Reaqtive/Core/Reaqtive.Linq/Reaqtive/Operators/Switch.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Reaqtive.Linq/Reaqtive/Operators/Take.cs
+++ b/Reaqtive/Core/Reaqtive.Linq/Reaqtive/Operators/Take.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Reaqtive.Linq/Reaqtive/Operators/TakeUntil.cs
+++ b/Reaqtive/Core/Reaqtive.Linq/Reaqtive/Operators/TakeUntil.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Reaqtive.Linq/Reaqtive/Operators/TakeWhile.cs
+++ b/Reaqtive/Core/Reaqtive.Linq/Reaqtive/Operators/TakeWhile.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Reaqtive.Linq/Reaqtive/Operators/Throttle.cs
+++ b/Reaqtive/Core/Reaqtive.Linq/Reaqtive/Operators/Throttle.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Reaqtive.Linq/Reaqtive/Operators/Throw.cs
+++ b/Reaqtive/Core/Reaqtive.Linq/Reaqtive/Operators/Throw.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Reaqtive.Linq/Reaqtive/Operators/Timer.cs
+++ b/Reaqtive/Core/Reaqtive.Linq/Reaqtive/Operators/Timer.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Reaqtive.Linq/Reaqtive/Operators/ToList.cs
+++ b/Reaqtive/Core/Reaqtive.Linq/Reaqtive/Operators/ToList.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Reaqtive.Linq/Reaqtive/Operators/Where.cs
+++ b/Reaqtive/Core/Reaqtive.Linq/Reaqtive/Operators/Where.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Reaqtive.Linq/Reaqtive/Operators/Window.cs
+++ b/Reaqtive/Core/Reaqtive.Linq/Reaqtive/Operators/Window.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Reaqtive.Linq/Reaqtive/Subjects/GroupedMultiSubject.cs
+++ b/Reaqtive/Core/Reaqtive.Linq/Reaqtive/Subjects/GroupedMultiSubject.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Reaqtive.Linq/Reaqtive/Subscribable.Generated.cs
+++ b/Reaqtive/Core/Reaqtive.Linq/Reaqtive/Subscribable.Generated.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Reaqtive.Linq/Reaqtive/TinyObserver.cs
+++ b/Reaqtive/Core/Reaqtive.Linq/Reaqtive/TinyObserver.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Reaqtive.Linq/Versioning.cs
+++ b/Reaqtive/Core/Reaqtive.Linq/Versioning.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Reaqtive.Quotation/Properties/AssemblyInfo.cs
+++ b/Reaqtive/Core/Reaqtive.Quotation/Properties/AssemblyInfo.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Reaqtive.Quotation/Reaqtive/Expressions/DefaultExpressionPolicy.cs
+++ b/Reaqtive/Core/Reaqtive.Quotation/Reaqtive/Expressions/DefaultExpressionPolicy.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Reaqtive.Quotation/Reaqtive/Expressions/ExpressionEvaluationPolicyExtensions.cs
+++ b/Reaqtive/Core/Reaqtive.Quotation/Reaqtive/Expressions/ExpressionEvaluationPolicyExtensions.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Reaqtive.Quotation/Reaqtive/Expressions/IExpressionEvaluationPolicy.cs
+++ b/Reaqtive/Core/Reaqtive.Quotation/Reaqtive/Expressions/IExpressionEvaluationPolicy.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Reaqtive.Quotation/Reaqtive/Expressions/IExpressionPolicy.cs
+++ b/Reaqtive/Core/Reaqtive.Quotation/Reaqtive/Expressions/IExpressionPolicy.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Reaqtive.Quotation/Reaqtive/Expressions/IExpressionSerializationPolicy.cs
+++ b/Reaqtive/Core/Reaqtive.Quotation/Reaqtive/Expressions/IExpressionSerializationPolicy.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Reaqtive.Scheduler/EventMetadata.Generated.cs
+++ b/Reaqtive/Core/Reaqtive.Scheduler/EventMetadata.Generated.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Reaqtive.Scheduler/GlobalSuppressions.cs
+++ b/Reaqtive/Core/Reaqtive.Scheduler/GlobalSuppressions.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Reaqtive.Scheduler/Properties/AssemblyInfo.cs
+++ b/Reaqtive/Core/Reaqtive.Scheduler/Properties/AssemblyInfo.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Reaqtive.Scheduler/Reaqtive/Scheduler/Accountant.cs
+++ b/Reaqtive/Core/Reaqtive.Scheduler/Reaqtive/Scheduler/Accountant.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Reaqtive.Scheduler/Reaqtive/Scheduler/Accounting.cs
+++ b/Reaqtive/Core/Reaqtive.Scheduler/Reaqtive/Scheduler/Accounting.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Reaqtive.Scheduler/Reaqtive/Scheduler/HashHelpers.cs
+++ b/Reaqtive/Core/Reaqtive.Scheduler/Reaqtive/Scheduler/HashHelpers.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Reaqtive.Scheduler/Reaqtive/Scheduler/HeapBasedPriorityQueue.cs
+++ b/Reaqtive/Core/Reaqtive.Scheduler/Reaqtive/Scheduler/HeapBasedPriorityQueue.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Reaqtive.Scheduler/Reaqtive/Scheduler/IAccountable.cs
+++ b/Reaqtive/Core/Reaqtive.Scheduler/Reaqtive/Scheduler/IAccountable.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Reaqtive.Scheduler/Reaqtive/Scheduler/ISchedulerExceptionHandler.cs
+++ b/Reaqtive/Core/Reaqtive.Scheduler/Reaqtive/Scheduler/ISchedulerExceptionHandler.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Reaqtive.Scheduler/Reaqtive/Scheduler/ISchedulerPerformanceCountersProvider.cs
+++ b/Reaqtive/Core/Reaqtive.Scheduler/Reaqtive/Scheduler/ISchedulerPerformanceCountersProvider.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Reaqtive.Scheduler/Reaqtive/Scheduler/ISchedulerStatus.cs
+++ b/Reaqtive/Core/Reaqtive.Scheduler/Reaqtive/Scheduler/ISchedulerStatus.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Reaqtive.Scheduler/Reaqtive/Scheduler/IWorkItem.cs
+++ b/Reaqtive/Core/Reaqtive.Scheduler/Reaqtive/Scheduler/IWorkItem.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Reaqtive.Scheduler/Reaqtive/Scheduler/LogicalScheduler.cs
+++ b/Reaqtive/Core/Reaqtive.Scheduler/Reaqtive/Scheduler/LogicalScheduler.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Reaqtive.Scheduler/Reaqtive/Scheduler/MonitorAutoResetEvent.cs
+++ b/Reaqtive/Core/Reaqtive.Scheduler/Reaqtive/Scheduler/MonitorAutoResetEvent.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Reaqtive.Scheduler/Reaqtive/Scheduler/NativeMethods.cs
+++ b/Reaqtive/Core/Reaqtive.Scheduler/Reaqtive/Scheduler/NativeMethods.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Reaqtive.Scheduler/Reaqtive/Scheduler/PerformanceCounters.cs
+++ b/Reaqtive/Core/Reaqtive.Scheduler/Reaqtive/Scheduler/PerformanceCounters.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Reaqtive.Scheduler/Reaqtive/Scheduler/SchedulerStatus.cs
+++ b/Reaqtive/Core/Reaqtive.Scheduler/Reaqtive/Scheduler/SchedulerStatus.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Reaqtive.Scheduler/Reaqtive/Scheduler/SnapshotCollection.cs
+++ b/Reaqtive/Core/Reaqtive.Scheduler/Reaqtive/Scheduler/SnapshotCollection.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Reaqtive.Scheduler/Reaqtive/Scheduler/TimingHelpers.cs
+++ b/Reaqtive/Core/Reaqtive.Scheduler/Reaqtive/Scheduler/TimingHelpers.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Reaqtive.Scheduler/Reaqtive/Scheduler/WorkItem.cs
+++ b/Reaqtive/Core/Reaqtive.Scheduler/Reaqtive/Scheduler/WorkItem.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Reaqtive.Scheduler/Reaqtive/Scheduler/WorkItemBase.cs
+++ b/Reaqtive/Core/Reaqtive.Scheduler/Reaqtive/Scheduler/WorkItemBase.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Reaqtive.Scheduler/System/Disposable.cs
+++ b/Reaqtive/Core/Reaqtive.Scheduler/System/Disposable.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Reaqtive.Testing/AnonymousDisposable.cs
+++ b/Reaqtive/Core/Reaqtive.Testing/AnonymousDisposable.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Reaqtive.Testing/AnonymousObserver.cs
+++ b/Reaqtive/Core/Reaqtive.Testing/AnonymousObserver.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Reaqtive.Testing/DefaultDisposable.cs
+++ b/Reaqtive/Core/Reaqtive.Testing/DefaultDisposable.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Reaqtive.Testing/Disposable.cs
+++ b/Reaqtive/Core/Reaqtive.Testing/Disposable.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Reaqtive.Testing/ICancelable.cs
+++ b/Reaqtive/Core/Reaqtive.Testing/ICancelable.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Reaqtive.Testing/ITestObservable.cs
+++ b/Reaqtive/Core/Reaqtive.Testing/ITestObservable.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Reaqtive.Testing/ITestObserver.cs
+++ b/Reaqtive/Core/Reaqtive.Testing/ITestObserver.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Reaqtive.Testing/Notification.cs
+++ b/Reaqtive/Core/Reaqtive.Testing/Notification.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Reaqtive.Testing/Observable.cs
+++ b/Reaqtive/Core/Reaqtive.Testing/Observable.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Reaqtive.Testing/ObservableExtensions.cs
+++ b/Reaqtive/Core/Reaqtive.Testing/ObservableExtensions.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Reaqtive.Testing/ReactiveAssert.cs
+++ b/Reaqtive/Core/Reaqtive.Testing/ReactiveAssert.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Reaqtive.Testing/ReactiveTest.cs
+++ b/Reaqtive/Core/Reaqtive.Testing/ReactiveTest.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Reaqtive.Testing/Recorded.cs
+++ b/Reaqtive/Core/Reaqtive.Testing/Recorded.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Reaqtive.Testing/Subject.cs
+++ b/Reaqtive/Core/Reaqtive.Testing/Subject.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Reaqtive.Testing/Subscription.cs
+++ b/Reaqtive/Core/Reaqtive.Testing/Subscription.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Reaqtive.TestingFramework/IOperatorStateContainer.cs
+++ b/Reaqtive/Core/Reaqtive.TestingFramework/IOperatorStateContainer.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Reaqtive.TestingFramework/Mocks/MockObserver.cs
+++ b/Reaqtive/Core/Reaqtive.TestingFramework/Mocks/MockObserver.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Reaqtive.TestingFramework/Mocks/MockOperatorContext.cs
+++ b/Reaqtive/Core/Reaqtive.TestingFramework/Mocks/MockOperatorContext.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Reaqtive.TestingFramework/Mocks/MockOperatorStateContainer.cs
+++ b/Reaqtive/Core/Reaqtive.TestingFramework/Mocks/MockOperatorStateContainer.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Reaqtive.TestingFramework/Mocks/MockSubscription.cs
+++ b/Reaqtive/Core/Reaqtive.TestingFramework/Mocks/MockSubscription.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Reaqtive.TestingFramework/Mocks/Subscribable/ApplySubscribable.cs
+++ b/Reaqtive/Core/Reaqtive.TestingFramework/Mocks/Subscribable/ApplySubscribable.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Reaqtive.TestingFramework/Mocks/Subscribable/ColdSubscribable.cs
+++ b/Reaqtive/Core/Reaqtive.TestingFramework/Mocks/Subscribable/ColdSubscribable.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Reaqtive.TestingFramework/Mocks/Subscribable/HotSubscribable.cs
+++ b/Reaqtive/Core/Reaqtive.TestingFramework/Mocks/Subscribable/HotSubscribable.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Reaqtive.TestingFramework/Mocks/Subscribable/ITestableSubscribable.cs
+++ b/Reaqtive/Core/Reaqtive.TestingFramework/Mocks/Subscribable/ITestableSubscribable.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Reaqtive.TestingFramework/Mocks/Subscribable/MockSubscribable.cs
+++ b/Reaqtive/Core/Reaqtive.TestingFramework/Mocks/Subscribable/MockSubscribable.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Reaqtive.TestingFramework/Properties/AssemblyInfo.cs
+++ b/Reaqtive/Core/Reaqtive.TestingFramework/Properties/AssemblyInfo.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Reaqtive.TestingFramework/Schedulers/IClockable.cs
+++ b/Reaqtive/Core/Reaqtive.TestingFramework/Schedulers/IClockable.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Reaqtive.TestingFramework/Schedulers/ILoggingScheduler.cs
+++ b/Reaqtive/Core/Reaqtive.TestingFramework/Schedulers/ILoggingScheduler.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Reaqtive.TestingFramework/Schedulers/ITestScheduler.cs
+++ b/Reaqtive/Core/Reaqtive.TestingFramework/Schedulers/ITestScheduler.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Reaqtive.TestingFramework/Schedulers/LoggingPhysicalTestScheduler.cs
+++ b/Reaqtive/Core/Reaqtive.TestingFramework/Schedulers/LoggingPhysicalTestScheduler.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Reaqtive.TestingFramework/Schedulers/LoggingTestScheduler.cs
+++ b/Reaqtive/Core/Reaqtive.TestingFramework/Schedulers/LoggingTestScheduler.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Reaqtive.TestingFramework/Schedulers/PhysicalTestScheduler.cs
+++ b/Reaqtive/Core/Reaqtive.TestingFramework/Schedulers/PhysicalTestScheduler.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Reaqtive.TestingFramework/Schedulers/TestScheduler.cs
+++ b/Reaqtive/Core/Reaqtive.TestingFramework/Schedulers/TestScheduler.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Reaqtive.TestingFramework/Schedulers/TestSchedulerExtensions.cs
+++ b/Reaqtive/Core/Reaqtive.TestingFramework/Schedulers/TestSchedulerExtensions.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Reaqtive.TestingFramework/Schedulers/VirtualTimeLogicalScheduler.cs
+++ b/Reaqtive/Core/Reaqtive.TestingFramework/Schedulers/VirtualTimeLogicalScheduler.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Reaqtive.TestingFramework/Schedulers/VirtualTimePhysicalScheduler.cs
+++ b/Reaqtive/Core/Reaqtive.TestingFramework/Schedulers/VirtualTimePhysicalScheduler.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Reaqtive.TestingFramework/Schedulers/VirtualTimePhysicalSchedulerBase.cs
+++ b/Reaqtive/Core/Reaqtive.TestingFramework/Schedulers/VirtualTimePhysicalSchedulerBase.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Reaqtive.TestingFramework/SubscriptionAction.cs
+++ b/Reaqtive/Core/Reaqtive.TestingFramework/SubscriptionAction.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Reaqtive.TestingFramework/TestBase.cs
+++ b/Reaqtive/Core/Reaqtive.TestingFramework/TestBase.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Reaqtive.TestingFramework/TestRunner/TestAssemblyRunner.cs
+++ b/Reaqtive/Core/Reaqtive.TestingFramework/TestRunner/TestAssemblyRunner.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Reaqtive.TestingFramework/TestRunner/TestClassRunner.cs
+++ b/Reaqtive/Core/Reaqtive.TestingFramework/TestRunner/TestClassRunner.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Reaqtive.TestingFramework/TestRunner/TestRunner.cs
+++ b/Reaqtive/Core/Reaqtive.TestingFramework/TestRunner/TestRunner.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Reaqtive.TestingFramework/TestRunner/TestRunnerExtensions.cs
+++ b/Reaqtive/Core/Reaqtive.TestingFramework/TestRunner/TestRunnerExtensions.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Reaqtive.TestingFramework/TestSubscribableExtensions.cs
+++ b/Reaqtive/Core/Reaqtive.TestingFramework/TestSubscribableExtensions.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Tests.Reaqtive.Core/Reaqtive/Observers/FaultObserverTests.cs
+++ b/Reaqtive/Core/Tests.Reaqtive.Core/Reaqtive/Observers/FaultObserverTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Tests.Reaqtive.Core/Reaqtive/Observers/ListObserverTests.cs
+++ b/Reaqtive/Core/Tests.Reaqtive.Core/Reaqtive/Observers/ListObserverTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Tests.Reaqtive.Core/Reaqtive/Observers/StatefulObserverTests.cs
+++ b/Reaqtive/Core/Tests.Reaqtive.Core/Reaqtive/Observers/StatefulObserverTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Tests.Reaqtive.Core/Reaqtive/Operators/ContextSwitchOperatorTests.cs
+++ b/Reaqtive/Core/Tests.Reaqtive.Core/Reaqtive/Operators/ContextSwitchOperatorTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Tests.Reaqtive.Core/Reaqtive/Operators/OperatorContextTests.cs
+++ b/Reaqtive/Core/Tests.Reaqtive.Core/Reaqtive/Operators/OperatorContextTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Tests.Reaqtive.Core/Reaqtive/Operators/StatefulOperatorTests.cs
+++ b/Reaqtive/Core/Tests.Reaqtive.Core/Reaqtive/Operators/StatefulOperatorTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Tests.Reaqtive.Core/Reaqtive/Operators/StatefulUnaryOperatorTests.cs
+++ b/Reaqtive/Core/Tests.Reaqtive.Core/Reaqtive/Operators/StatefulUnaryOperatorTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Tests.Reaqtive.Core/Reaqtive/Subjects/MultiSubjectBaseTests.cs
+++ b/Reaqtive/Core/Tests.Reaqtive.Core/Reaqtive/Subjects/MultiSubjectBaseTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Tests.Reaqtive.Core/Reaqtive/Subjects/SimpleSubjectTests.cs
+++ b/Reaqtive/Core/Tests.Reaqtive.Core/Reaqtive/Subjects/SimpleSubjectTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Tests.Reaqtive.Core/Reaqtive/Subscribables/SubscribableBaseTests.cs
+++ b/Reaqtive/Core/Tests.Reaqtive.Core/Reaqtive/Subscribables/SubscribableBaseTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Tests.Reaqtive.Core/Reaqtive/Subscriptions/CompositeSubscriptionTests.cs
+++ b/Reaqtive/Core/Tests.Reaqtive.Core/Reaqtive/Subscriptions/CompositeSubscriptionTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Tests.Reaqtive.Core/Reaqtive/Subscriptions/StableCompositeSubscriptionTests.cs
+++ b/Reaqtive/Core/Tests.Reaqtive.Core/Reaqtive/Subscriptions/StableCompositeSubscriptionTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Tests.Reaqtive.Core/Reaqtive/Subscriptions/StaticCompositeSubscriptionTests.cs
+++ b/Reaqtive/Core/Tests.Reaqtive.Core/Reaqtive/Subscriptions/StaticCompositeSubscriptionTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Tests.Reaqtive.Core/Reaqtive/Subscriptions/SubscriptionStateVisitorTests.cs
+++ b/Reaqtive/Core/Tests.Reaqtive.Core/Reaqtive/Subscriptions/SubscriptionStateVisitorTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Tests.Reaqtive.Core/Reaqtive/Subscriptions/SubscriptionVisitorTests.cs
+++ b/Reaqtive/Core/Tests.Reaqtive.Core/Reaqtive/Subscriptions/SubscriptionVisitorTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Tests.Reaqtive.Core/Reaqtive/Tasks/ActionTaskTests.cs
+++ b/Reaqtive/Core/Tests.Reaqtive.Core/Reaqtive/Tasks/ActionTaskTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Tests.Reaqtive.Core/Reaqtive/Tasks/ItemProcessingTaskTests.cs
+++ b/Reaqtive/Core/Tests.Reaqtive.Core/Reaqtive/Tasks/ItemProcessingTaskTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Tests.Reaqtive.Core/Reaqtive/Tasks/YieldableActionTaskTests.cs
+++ b/Reaqtive/Core/Tests.Reaqtive.Core/Reaqtive/Tasks/YieldableActionTaskTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Tests.Reaqtive.Linq/Dummies.cs
+++ b/Reaqtive/Core/Tests.Reaqtive.Linq/Dummies.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Tests.Reaqtive.Linq/Operators/Aggregate.Declarative.cs
+++ b/Reaqtive/Core/Tests.Reaqtive.Linq/Operators/Aggregate.Declarative.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Tests.Reaqtive.Linq/Operators/Aggregate.cs
+++ b/Reaqtive/Core/Tests.Reaqtive.Linq/Operators/Aggregate.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Tests.Reaqtive.Linq/Operators/All.Declarative.cs
+++ b/Reaqtive/Core/Tests.Reaqtive.Linq/Operators/All.Declarative.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Tests.Reaqtive.Linq/Operators/All.cs
+++ b/Reaqtive/Core/Tests.Reaqtive.Linq/Operators/All.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Tests.Reaqtive.Linq/Operators/Any.Declarative.cs
+++ b/Reaqtive/Core/Tests.Reaqtive.Linq/Operators/Any.Declarative.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Tests.Reaqtive.Linq/Operators/Any.cs
+++ b/Reaqtive/Core/Tests.Reaqtive.Linq/Operators/Any.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Tests.Reaqtive.Linq/Operators/Average.Declarative.Generated.cs
+++ b/Reaqtive/Core/Tests.Reaqtive.Linq/Operators/Average.Declarative.Generated.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Tests.Reaqtive.Linq/Operators/Average.Declarative.cs
+++ b/Reaqtive/Core/Tests.Reaqtive.Linq/Operators/Average.Declarative.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Tests.Reaqtive.Linq/Operators/Average.Generated.cs
+++ b/Reaqtive/Core/Tests.Reaqtive.Linq/Operators/Average.Generated.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Tests.Reaqtive.Linq/Operators/Average.cs
+++ b/Reaqtive/Core/Tests.Reaqtive.Linq/Operators/Average.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Tests.Reaqtive.Linq/Operators/Buffer.Declarative.cs
+++ b/Reaqtive/Core/Tests.Reaqtive.Linq/Operators/Buffer.Declarative.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Tests.Reaqtive.Linq/Operators/Buffer.cs
+++ b/Reaqtive/Core/Tests.Reaqtive.Linq/Operators/Buffer.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Tests.Reaqtive.Linq/Operators/CombineLatest.Generated.cs
+++ b/Reaqtive/Core/Tests.Reaqtive.Linq/Operators/CombineLatest.Generated.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Tests.Reaqtive.Linq/Operators/CombineLatest.cs
+++ b/Reaqtive/Core/Tests.Reaqtive.Linq/Operators/CombineLatest.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Tests.Reaqtive.Linq/Operators/Count.Declarative.cs
+++ b/Reaqtive/Core/Tests.Reaqtive.Linq/Operators/Count.Declarative.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Tests.Reaqtive.Linq/Operators/Count.cs
+++ b/Reaqtive/Core/Tests.Reaqtive.Linq/Operators/Count.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Tests.Reaqtive.Linq/Operators/DeclarativeExtensions.cs
+++ b/Reaqtive/Core/Tests.Reaqtive.Linq/Operators/DeclarativeExtensions.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Tests.Reaqtive.Linq/Operators/DelaySubscription.Declarative.cs
+++ b/Reaqtive/Core/Tests.Reaqtive.Linq/Operators/DelaySubscription.Declarative.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Tests.Reaqtive.Linq/Operators/DelaySubscription.cs
+++ b/Reaqtive/Core/Tests.Reaqtive.Linq/Operators/DelaySubscription.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Tests.Reaqtive.Linq/Operators/DistinctUntilChanged.Declarative.cs
+++ b/Reaqtive/Core/Tests.Reaqtive.Linq/Operators/DistinctUntilChanged.Declarative.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Tests.Reaqtive.Linq/Operators/DistinctUntilChanged.cs
+++ b/Reaqtive/Core/Tests.Reaqtive.Linq/Operators/DistinctUntilChanged.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Tests.Reaqtive.Linq/Operators/Do.cs
+++ b/Reaqtive/Core/Tests.Reaqtive.Linq/Operators/Do.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Tests.Reaqtive.Linq/Operators/Empty.Declarative.cs
+++ b/Reaqtive/Core/Tests.Reaqtive.Linq/Operators/Empty.Declarative.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Tests.Reaqtive.Linq/Operators/Empty.cs
+++ b/Reaqtive/Core/Tests.Reaqtive.Linq/Operators/Empty.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Tests.Reaqtive.Linq/Operators/Finally.cs
+++ b/Reaqtive/Core/Tests.Reaqtive.Linq/Operators/Finally.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Tests.Reaqtive.Linq/Operators/FirstAsync.Declarative.cs
+++ b/Reaqtive/Core/Tests.Reaqtive.Linq/Operators/FirstAsync.Declarative.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Tests.Reaqtive.Linq/Operators/FirstAsync.cs
+++ b/Reaqtive/Core/Tests.Reaqtive.Linq/Operators/FirstAsync.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Tests.Reaqtive.Linq/Operators/GroupBy.Declarative.cs
+++ b/Reaqtive/Core/Tests.Reaqtive.Linq/Operators/GroupBy.Declarative.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Tests.Reaqtive.Linq/Operators/GroupBy.cs
+++ b/Reaqtive/Core/Tests.Reaqtive.Linq/Operators/GroupBy.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Tests.Reaqtive.Linq/Operators/IsEmpty.Declarative.cs
+++ b/Reaqtive/Core/Tests.Reaqtive.Linq/Operators/IsEmpty.Declarative.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Tests.Reaqtive.Linq/Operators/IsEmpty.cs
+++ b/Reaqtive/Core/Tests.Reaqtive.Linq/Operators/IsEmpty.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Tests.Reaqtive.Linq/Operators/LongCount.Declarative.cs
+++ b/Reaqtive/Core/Tests.Reaqtive.Linq/Operators/LongCount.Declarative.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Tests.Reaqtive.Linq/Operators/LongCount.cs
+++ b/Reaqtive/Core/Tests.Reaqtive.Linq/Operators/LongCount.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Tests.Reaqtive.Linq/Operators/Max.Declarative.cs
+++ b/Reaqtive/Core/Tests.Reaqtive.Linq/Operators/Max.Declarative.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Tests.Reaqtive.Linq/Operators/Max.Generated.cs
+++ b/Reaqtive/Core/Tests.Reaqtive.Linq/Operators/Max.Generated.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Tests.Reaqtive.Linq/Operators/Max.cs
+++ b/Reaqtive/Core/Tests.Reaqtive.Linq/Operators/Max.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Tests.Reaqtive.Linq/Operators/Merge.Declarative.cs
+++ b/Reaqtive/Core/Tests.Reaqtive.Linq/Operators/Merge.Declarative.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Tests.Reaqtive.Linq/Operators/Merge.cs
+++ b/Reaqtive/Core/Tests.Reaqtive.Linq/Operators/Merge.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Tests.Reaqtive.Linq/Operators/Min.Declarative.cs
+++ b/Reaqtive/Core/Tests.Reaqtive.Linq/Operators/Min.Declarative.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Tests.Reaqtive.Linq/Operators/Min.Generated.cs
+++ b/Reaqtive/Core/Tests.Reaqtive.Linq/Operators/Min.Generated.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Tests.Reaqtive.Linq/Operators/Min.cs
+++ b/Reaqtive/Core/Tests.Reaqtive.Linq/Operators/Min.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Tests.Reaqtive.Linq/Operators/MinMax.Declarative.Generated.cs
+++ b/Reaqtive/Core/Tests.Reaqtive.Linq/Operators/MinMax.Declarative.Generated.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Tests.Reaqtive.Linq/Operators/MinMax.Generated.cs
+++ b/Reaqtive/Core/Tests.Reaqtive.Linq/Operators/MinMax.Generated.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Tests.Reaqtive.Linq/Operators/MinMax.cs
+++ b/Reaqtive/Core/Tests.Reaqtive.Linq/Operators/MinMax.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Tests.Reaqtive.Linq/Operators/Never.Declarative.cs
+++ b/Reaqtive/Core/Tests.Reaqtive.Linq/Operators/Never.Declarative.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Tests.Reaqtive.Linq/Operators/Never.cs
+++ b/Reaqtive/Core/Tests.Reaqtive.Linq/Operators/Never.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Tests.Reaqtive.Linq/Operators/OperatorTestBase.cs
+++ b/Reaqtive/Core/Tests.Reaqtive.Linq/Operators/OperatorTestBase.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Tests.Reaqtive.Linq/Operators/Regressions.Declarative.cs
+++ b/Reaqtive/Core/Tests.Reaqtive.Linq/Operators/Regressions.Declarative.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Tests.Reaqtive.Linq/Operators/Regressions.cs
+++ b/Reaqtive/Core/Tests.Reaqtive.Linq/Operators/Regressions.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Tests.Reaqtive.Linq/Operators/Retry.Declarative.cs
+++ b/Reaqtive/Core/Tests.Reaqtive.Linq/Operators/Retry.Declarative.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Tests.Reaqtive.Linq/Operators/Retry.cs
+++ b/Reaqtive/Core/Tests.Reaqtive.Linq/Operators/Retry.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Tests.Reaqtive.Linq/Operators/Return.Declarative.cs
+++ b/Reaqtive/Core/Tests.Reaqtive.Linq/Operators/Return.Declarative.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Tests.Reaqtive.Linq/Operators/Return.cs
+++ b/Reaqtive/Core/Tests.Reaqtive.Linq/Operators/Return.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Tests.Reaqtive.Linq/Operators/Sample.Declarative.cs
+++ b/Reaqtive/Core/Tests.Reaqtive.Linq/Operators/Sample.Declarative.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Tests.Reaqtive.Linq/Operators/Sample.cs
+++ b/Reaqtive/Core/Tests.Reaqtive.Linq/Operators/Sample.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Tests.Reaqtive.Linq/Operators/Scan.Declarative.cs
+++ b/Reaqtive/Core/Tests.Reaqtive.Linq/Operators/Scan.Declarative.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Tests.Reaqtive.Linq/Operators/Scan.cs
+++ b/Reaqtive/Core/Tests.Reaqtive.Linq/Operators/Scan.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Tests.Reaqtive.Linq/Operators/Select.Declarative.cs
+++ b/Reaqtive/Core/Tests.Reaqtive.Linq/Operators/Select.Declarative.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Tests.Reaqtive.Linq/Operators/Select.cs
+++ b/Reaqtive/Core/Tests.Reaqtive.Linq/Operators/Select.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Tests.Reaqtive.Linq/Operators/SelectMany.Declarative.cs
+++ b/Reaqtive/Core/Tests.Reaqtive.Linq/Operators/SelectMany.Declarative.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Tests.Reaqtive.Linq/Operators/SelectMany.cs
+++ b/Reaqtive/Core/Tests.Reaqtive.Linq/Operators/SelectMany.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Tests.Reaqtive.Linq/Operators/SequenceEqual.Declarative.cs
+++ b/Reaqtive/Core/Tests.Reaqtive.Linq/Operators/SequenceEqual.Declarative.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Tests.Reaqtive.Linq/Operators/SequenceEqual.cs
+++ b/Reaqtive/Core/Tests.Reaqtive.Linq/Operators/SequenceEqual.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Tests.Reaqtive.Linq/Operators/Skip.Declarative.cs
+++ b/Reaqtive/Core/Tests.Reaqtive.Linq/Operators/Skip.Declarative.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Tests.Reaqtive.Linq/Operators/Skip.cs
+++ b/Reaqtive/Core/Tests.Reaqtive.Linq/Operators/Skip.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Tests.Reaqtive.Linq/Operators/SkipUntil.Declarative.cs
+++ b/Reaqtive/Core/Tests.Reaqtive.Linq/Operators/SkipUntil.Declarative.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Tests.Reaqtive.Linq/Operators/SkipUntil.cs
+++ b/Reaqtive/Core/Tests.Reaqtive.Linq/Operators/SkipUntil.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Tests.Reaqtive.Linq/Operators/SkipWhile.Declarative.cs
+++ b/Reaqtive/Core/Tests.Reaqtive.Linq/Operators/SkipWhile.Declarative.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Tests.Reaqtive.Linq/Operators/SkipWhile.cs
+++ b/Reaqtive/Core/Tests.Reaqtive.Linq/Operators/SkipWhile.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Tests.Reaqtive.Linq/Operators/StartWith.Declarative.cs
+++ b/Reaqtive/Core/Tests.Reaqtive.Linq/Operators/StartWith.Declarative.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Tests.Reaqtive.Linq/Operators/StartWith.cs
+++ b/Reaqtive/Core/Tests.Reaqtive.Linq/Operators/StartWith.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Tests.Reaqtive.Linq/Operators/SubscribableTimeTest.cs
+++ b/Reaqtive/Core/Tests.Reaqtive.Linq/Operators/SubscribableTimeTest.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Tests.Reaqtive.Linq/Operators/Sum.Declarative.Generated.cs
+++ b/Reaqtive/Core/Tests.Reaqtive.Linq/Operators/Sum.Declarative.Generated.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Tests.Reaqtive.Linq/Operators/Sum.Declarative.cs
+++ b/Reaqtive/Core/Tests.Reaqtive.Linq/Operators/Sum.Declarative.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Tests.Reaqtive.Linq/Operators/Sum.Generated.cs
+++ b/Reaqtive/Core/Tests.Reaqtive.Linq/Operators/Sum.Generated.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Tests.Reaqtive.Linq/Operators/Sum.cs
+++ b/Reaqtive/Core/Tests.Reaqtive.Linq/Operators/Sum.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Tests.Reaqtive.Linq/Operators/Switch.Declarative.cs
+++ b/Reaqtive/Core/Tests.Reaqtive.Linq/Operators/Switch.Declarative.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Tests.Reaqtive.Linq/Operators/Switch.cs
+++ b/Reaqtive/Core/Tests.Reaqtive.Linq/Operators/Switch.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Tests.Reaqtive.Linq/Operators/Take.Declarative.cs
+++ b/Reaqtive/Core/Tests.Reaqtive.Linq/Operators/Take.Declarative.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Tests.Reaqtive.Linq/Operators/Take.cs
+++ b/Reaqtive/Core/Tests.Reaqtive.Linq/Operators/Take.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Tests.Reaqtive.Linq/Operators/TakeUntil.Declarative.cs
+++ b/Reaqtive/Core/Tests.Reaqtive.Linq/Operators/TakeUntil.Declarative.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Tests.Reaqtive.Linq/Operators/TakeUntil.cs
+++ b/Reaqtive/Core/Tests.Reaqtive.Linq/Operators/TakeUntil.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Tests.Reaqtive.Linq/Operators/TakeWhile.Declarative.cs
+++ b/Reaqtive/Core/Tests.Reaqtive.Linq/Operators/TakeWhile.Declarative.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Tests.Reaqtive.Linq/Operators/TakeWhile.cs
+++ b/Reaqtive/Core/Tests.Reaqtive.Linq/Operators/TakeWhile.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Tests.Reaqtive.Linq/Operators/Throttle.Declarative.cs
+++ b/Reaqtive/Core/Tests.Reaqtive.Linq/Operators/Throttle.Declarative.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Tests.Reaqtive.Linq/Operators/Throttle.cs
+++ b/Reaqtive/Core/Tests.Reaqtive.Linq/Operators/Throttle.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Tests.Reaqtive.Linq/Operators/Throw.Declarative.cs
+++ b/Reaqtive/Core/Tests.Reaqtive.Linq/Operators/Throw.Declarative.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Tests.Reaqtive.Linq/Operators/Throw.cs
+++ b/Reaqtive/Core/Tests.Reaqtive.Linq/Operators/Throw.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Tests.Reaqtive.Linq/Operators/ToList.Declarative.cs
+++ b/Reaqtive/Core/Tests.Reaqtive.Linq/Operators/ToList.Declarative.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Tests.Reaqtive.Linq/Operators/ToList.cs
+++ b/Reaqtive/Core/Tests.Reaqtive.Linq/Operators/ToList.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Tests.Reaqtive.Linq/Operators/ToSubscribable.cs
+++ b/Reaqtive/Core/Tests.Reaqtive.Linq/Operators/ToSubscribable.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Tests.Reaqtive.Linq/Operators/Versioning.cs
+++ b/Reaqtive/Core/Tests.Reaqtive.Linq/Operators/Versioning.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Tests.Reaqtive.Linq/Operators/Where.Declarative.cs
+++ b/Reaqtive/Core/Tests.Reaqtive.Linq/Operators/Where.Declarative.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Tests.Reaqtive.Linq/Operators/Where.cs
+++ b/Reaqtive/Core/Tests.Reaqtive.Linq/Operators/Where.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Tests.Reaqtive.Linq/Operators/Window.Declarative.cs
+++ b/Reaqtive/Core/Tests.Reaqtive.Linq/Operators/Window.Declarative.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Tests.Reaqtive.Linq/Operators/Window.cs
+++ b/Reaqtive/Core/Tests.Reaqtive.Linq/Operators/Window.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Tests.Reaqtive.Linq/TinyObserverTests.cs
+++ b/Reaqtive/Core/Tests.Reaqtive.Linq/TinyObserverTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Tests.Reaqtive.Quotation/Reaqtive/Expressions/ExpressionPolicyTests.cs
+++ b/Reaqtive/Core/Tests.Reaqtive.Quotation/Reaqtive/Expressions/ExpressionPolicyTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Tests.Reaqtive.Scheduler/Reaqtive/AccessCheckTests.cs
+++ b/Reaqtive/Core/Tests.Reaqtive.Scheduler/Reaqtive/AccessCheckTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Tests.Reaqtive.Scheduler/Reaqtive/EpsilonSchedulerTests.cs
+++ b/Reaqtive/Core/Tests.Reaqtive.Scheduler/Reaqtive/EpsilonSchedulerTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Tests.Reaqtive.Scheduler/Reaqtive/ErrorHandlingTests.cs
+++ b/Reaqtive/Core/Tests.Reaqtive.Scheduler/Reaqtive/ErrorHandlingTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Tests.Reaqtive.Scheduler/Reaqtive/NopSchedulerTests.cs
+++ b/Reaqtive/Core/Tests.Reaqtive.Scheduler/Reaqtive/NopSchedulerTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Tests.Reaqtive.Scheduler/Reaqtive/PriorityQueueTests.cs
+++ b/Reaqtive/Core/Tests.Reaqtive.Scheduler/Reaqtive/PriorityQueueTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Tests.Reaqtive.Scheduler/Reaqtive/Tasks/ActionTask.cs
+++ b/Reaqtive/Core/Tests.Reaqtive.Scheduler/Reaqtive/Tasks/ActionTask.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Tests.Reaqtive.Scheduler/Reaqtive/Tasks/MessageQueueBasedTask.cs
+++ b/Reaqtive/Core/Tests.Reaqtive.Scheduler/Reaqtive/Tasks/MessageQueueBasedTask.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Core/Tests.Reaqtive.Scheduler/Reaqtive/WorkItemBaseTests.cs
+++ b/Reaqtive/Core/Tests.Reaqtive.Scheduler/Reaqtive/WorkItemBaseTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Pearls/Rxcel/ExcelCompiler.cs
+++ b/Reaqtive/Pearls/Rxcel/ExcelCompiler.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Pearls/Rxcel/Expressions/BinaryExcelExpression.cs
+++ b/Reaqtive/Pearls/Rxcel/Expressions/BinaryExcelExpression.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Pearls/Rxcel/Expressions/CellExcelExpression.cs
+++ b/Reaqtive/Pearls/Rxcel/Expressions/CellExcelExpression.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Pearls/Rxcel/Expressions/ExcelExpression.cs
+++ b/Reaqtive/Pearls/Rxcel/Expressions/ExcelExpression.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Pearls/Rxcel/Expressions/ExcelExpressionKind.cs
+++ b/Reaqtive/Pearls/Rxcel/Expressions/ExcelExpressionKind.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Pearls/Rxcel/Expressions/ExcelExpressionVisitor.cs
+++ b/Reaqtive/Pearls/Rxcel/Expressions/ExcelExpressionVisitor.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Pearls/Rxcel/Expressions/FormulaExcelExpression.cs
+++ b/Reaqtive/Pearls/Rxcel/Expressions/FormulaExcelExpression.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Pearls/Rxcel/Expressions/NumberExcelExpression.cs
+++ b/Reaqtive/Pearls/Rxcel/Expressions/NumberExcelExpression.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Pearls/Rxcel/Expressions/RangeExcelExpression.cs
+++ b/Reaqtive/Pearls/Rxcel/Expressions/RangeExcelExpression.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Pearls/Rxcel/Model/Cell.cs
+++ b/Reaqtive/Pearls/Rxcel/Model/Cell.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Pearls/Rxcel/Parser/Parser.cs
+++ b/Reaqtive/Pearls/Rxcel/Parser/Parser.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Pearls/Rxcel/Parser/Token.cs
+++ b/Reaqtive/Pearls/Rxcel/Parser/Token.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Pearls/Rxcel/Parser/TokenKind.cs
+++ b/Reaqtive/Pearls/Rxcel/Parser/TokenKind.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Pearls/Rxcel/Properties/AssemblyInfo.cs
+++ b/Reaqtive/Pearls/Rxcel/Properties/AssemblyInfo.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtive/Pearls/Rxcel/Rx/CombineLatestMethods.cs
+++ b/Reaqtive/Pearls/Rxcel/Rx/CombineLatestMethods.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Client/Reaqtor.Client.Core/Properties/AssemblyInfo.cs
+++ b/Reaqtor/Core/Client/Reaqtor.Client.Core/Properties/AssemblyInfo.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Client/Reaqtor.Client.Core/Reaqtor/AsyncReactiveQueryProviderBase.HigherArities.cs
+++ b/Reaqtor/Core/Client/Reaqtor.Client.Core/Reaqtor/AsyncReactiveQueryProviderBase.HigherArities.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Client/Reaqtor.Client.Core/Reaqtor/AsyncReactiveQueryProviderBase.cs
+++ b/Reaqtor/Core/Client/Reaqtor.Client.Core/Reaqtor/AsyncReactiveQueryProviderBase.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Client/Reaqtor.Client.Core/Reaqtor/Internal/KnownQbservable.cs
+++ b/Reaqtor/Core/Client/Reaqtor.Client.Core/Reaqtor/Internal/KnownQbservable.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Client/Reaqtor.Client.Core/Reaqtor/Internal/KnownQbserver.cs
+++ b/Reaqtor/Core/Client/Reaqtor.Client.Core/Reaqtor/Internal/KnownQbserver.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Client/Reaqtor.Client.Core/Reaqtor/Internal/KnownQubject.cs
+++ b/Reaqtor/Core/Client/Reaqtor.Client.Core/Reaqtor/Internal/KnownQubject.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Client/Reaqtor.Client.Core/Reaqtor/Internal/KnownQubjectFactory.HigherArities.cs
+++ b/Reaqtor/Core/Client/Reaqtor.Client.Core/Reaqtor/Internal/KnownQubjectFactory.HigherArities.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Client/Reaqtor.Client.Core/Reaqtor/Internal/KnownQubjectFactory.cs
+++ b/Reaqtor/Core/Client/Reaqtor.Client.Core/Reaqtor/Internal/KnownQubjectFactory.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Client/Reaqtor.Client.Core/Reaqtor/Internal/KnownQubscription.cs
+++ b/Reaqtor/Core/Client/Reaqtor.Client.Core/Reaqtor/Internal/KnownQubscription.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Client/Reaqtor.Client.Core/Reaqtor/Internal/KnownQubscriptionFactory.HigherArities.cs
+++ b/Reaqtor/Core/Client/Reaqtor.Client.Core/Reaqtor/Internal/KnownQubscriptionFactory.HigherArities.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Client/Reaqtor.Client.Core/Reaqtor/Internal/KnownQubscriptionFactory.cs
+++ b/Reaqtor/Core/Client/Reaqtor.Client.Core/Reaqtor/Internal/KnownQubscriptionFactory.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Client/Reaqtor.Client.Core/Reaqtor/Internal/Qbservable.cs
+++ b/Reaqtor/Core/Client/Reaqtor.Client.Core/Reaqtor/Internal/Qbservable.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Client/Reaqtor.Client.Core/Reaqtor/Internal/Qbserver.cs
+++ b/Reaqtor/Core/Client/Reaqtor.Client.Core/Reaqtor/Internal/Qbserver.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Client/Reaqtor.Client.Core/Reaqtor/Internal/Qubject.cs
+++ b/Reaqtor/Core/Client/Reaqtor.Client.Core/Reaqtor/Internal/Qubject.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Client/Reaqtor.Client.Core/Reaqtor/Internal/QubjectFactory.HigherArities.cs
+++ b/Reaqtor/Core/Client/Reaqtor.Client.Core/Reaqtor/Internal/QubjectFactory.HigherArities.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Client/Reaqtor.Client.Core/Reaqtor/Internal/QubjectFactory.cs
+++ b/Reaqtor/Core/Client/Reaqtor.Client.Core/Reaqtor/Internal/QubjectFactory.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Client/Reaqtor.Client.Core/Reaqtor/Internal/Qubscription.cs
+++ b/Reaqtor/Core/Client/Reaqtor.Client.Core/Reaqtor/Internal/Qubscription.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Client/Reaqtor.Client.Core/Reaqtor/Internal/QubscriptionFactory.HigherArities.cs
+++ b/Reaqtor/Core/Client/Reaqtor.Client.Core/Reaqtor/Internal/QubscriptionFactory.HigherArities.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Client/Reaqtor.Client.Core/Reaqtor/Internal/QubscriptionFactory.cs
+++ b/Reaqtor/Core/Client/Reaqtor.Client.Core/Reaqtor/Internal/QubscriptionFactory.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Client/Reaqtor.Client.Core/Reaqtor/ReactiveClientProxyBase.HigherArities.cs
+++ b/Reaqtor/Core/Client/Reaqtor.Client.Core/Reaqtor/ReactiveClientProxyBase.HigherArities.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Client/Reaqtor.Client.Core/Reaqtor/ReactiveClientProxyBase.cs
+++ b/Reaqtor/Core/Client/Reaqtor.Client.Core/Reaqtor/ReactiveClientProxyBase.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Client/Reaqtor.Client.Core/Reaqtor/ReactiveDefinitionProxyBase.HigherArities.cs
+++ b/Reaqtor/Core/Client/Reaqtor.Client.Core/Reaqtor/ReactiveDefinitionProxyBase.HigherArities.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Client/Reaqtor.Client.Core/Reaqtor/ReactiveDefinitionProxyBase.cs
+++ b/Reaqtor/Core/Client/Reaqtor.Client.Core/Reaqtor/ReactiveDefinitionProxyBase.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Client/Reaqtor.Client.Core/Reaqtor/ReactiveMetadataProxyBase.cs
+++ b/Reaqtor/Core/Client/Reaqtor.Client.Core/Reaqtor/ReactiveMetadataProxyBase.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Client/Reaqtor.Client.Core/Reaqtor/UriToReactiveProxyBinder.cs
+++ b/Reaqtor/Core/Client/Reaqtor.Client.Core/Reaqtor/UriToReactiveProxyBinder.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Client/Reaqtor.Client.Model/Properties/AssemblyInfo.cs
+++ b/Reaqtor/Core/Client/Reaqtor.Client.Model/Properties/AssemblyInfo.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Client/Reaqtor.Client.Model/Reaqtor/IReactiveClientProxy.cs
+++ b/Reaqtor/Core/Client/Reaqtor.Client.Model/Reaqtor/IReactiveClientProxy.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Client/Reaqtor.Client.Model/Reaqtor/IReactiveDefinitionProxy.cs
+++ b/Reaqtor/Core/Client/Reaqtor.Client.Model/Reaqtor/IReactiveDefinitionProxy.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Client/Reaqtor.Client.Model/Reaqtor/IReactiveMetadataProxy.cs
+++ b/Reaqtor/Core/Client/Reaqtor.Client.Model/Reaqtor/IReactiveMetadataProxy.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Client/Reaqtor.Client.Model/Reaqtor/IReactiveProxy.cs
+++ b/Reaqtor/Core/Client/Reaqtor.Client.Model/Reaqtor/IReactiveProxy.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Client/Reaqtor.Client/Properties/AssemblyInfo.cs
+++ b/Reaqtor/Core/Client/Reaqtor.Client/Properties/AssemblyInfo.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Client/Reaqtor.Client/Reaqtor/AsyncReactiveQueryProvider.cs
+++ b/Reaqtor/Core/Client/Reaqtor.Client/Reaqtor/AsyncReactiveQueryProvider.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Client/Reaqtor.Client/Reaqtor/ReactiveClientContext.cs
+++ b/Reaqtor/Core/Client/Reaqtor.Client/Reaqtor/ReactiveClientContext.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Client/Reaqtor.Client/Reaqtor/ReactiveClientContextBase.HigherArities.cs
+++ b/Reaqtor/Core/Client/Reaqtor.Client/Reaqtor/ReactiveClientContextBase.HigherArities.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Client/Reaqtor.Client/Reaqtor/ReactiveClientContextBase.cs
+++ b/Reaqtor/Core/Client/Reaqtor.Client/Reaqtor/ReactiveClientContextBase.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Client/Reaqtor.Client/Reaqtor/ReactiveClientProxy.cs
+++ b/Reaqtor/Core/Client/Reaqtor.Client/Reaqtor/ReactiveClientProxy.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Client/Reaqtor.Client/Reaqtor/ReactiveDefinitionProxy.HigherArities.cs
+++ b/Reaqtor/Core/Client/Reaqtor.Client/Reaqtor/ReactiveDefinitionProxy.HigherArities.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Client/Reaqtor.Client/Reaqtor/ReactiveDefinitionProxy.cs
+++ b/Reaqtor/Core/Client/Reaqtor.Client/Reaqtor/ReactiveDefinitionProxy.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Client/Reaqtor.Client/Reaqtor/ReactiveMetadataProxy.cs
+++ b/Reaqtor/Core/Client/Reaqtor.Client/Reaqtor/ReactiveMetadataProxy.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Client/Tests.Reaqtor.Client.Core/Reaqtor/QbserverTests.cs
+++ b/Reaqtor/Core/Client/Tests.Reaqtor.Client.Core/Reaqtor/QbserverTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Client/Tests.Reaqtor.Client.Core/Reaqtor/UriToReactiveProxyBinderTests.cs
+++ b/Reaqtor/Core/Client/Tests.Reaqtor.Client.Core/Reaqtor/UriToReactiveProxyBinderTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Client/Tests.Reaqtor.Client/Constants.cs
+++ b/Reaqtor/Core/Client/Tests.Reaqtor.Client/Constants.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Client/Tests.Reaqtor.Client/ReactiveClientContextHigherArityTests.cs
+++ b/Reaqtor/Core/Client/Tests.Reaqtor.Client/ReactiveClientContextHigherArityTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Client/Tests.Reaqtor.Client/ReactiveClientContextTestBase.cs
+++ b/Reaqtor/Core/Client/Tests.Reaqtor.Client/ReactiveClientContextTestBase.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Client/Tests.Reaqtor.Client/ReactiveClientContextTests.Generated.cs
+++ b/Reaqtor/Core/Client/Tests.Reaqtor.Client/ReactiveClientContextTests.Generated.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Client/Tests.Reaqtor.Client/ReactiveClientContextTests.cs
+++ b/Reaqtor/Core/Client/Tests.Reaqtor.Client/ReactiveClientContextTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Client/Tests.Reaqtor.Client/TestClientContext.cs
+++ b/Reaqtor/Core/Client/Tests.Reaqtor.Client/TestClientContext.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Engine/Reaqtor.Engine.Contracts/Properties/AssemblyInfo.cs
+++ b/Reaqtor/Core/Engine/Reaqtor.Engine.Contracts/Properties/AssemblyInfo.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Engine/Reaqtor.Engine.Contracts/Reaqtor/IReactiveClientEngineProvider.cs
+++ b/Reaqtor/Core/Engine/Reaqtor.Engine.Contracts/Reaqtor/IReactiveClientEngineProvider.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Engine/Reaqtor.Engine.Contracts/Reaqtor/IReactiveDefinitionEngineProvider.cs
+++ b/Reaqtor/Core/Engine/Reaqtor.Engine.Contracts/Reaqtor/IReactiveDefinitionEngineProvider.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Engine/Reaqtor.Engine.Contracts/Reaqtor/IReactiveEngineProvider.cs
+++ b/Reaqtor/Core/Engine/Reaqtor.Engine.Contracts/Reaqtor/IReactiveEngineProvider.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Engine/Reaqtor.Engine.Contracts/Reaqtor/IReactiveMetadataEngineProvider.cs
+++ b/Reaqtor/Core/Engine/Reaqtor.Engine.Contracts/Reaqtor/IReactiveMetadataEngineProvider.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Engine/Reaqtor.QueryEngine.Interfaces/Properties/AssemblyInfo.cs
+++ b/Reaqtor/Core/Engine/Reaqtor.QueryEngine.Interfaces/Properties/AssemblyInfo.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Engine/Reaqtor.QueryEngine.Interfaces/Reaqtor/IHostedOperatorContext.cs
+++ b/Reaqtor/Core/Engine/Reaqtor.QueryEngine.Interfaces/Reaqtor/IHostedOperatorContext.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Engine/Reaqtor.QueryEngine.Interfaces/Reaqtor/QueryEngine/CheckpointKind.cs
+++ b/Reaqtor/Core/Engine/Reaqtor.QueryEngine.Interfaces/Reaqtor/QueryEngine/CheckpointKind.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Engine/Reaqtor.QueryEngine.Interfaces/Reaqtor/QueryEngine/ICheckpointStorageProvider.cs
+++ b/Reaqtor/Core/Engine/Reaqtor.QueryEngine.Interfaces/Reaqtor/QueryEngine/ICheckpointStorageProvider.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Engine/Reaqtor.QueryEngine.Interfaces/Reaqtor/QueryEngine/ICheckpointable.cs
+++ b/Reaqtor/Core/Engine/Reaqtor.QueryEngine.Interfaces/Reaqtor/QueryEngine/ICheckpointable.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Engine/Reaqtor.QueryEngine.Interfaces/Reaqtor/QueryEngine/ICheckpointingQueryEngine.cs
+++ b/Reaqtor/Core/Engine/Reaqtor.QueryEngine.Interfaces/Reaqtor/QueryEngine/ICheckpointingQueryEngine.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Engine/Reaqtor.QueryEngine.Interfaces/Reaqtor/QueryEngine/IDelegationTarget.cs
+++ b/Reaqtor/Core/Engine/Reaqtor.QueryEngine.Interfaces/Reaqtor/QueryEngine/IDelegationTarget.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Engine/Reaqtor.QueryEngine.Interfaces/Reaqtor/QueryEngine/IQueryEngine.cs
+++ b/Reaqtor/Core/Engine/Reaqtor.QueryEngine.Interfaces/Reaqtor/QueryEngine/IQueryEngine.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Engine/Reaqtor.QueryEngine.Interfaces/Reaqtor/QueryEngine/IQuotedTypeConversionTargets.cs
+++ b/Reaqtor/Core/Engine/Reaqtor.QueryEngine.Interfaces/Reaqtor/QueryEngine/IQuotedTypeConversionTargets.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Engine/Reaqtor.QueryEngine.Interfaces/Reaqtor/QueryEngine/IReactiveServiceResolver.cs
+++ b/Reaqtor/Core/Engine/Reaqtor.QueryEngine.Interfaces/Reaqtor/QueryEngine/IReactiveServiceResolver.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Engine/Reaqtor.QueryEngine.Interfaces/Reaqtor/QueryEngine/IReliableQueryEngine.cs
+++ b/Reaqtor/Core/Engine/Reaqtor.QueryEngine.Interfaces/Reaqtor/QueryEngine/IReliableQueryEngine.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Engine/Reaqtor.QueryEngine.Interfaces/Reaqtor/QueryEngine/ISerializationPolicy.cs
+++ b/Reaqtor/Core/Engine/Reaqtor.QueryEngine.Interfaces/Reaqtor/QueryEngine/ISerializationPolicy.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Engine/Reaqtor.QueryEngine.Interfaces/Reaqtor/QueryEngine/ISerializer.cs
+++ b/Reaqtor/Core/Engine/Reaqtor.QueryEngine.Interfaces/Reaqtor/QueryEngine/ISerializer.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Engine/Reaqtor.QueryEngine.Interfaces/Reaqtor/QueryEngine/IStateReader.cs
+++ b/Reaqtor/Core/Engine/Reaqtor.QueryEngine.Interfaces/Reaqtor/QueryEngine/IStateReader.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Engine/Reaqtor.QueryEngine.Interfaces/Reaqtor/QueryEngine/IStateWriter.cs
+++ b/Reaqtor/Core/Engine/Reaqtor.QueryEngine.Interfaces/Reaqtor/QueryEngine/IStateWriter.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Engine/Reaqtor.QueryEngine.Interfaces/Reaqtor/QueryEngine/KeyValueStore/IKeyValueStore.cs
+++ b/Reaqtor/Core/Engine/Reaqtor.QueryEngine.Interfaces/Reaqtor/QueryEngine/KeyValueStore/IKeyValueStore.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Engine/Reaqtor.QueryEngine.Interfaces/Reaqtor/QueryEngine/KeyValueStore/IKeyValueStoreTransaction.cs
+++ b/Reaqtor/Core/Engine/Reaqtor.QueryEngine.Interfaces/Reaqtor/QueryEngine/KeyValueStore/IKeyValueStoreTransaction.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Engine/Reaqtor.QueryEngine.Interfaces/Reaqtor/QueryEngine/KeyValueStore/IKeyValueTable.cs
+++ b/Reaqtor/Core/Engine/Reaqtor.QueryEngine.Interfaces/Reaqtor/QueryEngine/KeyValueStore/IKeyValueTable.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Engine/Reaqtor.QueryEngine.Interfaces/Reaqtor/QueryEngine/KeyValueStore/ITransactedKeyValueTable.cs
+++ b/Reaqtor/Core/Engine/Reaqtor.QueryEngine.Interfaces/Reaqtor/QueryEngine/KeyValueStore/ITransactedKeyValueTable.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Engine/Reaqtor.QueryEngine.Interfaces/Reaqtor/QueryEngine/KeyValueStore/ITransaction.cs
+++ b/Reaqtor/Core/Engine/Reaqtor.QueryEngine.Interfaces/Reaqtor/QueryEngine/KeyValueStore/ITransaction.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Engine/Reaqtor.QueryEngine.KeyValueStore.InMemory/EnumerableEx.cs
+++ b/Reaqtor/Core/Engine/Reaqtor.QueryEngine.KeyValueStore.InMemory/EnumerableEx.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Engine/Reaqtor.QueryEngine.KeyValueStore.InMemory/InMemoryKeyValueStore.cs
+++ b/Reaqtor/Core/Engine/Reaqtor.QueryEngine.KeyValueStore.InMemory/InMemoryKeyValueStore.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Engine/Reaqtor.QueryEngine.KeyValueStore.InMemory/InMemoryStateReader.cs
+++ b/Reaqtor/Core/Engine/Reaqtor.QueryEngine.KeyValueStore.InMemory/InMemoryStateReader.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Engine/Reaqtor.QueryEngine.KeyValueStore.InMemory/InMemoryStateStore.cs
+++ b/Reaqtor/Core/Engine/Reaqtor.QueryEngine.KeyValueStore.InMemory/InMemoryStateStore.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Engine/Reaqtor.QueryEngine.KeyValueStore.InMemory/InMemoryStateWriter.cs
+++ b/Reaqtor/Core/Engine/Reaqtor.QueryEngine.KeyValueStore.InMemory/InMemoryStateWriter.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Engine/Reaqtor.QueryEngine.KeyValueStore.InMemory/InMemoryStorageProvider.cs
+++ b/Reaqtor/Core/Engine/Reaqtor.QueryEngine.KeyValueStore.InMemory/InMemoryStorageProvider.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Engine/Reaqtor.QueryEngine.KeyValueStore.InMemory/Properties/AssemblyInfo.cs
+++ b/Reaqtor/Core/Engine/Reaqtor.QueryEngine.KeyValueStore.InMemory/Properties/AssemblyInfo.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Engine/Reaqtor.QueryEngine.KeyValueStore.InMemory/ReifiedOperations/AddOperation.cs
+++ b/Reaqtor/Core/Engine/Reaqtor.QueryEngine.KeyValueStore.InMemory/ReifiedOperations/AddOperation.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Engine/Reaqtor.QueryEngine.KeyValueStore.InMemory/ReifiedOperations/AddOperationResult.cs
+++ b/Reaqtor/Core/Engine/Reaqtor.QueryEngine.KeyValueStore.InMemory/ReifiedOperations/AddOperationResult.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Engine/Reaqtor.QueryEngine.KeyValueStore.InMemory/ReifiedOperations/ContainsOperation.cs
+++ b/Reaqtor/Core/Engine/Reaqtor.QueryEngine.KeyValueStore.InMemory/ReifiedOperations/ContainsOperation.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Engine/Reaqtor.QueryEngine.KeyValueStore.InMemory/ReifiedOperations/ContainsOperationResult.cs
+++ b/Reaqtor/Core/Engine/Reaqtor.QueryEngine.KeyValueStore.InMemory/ReifiedOperations/ContainsOperationResult.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Engine/Reaqtor.QueryEngine.KeyValueStore.InMemory/ReifiedOperations/EnumerateOperation.cs
+++ b/Reaqtor/Core/Engine/Reaqtor.QueryEngine.KeyValueStore.InMemory/ReifiedOperations/EnumerateOperation.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Engine/Reaqtor.QueryEngine.KeyValueStore.InMemory/ReifiedOperations/EnumerateOperationResult.cs
+++ b/Reaqtor/Core/Engine/Reaqtor.QueryEngine.KeyValueStore.InMemory/ReifiedOperations/EnumerateOperationResult.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Engine/Reaqtor.QueryEngine.KeyValueStore.InMemory/ReifiedOperations/GetOperation.cs
+++ b/Reaqtor/Core/Engine/Reaqtor.QueryEngine.KeyValueStore.InMemory/ReifiedOperations/GetOperation.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Engine/Reaqtor.QueryEngine.KeyValueStore.InMemory/ReifiedOperations/GetOperationResult.cs
+++ b/Reaqtor/Core/Engine/Reaqtor.QueryEngine.KeyValueStore.InMemory/ReifiedOperations/GetOperationResult.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Engine/Reaqtor.QueryEngine.KeyValueStore.InMemory/ReifiedOperations/OperationResult.cs
+++ b/Reaqtor/Core/Engine/Reaqtor.QueryEngine.KeyValueStore.InMemory/ReifiedOperations/OperationResult.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Engine/Reaqtor.QueryEngine.KeyValueStore.InMemory/ReifiedOperations/OperationType.cs
+++ b/Reaqtor/Core/Engine/Reaqtor.QueryEngine.KeyValueStore.InMemory/ReifiedOperations/OperationType.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Engine/Reaqtor.QueryEngine.KeyValueStore.InMemory/ReifiedOperations/ReifiedOperation.cs
+++ b/Reaqtor/Core/Engine/Reaqtor.QueryEngine.KeyValueStore.InMemory/ReifiedOperations/ReifiedOperation.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Engine/Reaqtor.QueryEngine.KeyValueStore.InMemory/ReifiedOperations/ReifiedOperation{TKey,TValue}.cs
+++ b/Reaqtor/Core/Engine/Reaqtor.QueryEngine.KeyValueStore.InMemory/ReifiedOperations/ReifiedOperation{TKey,TValue}.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Engine/Reaqtor.QueryEngine.KeyValueStore.InMemory/ReifiedOperations/RemoveOperation.cs
+++ b/Reaqtor/Core/Engine/Reaqtor.QueryEngine.KeyValueStore.InMemory/ReifiedOperations/RemoveOperation.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Engine/Reaqtor.QueryEngine.KeyValueStore.InMemory/ReifiedOperations/RemoveOperationResult.cs
+++ b/Reaqtor/Core/Engine/Reaqtor.QueryEngine.KeyValueStore.InMemory/ReifiedOperations/RemoveOperationResult.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Engine/Reaqtor.QueryEngine.KeyValueStore.InMemory/ReifiedOperations/Sequenced.cs
+++ b/Reaqtor/Core/Engine/Reaqtor.QueryEngine.KeyValueStore.InMemory/ReifiedOperations/Sequenced.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Engine/Reaqtor.QueryEngine.KeyValueStore.InMemory/ReifiedOperations/Sequenced{T}.cs
+++ b/Reaqtor/Core/Engine/Reaqtor.QueryEngine.KeyValueStore.InMemory/ReifiedOperations/Sequenced{T}.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Engine/Reaqtor.QueryEngine.KeyValueStore.InMemory/ReifiedOperations/UpdateOperation.cs
+++ b/Reaqtor/Core/Engine/Reaqtor.QueryEngine.KeyValueStore.InMemory/ReifiedOperations/UpdateOperation.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Engine/Reaqtor.QueryEngine.KeyValueStore.InMemory/ReifiedOperations/UpdateOperationResult.cs
+++ b/Reaqtor/Core/Engine/Reaqtor.QueryEngine.KeyValueStore.InMemory/ReifiedOperations/UpdateOperationResult.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Engine/Reaqtor.QueryEngine.KeyValueStore.InMemory/WriteConflictException.cs
+++ b/Reaqtor/Core/Engine/Reaqtor.QueryEngine.KeyValueStore.InMemory/WriteConflictException.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Engine/Reaqtor.QueryEngine.Mocks/MockLazyReactiveEngineProvider.cs
+++ b/Reaqtor/Core/Engine/Reaqtor.QueryEngine.Mocks/MockLazyReactiveEngineProvider.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Engine/Reaqtor.QueryEngine.Mocks/MockObservable.cs
+++ b/Reaqtor/Core/Engine/Reaqtor.QueryEngine.Mocks/MockObservable.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Engine/Reaqtor.QueryEngine.Mocks/MockObserver.cs
+++ b/Reaqtor/Core/Engine/Reaqtor.QueryEngine.Mocks/MockObserver.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Engine/Reaqtor.QueryEngine.Mocks/MockQueryEngineRegistry.cs
+++ b/Reaqtor/Core/Engine/Reaqtor.QueryEngine.Mocks/MockQueryEngineRegistry.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Engine/Reaqtor.QueryEngine.Mocks/MockReactiveServiceContext.cs
+++ b/Reaqtor/Core/Engine/Reaqtor.QueryEngine.Mocks/MockReactiveServiceContext.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Engine/Reaqtor.QueryEngine.Mocks/MockReactiveServiceResolver.cs
+++ b/Reaqtor/Core/Engine/Reaqtor.QueryEngine.Mocks/MockReactiveServiceResolver.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Engine/Reaqtor.QueryEngine.Mocks/Properties/AssemblyInfo.cs
+++ b/Reaqtor/Core/Engine/Reaqtor.QueryEngine.Mocks/Properties/AssemblyInfo.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Engine/Reaqtor.QueryEngine.Mocks/SubjectManager.cs
+++ b/Reaqtor/Core/Engine/Reaqtor.QueryEngine.Mocks/SubjectManager.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Engine/Reaqtor.QueryEngine.Mocks/TestReliableExecutionEnvironment.cs
+++ b/Reaqtor/Core/Engine/Reaqtor.QueryEngine.Mocks/TestReliableExecutionEnvironment.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Engine/Reaqtor.QueryEngine.Mocks/TestVisibility.cs
+++ b/Reaqtor/Core/Engine/Reaqtor.QueryEngine.Mocks/TestVisibility.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Engine/Reaqtor.QueryEngine.ReificationFramework/Internal/Deployable.Generated.cs
+++ b/Reaqtor/Core/Engine/Reaqtor.QueryEngine.ReificationFramework/Internal/Deployable.Generated.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Engine/Reaqtor.QueryEngine.ReificationFramework/Internal/Deployable.cs
+++ b/Reaqtor/Core/Engine/Reaqtor.QueryEngine.ReificationFramework/Internal/Deployable.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Engine/Reaqtor.QueryEngine.ReificationFramework/Internal/DeploymentReactiveServiceContext.cs
+++ b/Reaqtor/Core/Engine/Reaqtor.QueryEngine.ReificationFramework/Internal/DeploymentReactiveServiceContext.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Engine/Reaqtor.QueryEngine.ReificationFramework/Internal/ReificationReactiveServiceContext.cs
+++ b/Reaqtor/Core/Engine/Reaqtor.QueryEngine.ReificationFramework/Internal/ReificationReactiveServiceContext.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Engine/Reaqtor.QueryEngine.ReificationFramework/Properties/AssemblyInfo.cs
+++ b/Reaqtor/Core/Engine/Reaqtor.QueryEngine.ReificationFramework/Properties/AssemblyInfo.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Engine/Reaqtor.QueryEngine.ReificationFramework/QueryEngineEnvironment.cs
+++ b/Reaqtor/Core/Engine/Reaqtor.QueryEngine.ReificationFramework/QueryEngineEnvironment.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Engine/Reaqtor.QueryEngine.ReificationFramework/QueryEngineReificationBinder.cs
+++ b/Reaqtor/Core/Engine/Reaqtor.QueryEngine.ReificationFramework/QueryEngineReificationBinder.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Engine/Reaqtor.QueryEngine.ReificationFramework/ReactiveServiceOperationBinder.cs
+++ b/Reaqtor/Core/Engine/Reaqtor.QueryEngine.ReificationFramework/ReactiveServiceOperationBinder.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Engine/Reaqtor.QueryEngine.Serialization.DataModel/Properties/AssemblyInfo.cs
+++ b/Reaqtor/Core/Engine/Reaqtor.QueryEngine.Serialization.DataModel/Properties/AssemblyInfo.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Engine/Reaqtor.QueryEngine.Serialization.DataModel/SerializationPolicy.cs
+++ b/Reaqtor/Core/Engine/Reaqtor.QueryEngine.Serialization.DataModel/SerializationPolicy.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Engine/Reaqtor.QueryEngine.Serialization.DataModel/Serializer.cs
+++ b/Reaqtor/Core/Engine/Reaqtor.QueryEngine.Serialization.DataModel/Serializer.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Engine/Reaqtor.QueryEngine.Serialization.DataModel/SerializerHelpers.cs
+++ b/Reaqtor/Core/Engine/Reaqtor.QueryEngine.Serialization.DataModel/SerializerHelpers.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Engine/Reaqtor.QueryEngine.Serialization.DataModel/TestVisibility.cs
+++ b/Reaqtor/Core/Engine/Reaqtor.QueryEngine.Serialization.DataModel/TestVisibility.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Engine/Reaqtor.QueryEngine.Serialization.DataModel/Versioning.cs
+++ b/Reaqtor/Core/Engine/Reaqtor.QueryEngine.Serialization.DataModel/Versioning.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Engine/Reaqtor.QueryEngine/EventMetadata.Generated.cs
+++ b/Reaqtor/Core/Engine/Reaqtor.QueryEngine/EventMetadata.Generated.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Engine/Reaqtor.QueryEngine/Properties/AssemblyInfo.cs
+++ b/Reaqtor/Core/Engine/Reaqtor.QueryEngine/Properties/AssemblyInfo.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Engine/Reaqtor.QueryEngine/Reaqtor/Expressions/ExpressionHelpers.cs
+++ b/Reaqtor/Core/Engine/Reaqtor.QueryEngine/Reaqtor/Expressions/ExpressionHelpers.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Engine/Reaqtor.QueryEngine/Reaqtor/Expressions/ExpressionTemplatizer.cs
+++ b/Reaqtor/Core/Engine/Reaqtor.QueryEngine/Reaqtor/Expressions/ExpressionTemplatizer.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Engine/Reaqtor.QueryEngine/Reaqtor/Expressions/QuoteFactory.cs
+++ b/Reaqtor/Core/Engine/Reaqtor.QueryEngine/Reaqtor/Expressions/QuoteFactory.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Engine/Reaqtor.QueryEngine/Reaqtor/Expressions/Quoter.cs
+++ b/Reaqtor/Core/Engine/Reaqtor.QueryEngine/Reaqtor/Expressions/Quoter.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Engine/Reaqtor.QueryEngine/Reaqtor/Expressions/TemplatizationHelpers.cs
+++ b/Reaqtor/Core/Engine/Reaqtor.QueryEngine/Reaqtor/Expressions/TemplatizationHelpers.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Engine/Reaqtor.QueryEngine/Reaqtor/QueryEngine/Binding/DefinitionInliningBinder.cs
+++ b/Reaqtor/Core/Engine/Reaqtor.QueryEngine/Reaqtor/QueryEngine/Binding/DefinitionInliningBinder.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Engine/Reaqtor.QueryEngine/Reaqtor/QueryEngine/Binding/DelegationBinder.cs
+++ b/Reaqtor/Core/Engine/Reaqtor.QueryEngine/Reaqtor/QueryEngine/Binding/DelegationBinder.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Engine/Reaqtor.QueryEngine/Reaqtor/QueryEngine/Binding/FullBinder.cs
+++ b/Reaqtor/Core/Engine/Reaqtor.QueryEngine/Reaqtor/QueryEngine/Binding/FullBinder.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Engine/Reaqtor.QueryEngine/Reaqtor/QueryEngine/Binding/QueryEngineBinder.cs
+++ b/Reaqtor/Core/Engine/Reaqtor.QueryEngine/Reaqtor/QueryEngine/Binding/QueryEngineBinder.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Engine/Reaqtor.QueryEngine/Reaqtor/QueryEngine/Binding/ReliableEdgeBinder.cs
+++ b/Reaqtor/Core/Engine/Reaqtor.QueryEngine/Reaqtor/QueryEngine/Binding/ReliableEdgeBinder.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Engine/Reaqtor.QueryEngine/Reaqtor/QueryEngine/Checkpointable.cs
+++ b/Reaqtor/Core/Engine/Reaqtor.QueryEngine/Reaqtor/QueryEngine/Checkpointable.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Engine/Reaqtor.QueryEngine/Reaqtor/QueryEngine/CheckpointableStateManager.cs
+++ b/Reaqtor/Core/Engine/Reaqtor.QueryEngine/Reaqtor/QueryEngine/CheckpointableStateManager.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Engine/Reaqtor.QueryEngine/Reaqtor/QueryEngine/CheckpointingQueryEngine.AsyncReactiveEngineProvider.cs
+++ b/Reaqtor/Core/Engine/Reaqtor.QueryEngine/Reaqtor/QueryEngine/CheckpointingQueryEngine.AsyncReactiveEngineProvider.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Engine/Reaqtor.QueryEngine/Reaqtor/QueryEngine/CheckpointingQueryEngine.BuiltinEntitiesRegistry.cs
+++ b/Reaqtor/Core/Engine/Reaqtor.QueryEngine/Reaqtor/QueryEngine/CheckpointingQueryEngine.BuiltinEntitiesRegistry.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Engine/Reaqtor.QueryEngine/Reaqtor/QueryEngine/CheckpointingQueryEngine.CoreReactiveEngine.Checkpointable.cs
+++ b/Reaqtor/Core/Engine/Reaqtor.QueryEngine/Reaqtor/QueryEngine/CheckpointingQueryEngine.CoreReactiveEngine.Checkpointable.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Engine/Reaqtor.QueryEngine/Reaqtor/QueryEngine/CheckpointingQueryEngine.CoreReactiveEngine.Events.cs
+++ b/Reaqtor/Core/Engine/Reaqtor.QueryEngine/Reaqtor/QueryEngine/CheckpointingQueryEngine.CoreReactiveEngine.Events.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Engine/Reaqtor.QueryEngine/Reaqtor/QueryEngine/CheckpointingQueryEngine.CoreReactiveEngine.GarbageCollector.cs
+++ b/Reaqtor/Core/Engine/Reaqtor.QueryEngine/Reaqtor/QueryEngine/CheckpointingQueryEngine.CoreReactiveEngine.GarbageCollector.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Engine/Reaqtor.QueryEngine/Reaqtor/QueryEngine/CheckpointingQueryEngine.CoreReactiveEngine.Helpers.cs
+++ b/Reaqtor/Core/Engine/Reaqtor.QueryEngine/Reaqtor/QueryEngine/CheckpointingQueryEngine.CoreReactiveEngine.Helpers.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Engine/Reaqtor.QueryEngine/Reaqtor/QueryEngine/CheckpointingQueryEngine.CoreReactiveEngine.Mitigations.cs
+++ b/Reaqtor/Core/Engine/Reaqtor.QueryEngine/Reaqtor/QueryEngine/CheckpointingQueryEngine.CoreReactiveEngine.Mitigations.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Engine/Reaqtor.QueryEngine/Reaqtor/QueryEngine/CheckpointingQueryEngine.CoreReactiveEngine.RecoveryScheduler.cs
+++ b/Reaqtor/Core/Engine/Reaqtor.QueryEngine/Reaqtor/QueryEngine/CheckpointingQueryEngine.CoreReactiveEngine.RecoveryScheduler.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Engine/Reaqtor.QueryEngine/Reaqtor/QueryEngine/CheckpointingQueryEngine.CoreReactiveEngine.StateLoader.cs
+++ b/Reaqtor/Core/Engine/Reaqtor.QueryEngine/Reaqtor/QueryEngine/CheckpointingQueryEngine.CoreReactiveEngine.StateLoader.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Engine/Reaqtor.QueryEngine/Reaqtor/QueryEngine/CheckpointingQueryEngine.CoreReactiveEngine.StateSaver.cs
+++ b/Reaqtor/Core/Engine/Reaqtor.QueryEngine/Reaqtor/QueryEngine/CheckpointingQueryEngine.CoreReactiveEngine.StateSaver.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Engine/Reaqtor.QueryEngine/Reaqtor/QueryEngine/CheckpointingQueryEngine.CoreReactiveEngine.TemplateMigrationTask.cs
+++ b/Reaqtor/Core/Engine/Reaqtor.QueryEngine/Reaqtor/QueryEngine/CheckpointingQueryEngine.CoreReactiveEngine.TemplateMigrationTask.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Engine/Reaqtor.QueryEngine/Reaqtor/QueryEngine/CheckpointingQueryEngine.CoreReactiveEngine.cs
+++ b/Reaqtor/Core/Engine/Reaqtor.QueryEngine/Reaqtor/QueryEngine/CheckpointingQueryEngine.CoreReactiveEngine.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Engine/Reaqtor.QueryEngine/Reaqtor/QueryEngine/CheckpointingQueryEngine.EngineExpressionService.cs
+++ b/Reaqtor/Core/Engine/Reaqtor.QueryEngine/Reaqtor/QueryEngine/CheckpointingQueryEngine.EngineExpressionService.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Engine/Reaqtor.QueryEngine/Reaqtor/QueryEngine/CheckpointingQueryEngine.ExecutionEnvironment.cs
+++ b/Reaqtor/Core/Engine/Reaqtor.QueryEngine/Reaqtor/QueryEngine/CheckpointingQueryEngine.ExecutionEnvironment.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Engine/Reaqtor.QueryEngine/Reaqtor/QueryEngine/CheckpointingQueryEngine.ExpressionHelpers.cs
+++ b/Reaqtor/Core/Engine/Reaqtor.QueryEngine/Reaqtor/QueryEngine/CheckpointingQueryEngine.ExpressionHelpers.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Engine/Reaqtor.QueryEngine/Reaqtor/QueryEngine/CheckpointingQueryEngine.ReactiveEngine.cs
+++ b/Reaqtor/Core/Engine/Reaqtor.QueryEngine/Reaqtor/QueryEngine/CheckpointingQueryEngine.ReactiveEngine.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Engine/Reaqtor.QueryEngine/Reaqtor/QueryEngine/CheckpointingQueryEngine.ReadOnlyMetadataServiceContext.cs
+++ b/Reaqtor/Core/Engine/Reaqtor.QueryEngine/Reaqtor/QueryEngine/CheckpointingQueryEngine.ReadOnlyMetadataServiceContext.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Engine/Reaqtor.QueryEngine/Reaqtor/QueryEngine/CheckpointingQueryEngine.ReliableServiceContext.cs
+++ b/Reaqtor/Core/Engine/Reaqtor.QueryEngine/Reaqtor/QueryEngine/CheckpointingQueryEngine.ReliableServiceContext.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Engine/Reaqtor.QueryEngine/Reaqtor/QueryEngine/CheckpointingQueryEngine.ServiceContext.cs
+++ b/Reaqtor/Core/Engine/Reaqtor.QueryEngine/Reaqtor/QueryEngine/CheckpointingQueryEngine.ServiceContext.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Engine/Reaqtor.QueryEngine/Reaqtor/QueryEngine/CheckpointingQueryEngine.cs
+++ b/Reaqtor/Core/Engine/Reaqtor.QueryEngine/Reaqtor/QueryEngine/CheckpointingQueryEngine.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Engine/Reaqtor.QueryEngine/Reaqtor/QueryEngine/ConfigurationOptions.cs
+++ b/Reaqtor/Core/Engine/Reaqtor.QueryEngine/Reaqtor/QueryEngine/ConfigurationOptions.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Engine/Reaqtor.QueryEngine/Reaqtor/QueryEngine/Edges/EdgeCleanup.cs
+++ b/Reaqtor/Core/Engine/Reaqtor.QueryEngine/Reaqtor/QueryEngine/Edges/EdgeCleanup.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Engine/Reaqtor.QueryEngine/Reaqtor/QueryEngine/Edges/EdgeDescription.cs
+++ b/Reaqtor/Core/Engine/Reaqtor.QueryEngine/Reaqtor/QueryEngine/Edges/EdgeDescription.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Engine/Reaqtor.QueryEngine/Reaqtor/QueryEngine/Edges/EdgeRewriter.cs
+++ b/Reaqtor/Core/Engine/Reaqtor.QueryEngine/Reaqtor/QueryEngine/Edges/EdgeRewriter.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Engine/Reaqtor.QueryEngine/Reaqtor/QueryEngine/Edges/OutputEdge.cs
+++ b/Reaqtor/Core/Engine/Reaqtor.QueryEngine/Reaqtor/QueryEngine/Edges/OutputEdge.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Engine/Reaqtor.QueryEngine/Reaqtor/QueryEngine/Events/EventInvocationHelpers.cs
+++ b/Reaqtor/Core/Engine/Reaqtor.QueryEngine/Reaqtor/QueryEngine/Events/EventInvocationHelpers.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Engine/Reaqtor.QueryEngine/Reaqtor/QueryEngine/Events/MitigationBailOutException.cs
+++ b/Reaqtor/Core/Engine/Reaqtor.QueryEngine/Reaqtor/QueryEngine/Events/MitigationBailOutException.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Engine/Reaqtor.QueryEngine/Reaqtor/QueryEngine/Events/ObservableEventArgs.cs
+++ b/Reaqtor/Core/Engine/Reaqtor.QueryEngine/Reaqtor/QueryEngine/Events/ObservableEventArgs.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Engine/Reaqtor.QueryEngine/Reaqtor/QueryEngine/Events/ObserverEventArgs.cs
+++ b/Reaqtor/Core/Engine/Reaqtor.QueryEngine/Reaqtor/QueryEngine/Events/ObserverEventArgs.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Engine/Reaqtor.QueryEngine/Reaqtor/QueryEngine/Events/ReactiveEntityEventArgs.cs
+++ b/Reaqtor/Core/Engine/Reaqtor.QueryEngine/Reaqtor/QueryEngine/Events/ReactiveEntityEventArgs.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Engine/Reaqtor.QueryEngine/Reaqtor/QueryEngine/Events/ReactiveEntityLoadFailedEventArgs.cs
+++ b/Reaqtor/Core/Engine/Reaqtor.QueryEngine/Reaqtor/QueryEngine/Events/ReactiveEntityLoadFailedEventArgs.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Engine/Reaqtor.QueryEngine/Reaqtor/QueryEngine/Events/ReactiveEntityRecoveryFailureMitigation.cs
+++ b/Reaqtor/Core/Engine/Reaqtor.QueryEngine/Reaqtor/QueryEngine/Events/ReactiveEntityRecoveryFailureMitigation.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Engine/Reaqtor.QueryEngine/Reaqtor/QueryEngine/Events/ReactiveEntityRecoveryFailureMitigator.cs
+++ b/Reaqtor/Core/Engine/Reaqtor.QueryEngine/Reaqtor/QueryEngine/Events/ReactiveEntityRecoveryFailureMitigator.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Engine/Reaqtor.QueryEngine/Reaqtor/QueryEngine/Events/ReactiveEntityReplayFailedEventArgs.cs
+++ b/Reaqtor/Core/Engine/Reaqtor.QueryEngine/Reaqtor/QueryEngine/Events/ReactiveEntityReplayFailedEventArgs.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Engine/Reaqtor.QueryEngine/Reaqtor/QueryEngine/Events/ReactiveEntitySaveFailedEventArgs.cs
+++ b/Reaqtor/Core/Engine/Reaqtor.QueryEngine/Reaqtor/QueryEngine/Events/ReactiveEntitySaveFailedEventArgs.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Engine/Reaqtor.QueryEngine/Reaqtor/QueryEngine/Events/ReliableSubscriptionEventArgs.cs
+++ b/Reaqtor/Core/Engine/Reaqtor.QueryEngine/Reaqtor/QueryEngine/Events/ReliableSubscriptionEventArgs.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Engine/Reaqtor.QueryEngine/Reaqtor/QueryEngine/Events/SchedulerContinuedEventArgs.cs
+++ b/Reaqtor/Core/Engine/Reaqtor.QueryEngine/Reaqtor/QueryEngine/Events/SchedulerContinuedEventArgs.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Engine/Reaqtor.QueryEngine/Reaqtor/QueryEngine/Events/SchedulerContinuingEventArgs.cs
+++ b/Reaqtor/Core/Engine/Reaqtor.QueryEngine/Reaqtor/QueryEngine/Events/SchedulerContinuingEventArgs.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Engine/Reaqtor.QueryEngine/Reaqtor/QueryEngine/Events/SchedulerPausedEventArgs.cs
+++ b/Reaqtor/Core/Engine/Reaqtor.QueryEngine/Reaqtor/QueryEngine/Events/SchedulerPausedEventArgs.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Engine/Reaqtor.QueryEngine/Reaqtor/QueryEngine/Events/SchedulerPausingEventArgs.cs
+++ b/Reaqtor/Core/Engine/Reaqtor.QueryEngine/Reaqtor/QueryEngine/Events/SchedulerPausingEventArgs.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Engine/Reaqtor.QueryEngine/Reaqtor/QueryEngine/Events/StreamEventArgs.cs
+++ b/Reaqtor/Core/Engine/Reaqtor.QueryEngine/Reaqtor/QueryEngine/Events/StreamEventArgs.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Engine/Reaqtor.QueryEngine/Reaqtor/QueryEngine/Events/StreamFactoryEventArgs.cs
+++ b/Reaqtor/Core/Engine/Reaqtor.QueryEngine/Reaqtor/QueryEngine/Events/StreamFactoryEventArgs.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Engine/Reaqtor.QueryEngine/Reaqtor/QueryEngine/Events/SubscriptionEventArgs.cs
+++ b/Reaqtor/Core/Engine/Reaqtor.QueryEngine/Reaqtor/QueryEngine/Events/SubscriptionEventArgs.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Engine/Reaqtor.QueryEngine/Reaqtor/QueryEngine/Events/SubscriptionFactoryEventArgs.cs
+++ b/Reaqtor/Core/Engine/Reaqtor.QueryEngine/Reaqtor/QueryEngine/Events/SubscriptionFactoryEventArgs.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Engine/Reaqtor.QueryEngine/Reaqtor/QueryEngine/Exceptions/EngineUnloadedException.cs
+++ b/Reaqtor/Core/Engine/Reaqtor.QueryEngine/Reaqtor/QueryEngine/Exceptions/EngineUnloadedException.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Engine/Reaqtor.QueryEngine/Reaqtor/QueryEngine/Exceptions/EntityAlreadyExistsException.cs
+++ b/Reaqtor/Core/Engine/Reaqtor.QueryEngine/Reaqtor/QueryEngine/Exceptions/EntityAlreadyExistsException.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Engine/Reaqtor.QueryEngine/Reaqtor/QueryEngine/Exceptions/EntityLoadFailedException.cs
+++ b/Reaqtor/Core/Engine/Reaqtor.QueryEngine/Reaqtor/QueryEngine/Exceptions/EntityLoadFailedException.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Engine/Reaqtor.QueryEngine/Reaqtor/QueryEngine/Exceptions/EntityNotFoundException.cs
+++ b/Reaqtor/Core/Engine/Reaqtor.QueryEngine/Reaqtor/QueryEngine/Exceptions/EntityNotFoundException.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Engine/Reaqtor.QueryEngine/Reaqtor/QueryEngine/Exceptions/EntitySaveFailedException.cs
+++ b/Reaqtor/Core/Engine/Reaqtor.QueryEngine/Reaqtor/QueryEngine/Exceptions/EntitySaveFailedException.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Engine/Reaqtor.QueryEngine/Reaqtor/QueryEngine/ExpressionPolicy.cs
+++ b/Reaqtor/Core/Engine/Reaqtor.QueryEngine/Reaqtor/QueryEngine/ExpressionPolicy.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Engine/Reaqtor.QueryEngine/Reaqtor/QueryEngine/HostedOperatorContext.cs
+++ b/Reaqtor/Core/Engine/Reaqtor.QueryEngine/Reaqtor/QueryEngine/HostedOperatorContext.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Engine/Reaqtor.QueryEngine/Reaqtor/QueryEngine/IUnloadable.cs
+++ b/Reaqtor/Core/Engine/Reaqtor.QueryEngine/Reaqtor/QueryEngine/IUnloadable.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Engine/Reaqtor.QueryEngine/Reaqtor/QueryEngine/Invariant.cs
+++ b/Reaqtor/Core/Engine/Reaqtor.QueryEngine/Reaqtor/QueryEngine/Invariant.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Engine/Reaqtor.QueryEngine/Reaqtor/QueryEngine/InvariantException.cs
+++ b/Reaqtor/Core/Engine/Reaqtor.QueryEngine/Reaqtor/QueryEngine/InvariantException.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Engine/Reaqtor.QueryEngine/Reaqtor/QueryEngine/KeyValueStore/SerializingKeyValueTable.cs
+++ b/Reaqtor/Core/Engine/Reaqtor.QueryEngine/Reaqtor/QueryEngine/KeyValueStore/SerializingKeyValueTable.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Engine/Reaqtor.QueryEngine/Reaqtor/QueryEngine/KeyValueStore/TransactedKeyValueTable.cs
+++ b/Reaqtor/Core/Engine/Reaqtor.QueryEngine/Reaqtor/QueryEngine/KeyValueStore/TransactedKeyValueTable.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Engine/Reaqtor.QueryEngine/Reaqtor/QueryEngine/KeyValueStore/Transaction.cs
+++ b/Reaqtor/Core/Engine/Reaqtor.QueryEngine/Reaqtor/QueryEngine/KeyValueStore/Transaction.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Engine/Reaqtor.QueryEngine/Reaqtor/QueryEngine/Metrics/EntityMetric.cs
+++ b/Reaqtor/Core/Engine/Reaqtor.QueryEngine/Reaqtor/QueryEngine/Metrics/EntityMetric.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Engine/Reaqtor.QueryEngine/Reaqtor/QueryEngine/Metrics/EntityMetricsTracker.cs
+++ b/Reaqtor/Core/Engine/Reaqtor.QueryEngine/Reaqtor/QueryEngine/Metrics/EntityMetricsTracker.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Engine/Reaqtor.QueryEngine/Reaqtor/QueryEngine/OperationTracker.cs
+++ b/Reaqtor/Core/Engine/Reaqtor.QueryEngine/Reaqtor/QueryEngine/OperationTracker.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Engine/Reaqtor.QueryEngine/Reaqtor/QueryEngine/Persistence/EntityReader.cs
+++ b/Reaqtor/Core/Engine/Reaqtor.QueryEngine/Reaqtor/QueryEngine/Persistence/EntityReader.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Engine/Reaqtor.QueryEngine/Reaqtor/QueryEngine/Persistence/EntityWriter.cs
+++ b/Reaqtor/Core/Engine/Reaqtor.QueryEngine/Reaqtor/QueryEngine/Persistence/EntityWriter.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Engine/Reaqtor.QueryEngine/Reaqtor/QueryEngine/Persistence/OperatorStateReader.cs
+++ b/Reaqtor/Core/Engine/Reaqtor.QueryEngine/Reaqtor/QueryEngine/Persistence/OperatorStateReader.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Engine/Reaqtor.QueryEngine/Reaqtor/QueryEngine/Persistence/OperatorStateWriter.cs
+++ b/Reaqtor/Core/Engine/Reaqtor.QueryEngine/Reaqtor/QueryEngine/Persistence/OperatorStateWriter.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Engine/Reaqtor.QueryEngine/Reaqtor/QueryEngine/Persistence/ReaderBase.cs
+++ b/Reaqtor/Core/Engine/Reaqtor.QueryEngine/Reaqtor/QueryEngine/Persistence/ReaderBase.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Engine/Reaqtor.QueryEngine/Reaqtor/QueryEngine/Persistence/WriterBase.cs
+++ b/Reaqtor/Core/Engine/Reaqtor.QueryEngine/Reaqtor/QueryEngine/Persistence/WriterBase.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Engine/Reaqtor.QueryEngine/Reaqtor/QueryEngine/QueryEngineConstants.cs
+++ b/Reaqtor/Core/Engine/Reaqtor.QueryEngine/Reaqtor/QueryEngine/QueryEngineConstants.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Engine/Reaqtor.QueryEngine/Reaqtor/QueryEngine/QueryEngineStatus.cs
+++ b/Reaqtor/Core/Engine/Reaqtor.QueryEngine/Reaqtor/QueryEngine/QueryEngineStatus.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Engine/Reaqtor.QueryEngine/Reaqtor/QueryEngine/QuotedTypeConversionTargets.cs
+++ b/Reaqtor/Core/Engine/Reaqtor.QueryEngine/Reaqtor/QueryEngine/QuotedTypeConversionTargets.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Engine/Reaqtor.QueryEngine/Reaqtor/QueryEngine/Registry/ChainedLookupReactiveEntityCollection.cs
+++ b/Reaqtor/Core/Engine/Reaqtor.QueryEngine/Reaqtor/QueryEngine/Registry/ChainedLookupReactiveEntityCollection.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Engine/Reaqtor.QueryEngine/Reaqtor/QueryEngine/Registry/CooperativeLookupReactiveEntityCollection.cs
+++ b/Reaqtor/Core/Engine/Reaqtor.QueryEngine/Reaqtor/QueryEngine/Registry/CooperativeLookupReactiveEntityCollection.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Engine/Reaqtor.QueryEngine/Reaqtor/QueryEngine/Registry/Entities/DefinitionEntity.cs
+++ b/Reaqtor/Core/Engine/Reaqtor.QueryEngine/Reaqtor/QueryEngine/Registry/Entities/DefinitionEntity.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Engine/Reaqtor.QueryEngine/Reaqtor/QueryEngine/Registry/Entities/ObservableDefinitionEntity.cs
+++ b/Reaqtor/Core/Engine/Reaqtor.QueryEngine/Reaqtor/QueryEngine/Registry/Entities/ObservableDefinitionEntity.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Engine/Reaqtor.QueryEngine/Reaqtor/QueryEngine/Registry/Entities/ObserverDefinitionEntity.cs
+++ b/Reaqtor/Core/Engine/Reaqtor.QueryEngine/Reaqtor/QueryEngine/Registry/Entities/ObserverDefinitionEntity.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Engine/Reaqtor.QueryEngine/Reaqtor/QueryEngine/Registry/Entities/OtherDefinitionEntity.cs
+++ b/Reaqtor/Core/Engine/Reaqtor.QueryEngine/Reaqtor/QueryEngine/Registry/Entities/OtherDefinitionEntity.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Engine/Reaqtor.QueryEngine/Reaqtor/QueryEngine/Registry/Entities/ReactiveEntity.cs
+++ b/Reaqtor/Core/Engine/Reaqtor.QueryEngine/Reaqtor/QueryEngine/Registry/Entities/ReactiveEntity.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Engine/Reaqtor.QueryEngine/Reaqtor/QueryEngine/Registry/Entities/ReactiveEntityKind.cs
+++ b/Reaqtor/Core/Engine/Reaqtor.QueryEngine/Reaqtor/QueryEngine/Registry/Entities/ReactiveEntityKind.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Engine/Reaqtor.QueryEngine/Reaqtor/QueryEngine/Registry/Entities/ReliableSubscriptionEntity.cs
+++ b/Reaqtor/Core/Engine/Reaqtor.QueryEngine/Reaqtor/QueryEngine/Registry/Entities/ReliableSubscriptionEntity.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Engine/Reaqtor.QueryEngine/Reaqtor/QueryEngine/Registry/Entities/RuntimeEntity.cs
+++ b/Reaqtor/Core/Engine/Reaqtor.QueryEngine/Reaqtor/QueryEngine/Registry/Entities/RuntimeEntity.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Engine/Reaqtor.QueryEngine/Reaqtor/QueryEngine/Registry/Entities/StreamFactoryDefinitionEntity.cs
+++ b/Reaqtor/Core/Engine/Reaqtor.QueryEngine/Reaqtor/QueryEngine/Registry/Entities/StreamFactoryDefinitionEntity.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Engine/Reaqtor.QueryEngine/Reaqtor/QueryEngine/Registry/Entities/SubjectEntity.cs
+++ b/Reaqtor/Core/Engine/Reaqtor.QueryEngine/Reaqtor/QueryEngine/Registry/Entities/SubjectEntity.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Engine/Reaqtor.QueryEngine/Reaqtor/QueryEngine/Registry/Entities/SubscriptionEntity.cs
+++ b/Reaqtor/Core/Engine/Reaqtor.QueryEngine/Reaqtor/QueryEngine/Registry/Entities/SubscriptionEntity.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Engine/Reaqtor.QueryEngine/Reaqtor/QueryEngine/Registry/Entities/SubscriptionFactoryDefinitionEntity.cs
+++ b/Reaqtor/Core/Engine/Reaqtor.QueryEngine/Reaqtor/QueryEngine/Registry/Entities/SubscriptionFactoryDefinitionEntity.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Engine/Reaqtor.QueryEngine/Reaqtor/QueryEngine/Registry/Interfaces/IInvertedLookupReactiveEntityCollection.cs
+++ b/Reaqtor/Core/Engine/Reaqtor.QueryEngine/Reaqtor/QueryEngine/Registry/Interfaces/IInvertedLookupReactiveEntityCollection.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Engine/Reaqtor.QueryEngine/Reaqtor/QueryEngine/Registry/Interfaces/ILoggedQueryEngineRegistry.cs
+++ b/Reaqtor/Core/Engine/Reaqtor.QueryEngine/Reaqtor/QueryEngine/Registry/Interfaces/ILoggedQueryEngineRegistry.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Engine/Reaqtor.QueryEngine/Reaqtor/QueryEngine/Registry/Interfaces/IQueryEngineRegistry.cs
+++ b/Reaqtor/Core/Engine/Reaqtor.QueryEngine/Reaqtor/QueryEngine/Registry/Interfaces/IQueryEngineRegistry.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Engine/Reaqtor.QueryEngine/Reaqtor/QueryEngine/Registry/Interfaces/IQueryEngineRegistrySnapshot.cs
+++ b/Reaqtor/Core/Engine/Reaqtor.QueryEngine/Reaqtor/QueryEngine/Registry/Interfaces/IQueryEngineRegistrySnapshot.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Engine/Reaqtor.QueryEngine/Reaqtor/QueryEngine/Registry/Interfaces/IReactiveEntityCollection.cs
+++ b/Reaqtor/Core/Engine/Reaqtor.QueryEngine/Reaqtor/QueryEngine/Registry/Interfaces/IReactiveEntityCollection.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Engine/Reaqtor.QueryEngine/Reaqtor/QueryEngine/Registry/Interfaces/IReadOnlyReactiveEntityCollection.cs
+++ b/Reaqtor/Core/Engine/Reaqtor.QueryEngine/Reaqtor/QueryEngine/Registry/Interfaces/IReadOnlyReactiveEntityCollection.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Engine/Reaqtor.QueryEngine/Reaqtor/QueryEngine/Registry/InvertedDefinitionEntityComparer.cs
+++ b/Reaqtor/Core/Engine/Reaqtor.QueryEngine/Reaqtor/QueryEngine/Registry/InvertedDefinitionEntityComparer.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Engine/Reaqtor.QueryEngine/Reaqtor/QueryEngine/Registry/InvertedLookupReactiveEntityCollection.cs
+++ b/Reaqtor/Core/Engine/Reaqtor.QueryEngine/Reaqtor/QueryEngine/Registry/InvertedLookupReactiveEntityCollection.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Engine/Reaqtor.QueryEngine/Reaqtor/QueryEngine/Registry/QueryEngineRegistry.cs
+++ b/Reaqtor/Core/Engine/Reaqtor.QueryEngine/Reaqtor/QueryEngine/Registry/QueryEngineRegistry.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Engine/Reaqtor.QueryEngine/Reaqtor/QueryEngine/Registry/QueryEngineRegistryTemplatizer.cs
+++ b/Reaqtor/Core/Engine/Reaqtor.QueryEngine/Reaqtor/QueryEngine/Registry/QueryEngineRegistryTemplatizer.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Engine/Reaqtor.QueryEngine/Reaqtor/QueryEngine/Registry/ReactiveEntityCollection.cs
+++ b/Reaqtor/Core/Engine/Reaqtor.QueryEngine/Reaqtor/QueryEngine/Registry/ReactiveEntityCollection.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Engine/Reaqtor.QueryEngine/Reaqtor/QueryEngine/Registry/ReadOnlyReactiveEntityCollection.cs
+++ b/Reaqtor/Core/Engine/Reaqtor.QueryEngine/Reaqtor/QueryEngine/Registry/ReadOnlyReactiveEntityCollection.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Engine/Reaqtor.QueryEngine/Reaqtor/QueryEngine/ReliableMultiSubjectExtensions.cs
+++ b/Reaqtor/Core/Engine/Reaqtor.QueryEngine/Reaqtor/QueryEngine/ReliableMultiSubjectExtensions.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Engine/Reaqtor.QueryEngine/Reaqtor/QueryEngine/ReliableObservableExtensions.cs
+++ b/Reaqtor/Core/Engine/Reaqtor.QueryEngine/Reaqtor/QueryEngine/ReliableObservableExtensions.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Engine/Reaqtor.QueryEngine/Reaqtor/QueryEngine/ReliableSentinels.cs
+++ b/Reaqtor/Core/Engine/Reaqtor.QueryEngine/Reaqtor/QueryEngine/ReliableSentinels.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Engine/Reaqtor.QueryEngine/Reaqtor/QueryEngine/Runtime/BridgeCleanupException.cs
+++ b/Reaqtor/Core/Engine/Reaqtor.QueryEngine/Reaqtor/QueryEngine/Runtime/BridgeCleanupException.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Engine/Reaqtor.QueryEngine/Reaqtor/QueryEngine/Runtime/BridgeVersion.cs
+++ b/Reaqtor/Core/Engine/Reaqtor.QueryEngine/Reaqtor/QueryEngine/Runtime/BridgeVersion.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Engine/Reaqtor.QueryEngine/Reaqtor/QueryEngine/Runtime/InnerSubject.cs
+++ b/Reaqtor/Core/Engine/Reaqtor.QueryEngine/Reaqtor/QueryEngine/Runtime/InnerSubject.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Engine/Reaqtor.QueryEngine/Reaqtor/QueryEngine/Runtime/MultiObserver.cs
+++ b/Reaqtor/Core/Engine/Reaqtor.QueryEngine/Reaqtor/QueryEngine/Runtime/MultiObserver.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Engine/Reaqtor.QueryEngine/Reaqtor/QueryEngine/Runtime/ObserverToReliableObserver.cs
+++ b/Reaqtor/Core/Engine/Reaqtor.QueryEngine/Reaqtor/QueryEngine/Runtime/ObserverToReliableObserver.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Engine/Reaqtor.QueryEngine/Reaqtor/QueryEngine/Runtime/RefCountSubject.cs
+++ b/Reaqtor/Core/Engine/Reaqtor.QueryEngine/Reaqtor/QueryEngine/Runtime/RefCountSubject.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Engine/Reaqtor.QueryEngine/Reaqtor/QueryEngine/Runtime/ReliableSubscriptionInput.cs
+++ b/Reaqtor/Core/Engine/Reaqtor.QueryEngine/Reaqtor/QueryEngine/Runtime/ReliableSubscriptionInput.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Engine/Reaqtor.QueryEngine/Reaqtor/QueryEngine/SubscribableExtensions.cs
+++ b/Reaqtor/Core/Engine/Reaqtor.QueryEngine/Reaqtor/QueryEngine/SubscribableExtensions.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Engine/Reaqtor.QueryEngine/Reaqtor/QueryEngine/TraceNoun.cs
+++ b/Reaqtor/Core/Engine/Reaqtor.QueryEngine/Reaqtor/QueryEngine/TraceNoun.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Engine/Reaqtor.QueryEngine/Reaqtor/QueryEngine/TraceVerb.cs
+++ b/Reaqtor/Core/Engine/Reaqtor.QueryEngine/Reaqtor/QueryEngine/TraceVerb.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Engine/Reaqtor.QueryEngine/Reaqtor/QueryEngine/TransactionLog/ArtifactOperation.cs
+++ b/Reaqtor/Core/Engine/Reaqtor.QueryEngine/Reaqtor/QueryEngine/TransactionLog/ArtifactOperation.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Engine/Reaqtor.QueryEngine/Reaqtor/QueryEngine/TransactionLog/ArtifactOperationKind.cs
+++ b/Reaqtor/Core/Engine/Reaqtor.QueryEngine/Reaqtor/QueryEngine/TransactionLog/ArtifactOperationKind.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Engine/Reaqtor.QueryEngine/Reaqtor/QueryEngine/TransactionLog/IReplayTransactionLog.cs
+++ b/Reaqtor/Core/Engine/Reaqtor.QueryEngine/Reaqtor/QueryEngine/TransactionLog/IReplayTransactionLog.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Engine/Reaqtor.QueryEngine/Reaqtor/QueryEngine/TransactionLog/IScopedTransactionLog.cs
+++ b/Reaqtor/Core/Engine/Reaqtor.QueryEngine/Reaqtor/QueryEngine/TransactionLog/IScopedTransactionLog.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Engine/Reaqtor.QueryEngine/Reaqtor/QueryEngine/TransactionLog/ITransactionLog.cs
+++ b/Reaqtor/Core/Engine/Reaqtor.QueryEngine/Reaqtor/QueryEngine/TransactionLog/ITransactionLog.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Engine/Reaqtor.QueryEngine/Reaqtor/QueryEngine/TransactionLog/TransactionLog.cs
+++ b/Reaqtor/Core/Engine/Reaqtor.QueryEngine/Reaqtor/QueryEngine/TransactionLog/TransactionLog.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Engine/Reaqtor.QueryEngine/Reaqtor/QueryEngine/TransactionLog/TransactionLogManager.cs
+++ b/Reaqtor/Core/Engine/Reaqtor.QueryEngine/Reaqtor/QueryEngine/TransactionLog/TransactionLogManager.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Engine/Reaqtor.QueryEngine/Reaqtor/QueryEngine/TransactionLog/TransactionLogOperationReader.cs
+++ b/Reaqtor/Core/Engine/Reaqtor.QueryEngine/Reaqtor/QueryEngine/TransactionLog/TransactionLogOperationReader.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Engine/Reaqtor.QueryEngine/Reaqtor/QueryEngine/TransactionLog/TransactionLogOperationWriter.cs
+++ b/Reaqtor/Core/Engine/Reaqtor.QueryEngine/Reaqtor/QueryEngine/TransactionLog/TransactionLogOperationWriter.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Engine/Reaqtor.QueryEngine/Reaqtor/QueryEngine/TransactionLog/TransactionState.cs
+++ b/Reaqtor/Core/Engine/Reaqtor.QueryEngine/Reaqtor/QueryEngine/TransactionLog/TransactionState.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Engine/Reaqtor.QueryEngine/Reaqtor/QueryEngine/TransactionLog/TransactionStateVersion.cs
+++ b/Reaqtor/Core/Engine/Reaqtor.QueryEngine/Reaqtor/QueryEngine/TransactionLog/TransactionStateVersion.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Engine/Reaqtor.QueryEngine/Reaqtor/QueryEngine/Utils.cs
+++ b/Reaqtor/Core/Engine/Reaqtor.QueryEngine/Reaqtor/QueryEngine/Utils.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Engine/Reaqtor.QueryEngine/System/ControlFlow/Control.cs
+++ b/Reaqtor/Core/Engine/Reaqtor.QueryEngine/System/ControlFlow/Control.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Engine/Reaqtor.QueryEngine/System/Diagnostics/IStopwatch.cs
+++ b/Reaqtor/Core/Engine/Reaqtor.QueryEngine/System/Diagnostics/IStopwatch.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Engine/Reaqtor.QueryEngine/System/Diagnostics/StopwatchExtensions.cs
+++ b/Reaqtor/Core/Engine/Reaqtor.QueryEngine/System/Diagnostics/StopwatchExtensions.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Engine/Reaqtor.QueryEngine/System/Diagnostics/StopwatchImpl.cs
+++ b/Reaqtor/Core/Engine/Reaqtor.QueryEngine/System/Diagnostics/StopwatchImpl.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Engine/Reaqtor.QueryEngine/System/Progress.cs
+++ b/Reaqtor/Core/Engine/Reaqtor.QueryEngine/System/Progress.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Engine/Reaqtor.QueryEngine/System/Threading/AsyncLock.cs
+++ b/Reaqtor/Core/Engine/Reaqtor.QueryEngine/System/Threading/AsyncLock.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Engine/Reaqtor.QueryEngine/System/Threading/AsyncReaderWriterLock.cs
+++ b/Reaqtor/Core/Engine/Reaqtor.QueryEngine/System/Threading/AsyncReaderWriterLock.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Engine/Reaqtor.QueryEngine/TestVisibility.cs
+++ b/Reaqtor/Core/Engine/Reaqtor.QueryEngine/TestVisibility.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Engine/Reaqtor.QueryEngine/Versioning.cs
+++ b/Reaqtor/Core/Engine/Reaqtor.QueryEngine/Versioning.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Engine/Tests.Reaqtor.QueryEngine/CheckpointableStateManagerTests.cs
+++ b/Reaqtor/Core/Engine/Tests.Reaqtor.QueryEngine/CheckpointableStateManagerTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Engine/Tests.Reaqtor.QueryEngine/CheckpointableTests.cs
+++ b/Reaqtor/Core/Engine/Tests.Reaqtor.QueryEngine/CheckpointableTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Engine/Tests.Reaqtor.QueryEngine/ConfigurationOptionsTests.cs
+++ b/Reaqtor/Core/Engine/Tests.Reaqtor.QueryEngine/ConfigurationOptionsTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Engine/Tests.Reaqtor.QueryEngine/ControlFlowTests.cs
+++ b/Reaqtor/Core/Engine/Tests.Reaqtor.QueryEngine/ControlFlowTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Engine/Tests.Reaqtor.QueryEngine/EntityMetricsTrackerTests.cs
+++ b/Reaqtor/Core/Engine/Tests.Reaqtor.QueryEngine/EntityMetricsTrackerTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Engine/Tests.Reaqtor.QueryEngine/EntityReaderWriterTests.cs
+++ b/Reaqtor/Core/Engine/Tests.Reaqtor.QueryEngine/EntityReaderWriterTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Engine/Tests.Reaqtor.QueryEngine/EntityTests.cs
+++ b/Reaqtor/Core/Engine/Tests.Reaqtor.QueryEngine/EntityTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Engine/Tests.Reaqtor.QueryEngine/ExceptionTests.cs
+++ b/Reaqtor/Core/Engine/Tests.Reaqtor.QueryEngine/ExceptionTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Engine/Tests.Reaqtor.QueryEngine/ExpressionPolicyTests.cs
+++ b/Reaqtor/Core/Engine/Tests.Reaqtor.QueryEngine/ExpressionPolicyTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Engine/Tests.Reaqtor.QueryEngine/InMemoryKeyValueStoreTests.cs
+++ b/Reaqtor/Core/Engine/Tests.Reaqtor.QueryEngine/InMemoryKeyValueStoreTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Engine/Tests.Reaqtor.QueryEngine/InMemoryStorageTests.cs
+++ b/Reaqtor/Core/Engine/Tests.Reaqtor.QueryEngine/InMemoryStorageTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Engine/Tests.Reaqtor.QueryEngine/InnerSubjectTests.cs
+++ b/Reaqtor/Core/Engine/Tests.Reaqtor.QueryEngine/InnerSubjectTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Engine/Tests.Reaqtor.QueryEngine/InvertedLookupReactiveEntityCollectionTests.cs
+++ b/Reaqtor/Core/Engine/Tests.Reaqtor.QueryEngine/InvertedLookupReactiveEntityCollectionTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Engine/Tests.Reaqtor.QueryEngine/MultiObserverTests.cs
+++ b/Reaqtor/Core/Engine/Tests.Reaqtor.QueryEngine/MultiObserverTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Engine/Tests.Reaqtor.QueryEngine/OneQueryEngineSanityTests.cs
+++ b/Reaqtor/Core/Engine/Tests.Reaqtor.QueryEngine/OneQueryEngineSanityTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Engine/Tests.Reaqtor.QueryEngine/OperationTrackerTests.cs
+++ b/Reaqtor/Core/Engine/Tests.Reaqtor.QueryEngine/OperationTrackerTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Engine/Tests.Reaqtor.QueryEngine/Operators/FirstAsync.cs
+++ b/Reaqtor/Core/Engine/Tests.Reaqtor.QueryEngine/Operators/FirstAsync.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Engine/Tests.Reaqtor.QueryEngine/Operators/PeriodicTimer.cs
+++ b/Reaqtor/Core/Engine/Tests.Reaqtor.QueryEngine/Operators/PeriodicTimer.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Engine/Tests.Reaqtor.QueryEngine/Operators/SkipUntil.cs
+++ b/Reaqtor/Core/Engine/Tests.Reaqtor.QueryEngine/Operators/SkipUntil.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Engine/Tests.Reaqtor.QueryEngine/Operators/StartWith.cs
+++ b/Reaqtor/Core/Engine/Tests.Reaqtor.QueryEngine/Operators/StartWith.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Engine/Tests.Reaqtor.QueryEngine/Operators/SubscribeOnScheduler.cs
+++ b/Reaqtor/Core/Engine/Tests.Reaqtor.QueryEngine/Operators/SubscribeOnScheduler.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Engine/Tests.Reaqtor.QueryEngine/Operators/TakeUntil.cs
+++ b/Reaqtor/Core/Engine/Tests.Reaqtor.QueryEngine/Operators/TakeUntil.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Engine/Tests.Reaqtor.QueryEngine/Operators/TakeWhile.cs
+++ b/Reaqtor/Core/Engine/Tests.Reaqtor.QueryEngine/Operators/TakeWhile.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Engine/Tests.Reaqtor.QueryEngine/Operators/TestOperators.cs
+++ b/Reaqtor/Core/Engine/Tests.Reaqtor.QueryEngine/Operators/TestOperators.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Engine/Tests.Reaqtor.QueryEngine/Operators/Timer.cs
+++ b/Reaqtor/Core/Engine/Tests.Reaqtor.QueryEngine/Operators/Timer.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Engine/Tests.Reaqtor.QueryEngine/PerformanceTests.cs
+++ b/Reaqtor/Core/Engine/Tests.Reaqtor.QueryEngine/PerformanceTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Engine/Tests.Reaqtor.QueryEngine/ProgressTests.cs
+++ b/Reaqtor/Core/Engine/Tests.Reaqtor.QueryEngine/ProgressTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Engine/Tests.Reaqtor.QueryEngine/QueryEngineBinderTests.cs
+++ b/Reaqtor/Core/Engine/Tests.Reaqtor.QueryEngine/QueryEngineBinderTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Engine/Tests.Reaqtor.QueryEngine/QueryEngineEventsTests.cs
+++ b/Reaqtor/Core/Engine/Tests.Reaqtor.QueryEngine/QueryEngineEventsTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Engine/Tests.Reaqtor.QueryEngine/QueryEngineRegistryTemplatizerTests.cs
+++ b/Reaqtor/Core/Engine/Tests.Reaqtor.QueryEngine/QueryEngineRegistryTemplatizerTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Engine/Tests.Reaqtor.QueryEngine/QueryEngineRegistryTests.cs
+++ b/Reaqtor/Core/Engine/Tests.Reaqtor.QueryEngine/QueryEngineRegistryTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Engine/Tests.Reaqtor.QueryEngine/QueryEngineTest.cs
+++ b/Reaqtor/Core/Engine/Tests.Reaqtor.QueryEngine/QueryEngineTest.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Engine/Tests.Reaqtor.QueryEngine/QuoterTests.cs
+++ b/Reaqtor/Core/Engine/Tests.Reaqtor.QueryEngine/QuoterTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Engine/Tests.Reaqtor.QueryEngine/ReactiveEntityCollectionTests.cs
+++ b/Reaqtor/Core/Engine/Tests.Reaqtor.QueryEngine/ReactiveEntityCollectionTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Engine/Tests.Reaqtor.QueryEngine/ReaderBaseTests.cs
+++ b/Reaqtor/Core/Engine/Tests.Reaqtor.QueryEngine/ReaderBaseTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Engine/Tests.Reaqtor.QueryEngine/ReliableMultiSubjectProxyTests.cs
+++ b/Reaqtor/Core/Engine/Tests.Reaqtor.QueryEngine/ReliableMultiSubjectProxyTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Engine/Tests.Reaqtor.QueryEngine/ReliableSentinelsTests.cs
+++ b/Reaqtor/Core/Engine/Tests.Reaqtor.QueryEngine/ReliableSentinelsTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Engine/Tests.Reaqtor.QueryEngine/StateWriterExtensionsTests.cs
+++ b/Reaqtor/Core/Engine/Tests.Reaqtor.QueryEngine/StateWriterExtensionsTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Engine/Tests.Reaqtor.QueryEngine/StreamSegmentTests.cs
+++ b/Reaqtor/Core/Engine/Tests.Reaqtor.QueryEngine/StreamSegmentTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Engine/Tests.Reaqtor.QueryEngine/TemplatizationHelpersTests.cs
+++ b/Reaqtor/Core/Engine/Tests.Reaqtor.QueryEngine/TemplatizationHelpersTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Engine/Tests.Reaqtor.QueryEngine/TestObserverExtensions.cs
+++ b/Reaqtor/Core/Engine/Tests.Reaqtor.QueryEngine/TestObserverExtensions.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Engine/Tests.Reaqtor.QueryEngine/TwoQueryEnginesSanityTests.cs
+++ b/Reaqtor/Core/Engine/Tests.Reaqtor.QueryEngine/TwoQueryEnginesSanityTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Engine/Tests.Reaqtor.QueryEngine/Utils/ClientDefinitions.cs
+++ b/Reaqtor/Core/Engine/Tests.Reaqtor.QueryEngine/Utils/ClientDefinitions.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Engine/Tests.Reaqtor.QueryEngine/Utils/EngineTestExtensions.cs
+++ b/Reaqtor/Core/Engine/Tests.Reaqtor.QueryEngine/Utils/EngineTestExtensions.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Engine/Tests.Reaqtor.QueryEngine/Utils/TestableEntityFactory.cs
+++ b/Reaqtor/Core/Engine/Tests.Reaqtor.QueryEngine/Utils/TestableEntityFactory.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Engine/Tests.Reaqtor.QueryEngine/Utils/TupletizingContext.cs
+++ b/Reaqtor/Core/Engine/Tests.Reaqtor.QueryEngine/Utils/TupletizingContext.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Engine/Tests.Reaqtor.QueryEngine/UtilsTests.cs
+++ b/Reaqtor/Core/Engine/Tests.Reaqtor.QueryEngine/UtilsTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Engine/Tests.Reaqtor.QueryEngine/VirtualTimeEngineTest.cs
+++ b/Reaqtor/Core/Engine/Tests.Reaqtor.QueryEngine/VirtualTimeEngineTest.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Engine/Tests.Reaqtor.QueryEngine/VirtualTimeEngineTests.cs
+++ b/Reaqtor/Core/Engine/Tests.Reaqtor.QueryEngine/VirtualTimeEngineTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Expressions/Reaqtor.Expressions.Binding/ExpressionBinder.cs
+++ b/Reaqtor/Core/Expressions/Reaqtor.Expressions.Binding/ExpressionBinder.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Expressions/Reaqtor.Expressions.Binding/Properties/AssemblyInfo.cs
+++ b/Reaqtor/Core/Expressions/Reaqtor.Expressions.Binding/Properties/AssemblyInfo.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Expressions/Reaqtor.Expressions.Core/Properties/AssemblyInfo.cs
+++ b/Reaqtor/Core/Expressions/Reaqtor.Expressions.Core/Properties/AssemblyInfo.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Expressions/Reaqtor.Expressions.Core/Reaqtor/Async/AsyncReactiveQbservableBase.cs
+++ b/Reaqtor/Core/Expressions/Reaqtor.Expressions.Core/Reaqtor/Async/AsyncReactiveQbservableBase.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Expressions/Reaqtor.Expressions.Core/Reaqtor/Async/AsyncReactiveQbserverBase.cs
+++ b/Reaqtor/Core/Expressions/Reaqtor.Expressions.Core/Reaqtor/Async/AsyncReactiveQbserverBase.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Expressions/Reaqtor.Expressions.Core/Reaqtor/Async/AsyncReactiveQubjectBase.cs
+++ b/Reaqtor/Core/Expressions/Reaqtor.Expressions.Core/Reaqtor/Async/AsyncReactiveQubjectBase.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Expressions/Reaqtor.Expressions.Core/Reaqtor/Async/AsyncReactiveQubjectFactoryBase.HighArities.cs
+++ b/Reaqtor/Core/Expressions/Reaqtor.Expressions.Core/Reaqtor/Async/AsyncReactiveQubjectFactoryBase.HighArities.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Expressions/Reaqtor.Expressions.Core/Reaqtor/Async/AsyncReactiveQubjectFactoryBase.cs
+++ b/Reaqtor/Core/Expressions/Reaqtor.Expressions.Core/Reaqtor/Async/AsyncReactiveQubjectFactoryBase.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Expressions/Reaqtor.Expressions.Core/Reaqtor/Async/AsyncReactiveQubscriptionBase.cs
+++ b/Reaqtor/Core/Expressions/Reaqtor.Expressions.Core/Reaqtor/Async/AsyncReactiveQubscriptionBase.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Expressions/Reaqtor.Expressions.Core/Reaqtor/Async/AsyncReactiveQubscriptionFactoryBase.HighArities.cs
+++ b/Reaqtor/Core/Expressions/Reaqtor.Expressions.Core/Reaqtor/Async/AsyncReactiveQubscriptionFactoryBase.HighArities.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Expressions/Reaqtor.Expressions.Core/Reaqtor/Async/AsyncReactiveQubscriptionFactoryBase.cs
+++ b/Reaqtor/Core/Expressions/Reaqtor.Expressions.Core/Reaqtor/Async/AsyncReactiveQubscriptionFactoryBase.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Expressions/Reaqtor.Expressions.Core/Reaqtor/ReactiveQbservable.cs
+++ b/Reaqtor/Core/Expressions/Reaqtor.Expressions.Core/Reaqtor/ReactiveQbservable.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Expressions/Reaqtor.Expressions.Core/Reaqtor/ReactiveQbservable.generated.cs
+++ b/Reaqtor/Core/Expressions/Reaqtor.Expressions.Core/Reaqtor/ReactiveQbservable.generated.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Expressions/Reaqtor.Expressions.Core/Reaqtor/ReactiveQbservableBase.cs
+++ b/Reaqtor/Core/Expressions/Reaqtor.Expressions.Core/Reaqtor/ReactiveQbservableBase.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Expressions/Reaqtor.Expressions.Core/Reaqtor/ReactiveQbserver.cs
+++ b/Reaqtor/Core/Expressions/Reaqtor.Expressions.Core/Reaqtor/ReactiveQbserver.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Expressions/Reaqtor.Expressions.Core/Reaqtor/ReactiveQbserverBase.cs
+++ b/Reaqtor/Core/Expressions/Reaqtor.Expressions.Core/Reaqtor/ReactiveQbserverBase.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Expressions/Reaqtor.Expressions.Core/Reaqtor/ReactiveQubjectBase.cs
+++ b/Reaqtor/Core/Expressions/Reaqtor.Expressions.Core/Reaqtor/ReactiveQubjectBase.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Expressions/Reaqtor.Expressions.Core/Reaqtor/ReactiveQubjectFactory.cs
+++ b/Reaqtor/Core/Expressions/Reaqtor.Expressions.Core/Reaqtor/ReactiveQubjectFactory.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Expressions/Reaqtor.Expressions.Core/Reaqtor/ReactiveQubjectFactoryBase.HigherArities.cs
+++ b/Reaqtor/Core/Expressions/Reaqtor.Expressions.Core/Reaqtor/ReactiveQubjectFactoryBase.HigherArities.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Expressions/Reaqtor.Expressions.Core/Reaqtor/ReactiveQubjectFactoryBase.cs
+++ b/Reaqtor/Core/Expressions/Reaqtor.Expressions.Core/Reaqtor/ReactiveQubjectFactoryBase.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Expressions/Reaqtor.Expressions.Core/Reaqtor/ReactiveQubscriptionBase.cs
+++ b/Reaqtor/Core/Expressions/Reaqtor.Expressions.Core/Reaqtor/ReactiveQubscriptionBase.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Expressions/Reaqtor.Expressions.Core/Reaqtor/ReactiveQubscriptionFactoryBase.HigherArities.cs
+++ b/Reaqtor/Core/Expressions/Reaqtor.Expressions.Core/Reaqtor/ReactiveQubscriptionFactoryBase.HigherArities.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Expressions/Reaqtor.Expressions.Core/Reaqtor/ReactiveQubscriptionFactoryBase.cs
+++ b/Reaqtor/Core/Expressions/Reaqtor.Expressions.Core/Reaqtor/ReactiveQubscriptionFactoryBase.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Expressions/Reaqtor.Expressions.Core/Reaqtor/ReactiveQueryProviderExtensions.cs
+++ b/Reaqtor/Core/Expressions/Reaqtor.Expressions.Core/Reaqtor/ReactiveQueryProviderExtensions.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Expressions/Reaqtor.Expressions.Model/Properties/AssemblyInfo.cs
+++ b/Reaqtor/Core/Expressions/Reaqtor.Expressions.Model/Properties/AssemblyInfo.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Expressions/Reaqtor.Expressions.Model/Reaqtor/Async/IAsyncReactiveExpressible.cs
+++ b/Reaqtor/Core/Expressions/Reaqtor.Expressions.Model/Reaqtor/Async/IAsyncReactiveExpressible.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Expressions/Reaqtor.Expressions.Model/Reaqtor/Async/IAsyncReactiveGroupedQbservable.cs
+++ b/Reaqtor/Core/Expressions/Reaqtor.Expressions.Model/Reaqtor/Async/IAsyncReactiveGroupedQbservable.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Expressions/Reaqtor.Expressions.Model/Reaqtor/Async/IAsyncReactiveQbservable.Generic.cs
+++ b/Reaqtor/Core/Expressions/Reaqtor.Expressions.Model/Reaqtor/Async/IAsyncReactiveQbservable.Generic.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Expressions/Reaqtor.Expressions.Model/Reaqtor/Async/IAsyncReactiveQbservable.cs
+++ b/Reaqtor/Core/Expressions/Reaqtor.Expressions.Model/Reaqtor/Async/IAsyncReactiveQbservable.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Expressions/Reaqtor.Expressions.Model/Reaqtor/Async/IAsyncReactiveQbserver.Generic.cs
+++ b/Reaqtor/Core/Expressions/Reaqtor.Expressions.Model/Reaqtor/Async/IAsyncReactiveQbserver.Generic.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Expressions/Reaqtor.Expressions.Model/Reaqtor/Async/IAsyncReactiveQbserver.cs
+++ b/Reaqtor/Core/Expressions/Reaqtor.Expressions.Model/Reaqtor/Async/IAsyncReactiveQbserver.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Expressions/Reaqtor.Expressions.Model/Reaqtor/Async/IAsyncReactiveQubject.Generic.cs
+++ b/Reaqtor/Core/Expressions/Reaqtor.Expressions.Model/Reaqtor/Async/IAsyncReactiveQubject.Generic.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Expressions/Reaqtor.Expressions.Model/Reaqtor/Async/IAsyncReactiveQubject.cs
+++ b/Reaqtor/Core/Expressions/Reaqtor.Expressions.Model/Reaqtor/Async/IAsyncReactiveQubject.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Expressions/Reaqtor.Expressions.Model/Reaqtor/Async/IAsyncReactiveQubjectFactory.Generic.HighArities.cs
+++ b/Reaqtor/Core/Expressions/Reaqtor.Expressions.Model/Reaqtor/Async/IAsyncReactiveQubjectFactory.Generic.HighArities.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Expressions/Reaqtor.Expressions.Model/Reaqtor/Async/IAsyncReactiveQubjectFactory.Generic.cs
+++ b/Reaqtor/Core/Expressions/Reaqtor.Expressions.Model/Reaqtor/Async/IAsyncReactiveQubjectFactory.Generic.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Expressions/Reaqtor.Expressions.Model/Reaqtor/Async/IAsyncReactiveQubscription.cs
+++ b/Reaqtor/Core/Expressions/Reaqtor.Expressions.Model/Reaqtor/Async/IAsyncReactiveQubscription.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Expressions/Reaqtor.Expressions.Model/Reaqtor/Async/IAsyncReactiveQubscriptionFactory.Generic.HighArities.cs
+++ b/Reaqtor/Core/Expressions/Reaqtor.Expressions.Model/Reaqtor/Async/IAsyncReactiveQubscriptionFactory.Generic.HighArities.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Expressions/Reaqtor.Expressions.Model/Reaqtor/Async/IAsyncReactiveQubscriptionFactory.Generic.cs
+++ b/Reaqtor/Core/Expressions/Reaqtor.Expressions.Model/Reaqtor/Async/IAsyncReactiveQubscriptionFactory.Generic.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Expressions/Reaqtor.Expressions.Model/Reaqtor/Async/IAsyncReactiveQueryProvider.cs
+++ b/Reaqtor/Core/Expressions/Reaqtor.Expressions.Model/Reaqtor/Async/IAsyncReactiveQueryProvider.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Expressions/Reaqtor.Expressions.Model/Reaqtor/IReactiveExpressible.cs
+++ b/Reaqtor/Core/Expressions/Reaqtor.Expressions.Model/Reaqtor/IReactiveExpressible.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Expressions/Reaqtor.Expressions.Model/Reaqtor/IReactiveGroupedQbservable.cs
+++ b/Reaqtor/Core/Expressions/Reaqtor.Expressions.Model/Reaqtor/IReactiveGroupedQbservable.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Expressions/Reaqtor.Expressions.Model/Reaqtor/IReactiveQbservable.Generic.cs
+++ b/Reaqtor/Core/Expressions/Reaqtor.Expressions.Model/Reaqtor/IReactiveQbservable.Generic.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Expressions/Reaqtor.Expressions.Model/Reaqtor/IReactiveQbservable.cs
+++ b/Reaqtor/Core/Expressions/Reaqtor.Expressions.Model/Reaqtor/IReactiveQbservable.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Expressions/Reaqtor.Expressions.Model/Reaqtor/IReactiveQbserver.Generic.cs
+++ b/Reaqtor/Core/Expressions/Reaqtor.Expressions.Model/Reaqtor/IReactiveQbserver.Generic.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Expressions/Reaqtor.Expressions.Model/Reaqtor/IReactiveQbserver.cs
+++ b/Reaqtor/Core/Expressions/Reaqtor.Expressions.Model/Reaqtor/IReactiveQbserver.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Expressions/Reaqtor.Expressions.Model/Reaqtor/IReactiveQubject.Generic.cs
+++ b/Reaqtor/Core/Expressions/Reaqtor.Expressions.Model/Reaqtor/IReactiveQubject.Generic.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Expressions/Reaqtor.Expressions.Model/Reaqtor/IReactiveQubject.cs
+++ b/Reaqtor/Core/Expressions/Reaqtor.Expressions.Model/Reaqtor/IReactiveQubject.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Expressions/Reaqtor.Expressions.Model/Reaqtor/IReactiveQubjectFactory.Generic.HigherArities.cs
+++ b/Reaqtor/Core/Expressions/Reaqtor.Expressions.Model/Reaqtor/IReactiveQubjectFactory.Generic.HigherArities.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Expressions/Reaqtor.Expressions.Model/Reaqtor/IReactiveQubjectFactory.Generic.cs
+++ b/Reaqtor/Core/Expressions/Reaqtor.Expressions.Model/Reaqtor/IReactiveQubjectFactory.Generic.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Expressions/Reaqtor.Expressions.Model/Reaqtor/IReactiveQubscription.cs
+++ b/Reaqtor/Core/Expressions/Reaqtor.Expressions.Model/Reaqtor/IReactiveQubscription.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Expressions/Reaqtor.Expressions.Model/Reaqtor/IReactiveQubscriptionFactory.Generic.HigherArities.cs
+++ b/Reaqtor/Core/Expressions/Reaqtor.Expressions.Model/Reaqtor/IReactiveQubscriptionFactory.Generic.HigherArities.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Expressions/Reaqtor.Expressions.Model/Reaqtor/IReactiveQubscriptionFactory.Generic.cs
+++ b/Reaqtor/Core/Expressions/Reaqtor.Expressions.Model/Reaqtor/IReactiveQubscriptionFactory.Generic.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Expressions/Reaqtor.Expressions.Model/Reaqtor/IReactiveQueryProvider.cs
+++ b/Reaqtor/Core/Expressions/Reaqtor.Expressions.Model/Reaqtor/IReactiveQueryProvider.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Hosting/Reaqtor.Hosting.Service/GlobalSuppressions.cs
+++ b/Reaqtor/Core/Hosting/Reaqtor.Hosting.Service/GlobalSuppressions.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Hosting/Reaqtor.Hosting.Service/Internal/DataModelTypeUnifier.cs
+++ b/Reaqtor/Core/Hosting/Reaqtor.Hosting.Service/Internal/DataModelTypeUnifier.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Hosting/Reaqtor.Hosting.Service/Properties/AssemblyInfo.cs
+++ b/Reaqtor/Core/Hosting/Reaqtor.Hosting.Service/Properties/AssemblyInfo.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Hosting/Reaqtor.Hosting.Service/Serialization/UnifyingSerializationHelpers.cs
+++ b/Reaqtor/Core/Hosting/Reaqtor.Hosting.Service/Serialization/UnifyingSerializationHelpers.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Hosting/Reaqtor.Hosting.Shared/GlobalSuppressions.cs
+++ b/Reaqtor/Core/Hosting/Reaqtor.Hosting.Shared/GlobalSuppressions.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Hosting/Reaqtor.Hosting.Shared/Properties/AssemblyInfo.cs
+++ b/Reaqtor/Core/Hosting/Reaqtor.Hosting.Shared/Properties/AssemblyInfo.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Hosting/Reaqtor.Hosting.Shared/Serialization/ClientSerializationHelpers.cs
+++ b/Reaqtor/Core/Hosting/Reaqtor.Hosting.Shared/Serialization/ClientSerializationHelpers.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Hosting/Reaqtor.Hosting.Shared/Serialization/ReactiveResourceConverter.cs
+++ b/Reaqtor/Core/Hosting/Reaqtor.Hosting.Shared/Serialization/ReactiveResourceConverter.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Hosting/Reaqtor.Hosting.Shared/Serialization/SerializationHelpers.cs
+++ b/Reaqtor/Core/Hosting/Reaqtor.Hosting.Shared/Serialization/SerializationHelpers.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Hosting/Reaqtor.Hosting.Shared/Serialization/SerializationHelpersExtensions.cs
+++ b/Reaqtor/Core/Hosting/Reaqtor.Hosting.Shared/Serialization/SerializationHelpersExtensions.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Hosting/Reaqtor.Hosting.Shared/Tools/ReactiveEntities.cs
+++ b/Reaqtor/Core/Hosting/Reaqtor.Hosting.Shared/Tools/ReactiveEntities.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Hosting/Reaqtor.Hosting.Shared/Tools/ReactiveEntityFinder.cs
+++ b/Reaqtor/Core/Hosting/Reaqtor.Hosting.Shared/Tools/ReactiveEntityFinder.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Hosting/Reaqtor.Hosting.Shared/Tools/ReactiveEntityType.cs
+++ b/Reaqtor/Core/Hosting/Reaqtor.Hosting.Shared/Tools/ReactiveEntityType.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Hosting/Reaqtor.Hosting.Shared/Tools/ReactiveEntityTypeExtensions.cs
+++ b/Reaqtor/Core/Hosting/Reaqtor.Hosting.Shared/Tools/ReactiveEntityTypeExtensions.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Hosting/Tests.Reaqtor.Hosting.Service/Internal/DataModelTypeUnifierTests.cs
+++ b/Reaqtor/Core/Hosting/Tests.Reaqtor.Hosting.Service/Internal/DataModelTypeUnifierTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Hosting/Tests.Reaqtor.Hosting.Service/Serialization/UnifyingSerializationHelpersTests.cs
+++ b/Reaqtor/Core/Hosting/Tests.Reaqtor.Hosting.Service/Serialization/UnifyingSerializationHelpersTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Hosting/Tests.Reaqtor.Hosting.Shared/Serialization/ReactiveResourceConverterTests.cs
+++ b/Reaqtor/Core/Hosting/Tests.Reaqtor.Hosting.Shared/Serialization/ReactiveResourceConverterTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Hosting/Tests.Reaqtor.Hosting.Shared/Serialization/SerializationHelpersTests.cs
+++ b/Reaqtor/Core/Hosting/Tests.Reaqtor.Hosting.Shared/Serialization/SerializationHelpersTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Hosting/Tests.Reaqtor.Hosting.Shared/Tools/ReactiveEntitiesTests.cs
+++ b/Reaqtor/Core/Hosting/Tests.Reaqtor.Hosting.Shared/Tools/ReactiveEntitiesTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Hosting/Tests.Reaqtor.Hosting.Shared/Tools/ReactiveEntityFinderTests.cs
+++ b/Reaqtor/Core/Hosting/Tests.Reaqtor.Hosting.Shared/Tools/ReactiveEntityFinderTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Hosting/Tests.Reaqtor.Hosting.Shared/Tools/ReactiveEntityTypeExtensionsTests.cs
+++ b/Reaqtor/Core/Hosting/Tests.Reaqtor.Hosting.Shared/Tools/ReactiveEntityTypeExtensionsTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Local/Reaqtor.Local.Core/Properties/AssemblyInfo.cs
+++ b/Reaqtor/Core/Local/Reaqtor.Local.Core/Properties/AssemblyInfo.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Local/Reaqtor.Local.Core/Reaqtor/Async/AsyncReactiveObservableBase.cs
+++ b/Reaqtor/Core/Local/Reaqtor.Local.Core/Reaqtor/Async/AsyncReactiveObservableBase.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Local/Reaqtor.Local.Core/Reaqtor/Async/AsyncReactiveSubscriptionBase.cs
+++ b/Reaqtor/Core/Local/Reaqtor.Local.Core/Reaqtor/Async/AsyncReactiveSubscriptionBase.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Local/Reaqtor.Local.Core/Reaqtor/ReactiveObservableBase.cs
+++ b/Reaqtor/Core/Local/Reaqtor.Local.Core/Reaqtor/ReactiveObservableBase.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Local/Reaqtor.Local.Core/Reaqtor/ReactiveObserverBase.cs
+++ b/Reaqtor/Core/Local/Reaqtor.Local.Core/Reaqtor/ReactiveObserverBase.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Local/Reaqtor.Local.Core/Reaqtor/ReactiveSubjectBase.cs
+++ b/Reaqtor/Core/Local/Reaqtor.Local.Core/Reaqtor/ReactiveSubjectBase.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Local/Reaqtor.Local.Core/Reaqtor/ReactiveSubscriptionBase.cs
+++ b/Reaqtor/Core/Local/Reaqtor.Local.Core/Reaqtor/ReactiveSubscriptionBase.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Local/Reaqtor.Local.Core/System/AsyncDisposableBase.cs
+++ b/Reaqtor/Core/Local/Reaqtor.Local.Core/System/AsyncDisposableBase.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Local/Reaqtor.Local.Core/System/AsyncDisposableExtensions.cs
+++ b/Reaqtor/Core/Local/Reaqtor.Local.Core/System/AsyncDisposableExtensions.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Local/Reaqtor.Local.Model/GlobalSuppressions.cs
+++ b/Reaqtor/Core/Local/Reaqtor.Local.Model/GlobalSuppressions.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Local/Reaqtor.Local.Model/Properties/AssemblyInfo.cs
+++ b/Reaqtor/Core/Local/Reaqtor.Local.Model/Properties/AssemblyInfo.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Local/Reaqtor.Local.Model/Reaqtor/Async/IAsyncReactiveGroupedObservable.cs
+++ b/Reaqtor/Core/Local/Reaqtor.Local.Model/Reaqtor/Async/IAsyncReactiveGroupedObservable.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Local/Reaqtor.Local.Model/Reaqtor/Async/IAsyncReactiveObservable.Generic.cs
+++ b/Reaqtor/Core/Local/Reaqtor.Local.Model/Reaqtor/Async/IAsyncReactiveObservable.Generic.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Local/Reaqtor.Local.Model/Reaqtor/Async/IAsyncReactiveSubject.Generic.cs
+++ b/Reaqtor/Core/Local/Reaqtor.Local.Model/Reaqtor/Async/IAsyncReactiveSubject.Generic.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Local/Reaqtor.Local.Model/Reaqtor/Async/IAsyncReactiveSubjectFactory.Generic.HighArities.cs
+++ b/Reaqtor/Core/Local/Reaqtor.Local.Model/Reaqtor/Async/IAsyncReactiveSubjectFactory.Generic.HighArities.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Local/Reaqtor.Local.Model/Reaqtor/Async/IAsyncReactiveSubjectFactory.Generic.cs
+++ b/Reaqtor/Core/Local/Reaqtor.Local.Model/Reaqtor/Async/IAsyncReactiveSubjectFactory.Generic.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Local/Reaqtor.Local.Model/Reaqtor/Async/IAsyncReactiveSubscription.cs
+++ b/Reaqtor/Core/Local/Reaqtor.Local.Model/Reaqtor/Async/IAsyncReactiveSubscription.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Local/Reaqtor.Local.Model/Reaqtor/Async/IAsyncReactiveSubscriptionFactory.Generic.HighArities.cs
+++ b/Reaqtor/Core/Local/Reaqtor.Local.Model/Reaqtor/Async/IAsyncReactiveSubscriptionFactory.Generic.HighArities.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Local/Reaqtor.Local.Model/Reaqtor/Async/IAsyncReactiveSubscriptionFactory.Generic.cs
+++ b/Reaqtor/Core/Local/Reaqtor.Local.Model/Reaqtor/Async/IAsyncReactiveSubscriptionFactory.Generic.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Local/Reaqtor.Local.Model/Reaqtor/Constants.cs
+++ b/Reaqtor/Core/Local/Reaqtor.Local.Model/Reaqtor/Constants.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Local/Reaqtor.Local.Model/Reaqtor/IReactiveGroupedObservable.cs
+++ b/Reaqtor/Core/Local/Reaqtor.Local.Model/Reaqtor/IReactiveGroupedObservable.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Local/Reaqtor.Local.Model/Reaqtor/IReactiveObservable.Generic.cs
+++ b/Reaqtor/Core/Local/Reaqtor.Local.Model/Reaqtor/IReactiveObservable.Generic.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Local/Reaqtor.Local.Model/Reaqtor/IReactiveObserver.Generic.cs
+++ b/Reaqtor/Core/Local/Reaqtor.Local.Model/Reaqtor/IReactiveObserver.Generic.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Local/Reaqtor.Local.Model/Reaqtor/IReactiveSubject.Generic.cs
+++ b/Reaqtor/Core/Local/Reaqtor.Local.Model/Reaqtor/IReactiveSubject.Generic.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Local/Reaqtor.Local.Model/Reaqtor/IReactiveSubjectFactory.Generic.HigherArities.cs
+++ b/Reaqtor/Core/Local/Reaqtor.Local.Model/Reaqtor/IReactiveSubjectFactory.Generic.HigherArities.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Local/Reaqtor.Local.Model/Reaqtor/IReactiveSubjectFactory.Generic.cs
+++ b/Reaqtor/Core/Local/Reaqtor.Local.Model/Reaqtor/IReactiveSubjectFactory.Generic.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Local/Reaqtor.Local.Model/Reaqtor/IReactiveSubscription.cs
+++ b/Reaqtor/Core/Local/Reaqtor.Local.Model/Reaqtor/IReactiveSubscription.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Local/Reaqtor.Local.Model/Reaqtor/IReactiveSubscriptionFactory.Generic.HigherArities.cs
+++ b/Reaqtor/Core/Local/Reaqtor.Local.Model/Reaqtor/IReactiveSubscriptionFactory.Generic.HigherArities.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Local/Reaqtor.Local.Model/Reaqtor/IReactiveSubscriptionFactory.Generic.cs
+++ b/Reaqtor/Core/Local/Reaqtor.Local.Model/Reaqtor/IReactiveSubscriptionFactory.Generic.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Local/Reaqtor.Local.Model/Reaqtor/ResourceNaming.cs
+++ b/Reaqtor/Core/Local/Reaqtor.Local.Model/Reaqtor/ResourceNaming.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Local/Reaqtor.Local.Model/System/IAsyncDisposable.cs
+++ b/Reaqtor/Core/Local/Reaqtor.Local.Model/System/IAsyncDisposable.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Local/Tests.Reaqtor.Local.Core/Async/AsyncReactiveSubjectBaseTests.cs
+++ b/Reaqtor/Core/Local/Tests.Reaqtor.Local.Core/Async/AsyncReactiveSubjectBaseTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Metadata/Reaqtor.Metadata.Model/Properties/AssemblyInfo.cs
+++ b/Reaqtor/Core/Metadata/Reaqtor.Metadata.Model/Properties/AssemblyInfo.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Metadata/Reaqtor.Metadata.Model/Reaqtor/Metadata/Async/IAsyncReactiveDefinedResource.cs
+++ b/Reaqtor/Core/Metadata/Reaqtor.Metadata.Model/Reaqtor/Metadata/Async/IAsyncReactiveDefinedResource.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Metadata/Reaqtor.Metadata.Model/Reaqtor/Metadata/Async/IAsyncReactiveObservableDefinition.cs
+++ b/Reaqtor/Core/Metadata/Reaqtor.Metadata.Model/Reaqtor/Metadata/Async/IAsyncReactiveObservableDefinition.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Metadata/Reaqtor.Metadata.Model/Reaqtor/Metadata/Async/IAsyncReactiveObserverDefinition.cs
+++ b/Reaqtor/Core/Metadata/Reaqtor.Metadata.Model/Reaqtor/Metadata/Async/IAsyncReactiveObserverDefinition.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Metadata/Reaqtor.Metadata.Model/Reaqtor/Metadata/Async/IAsyncReactiveProcessResource.cs
+++ b/Reaqtor/Core/Metadata/Reaqtor.Metadata.Model/Reaqtor/Metadata/Async/IAsyncReactiveProcessResource.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Metadata/Reaqtor.Metadata.Model/Reaqtor/Metadata/Async/IAsyncReactiveResource.cs
+++ b/Reaqtor/Core/Metadata/Reaqtor.Metadata.Model/Reaqtor/Metadata/Async/IAsyncReactiveResource.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Metadata/Reaqtor.Metadata.Model/Reaqtor/Metadata/Async/IAsyncReactiveStreamFactoryDefinition.cs
+++ b/Reaqtor/Core/Metadata/Reaqtor.Metadata.Model/Reaqtor/Metadata/Async/IAsyncReactiveStreamFactoryDefinition.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Metadata/Reaqtor.Metadata.Model/Reaqtor/Metadata/Async/IAsyncReactiveStreamProcess.cs
+++ b/Reaqtor/Core/Metadata/Reaqtor.Metadata.Model/Reaqtor/Metadata/Async/IAsyncReactiveStreamProcess.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Metadata/Reaqtor.Metadata.Model/Reaqtor/Metadata/Async/IAsyncReactiveSubscriptionFactoryDefinition.cs
+++ b/Reaqtor/Core/Metadata/Reaqtor.Metadata.Model/Reaqtor/Metadata/Async/IAsyncReactiveSubscriptionFactoryDefinition.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Metadata/Reaqtor.Metadata.Model/Reaqtor/Metadata/Async/IAsyncReactiveSubscriptionProcess.cs
+++ b/Reaqtor/Core/Metadata/Reaqtor.Metadata.Model/Reaqtor/Metadata/Async/IAsyncReactiveSubscriptionProcess.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Metadata/Reaqtor.Metadata.Model/Reaqtor/Metadata/IReactiveDefinedResource.cs
+++ b/Reaqtor/Core/Metadata/Reaqtor.Metadata.Model/Reaqtor/Metadata/IReactiveDefinedResource.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Metadata/Reaqtor.Metadata.Model/Reaqtor/Metadata/IReactiveObservableDefinition.cs
+++ b/Reaqtor/Core/Metadata/Reaqtor.Metadata.Model/Reaqtor/Metadata/IReactiveObservableDefinition.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Metadata/Reaqtor.Metadata.Model/Reaqtor/Metadata/IReactiveObserverDefinition.cs
+++ b/Reaqtor/Core/Metadata/Reaqtor.Metadata.Model/Reaqtor/Metadata/IReactiveObserverDefinition.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Metadata/Reaqtor.Metadata.Model/Reaqtor/Metadata/IReactiveProcessResource.cs
+++ b/Reaqtor/Core/Metadata/Reaqtor.Metadata.Model/Reaqtor/Metadata/IReactiveProcessResource.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Metadata/Reaqtor.Metadata.Model/Reaqtor/Metadata/IReactiveResource.cs
+++ b/Reaqtor/Core/Metadata/Reaqtor.Metadata.Model/Reaqtor/Metadata/IReactiveResource.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Metadata/Reaqtor.Metadata.Model/Reaqtor/Metadata/IReactiveStreamFactoryDefinition.cs
+++ b/Reaqtor/Core/Metadata/Reaqtor.Metadata.Model/Reaqtor/Metadata/IReactiveStreamFactoryDefinition.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Metadata/Reaqtor.Metadata.Model/Reaqtor/Metadata/IReactiveStreamProcess.cs
+++ b/Reaqtor/Core/Metadata/Reaqtor.Metadata.Model/Reaqtor/Metadata/IReactiveStreamProcess.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Metadata/Reaqtor.Metadata.Model/Reaqtor/Metadata/IReactiveSubscriptionFactoryDefinition.cs
+++ b/Reaqtor/Core/Metadata/Reaqtor.Metadata.Model/Reaqtor/Metadata/IReactiveSubscriptionFactoryDefinition.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Metadata/Reaqtor.Metadata.Model/Reaqtor/Metadata/IReactiveSubscriptionProcess.cs
+++ b/Reaqtor/Core/Metadata/Reaqtor.Metadata.Model/Reaqtor/Metadata/IReactiveSubscriptionProcess.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Reactive/Reaqtor.Reactive.HigherOrder/EventMetadata.Generated.cs
+++ b/Reaqtor/Core/Reactive/Reaqtor.Reactive.HigherOrder/EventMetadata.Generated.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Reactive/Reaqtor.Reactive.HigherOrder/Properties/AssemblyInfo.cs
+++ b/Reaqtor/Core/Reactive/Reaqtor.Reactive.HigherOrder/Properties/AssemblyInfo.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Reactive/Reaqtor.Reactive.HigherOrder/Reaqtor/Reactive/Expressions/IQuoted.cs
+++ b/Reaqtor/Core/Reactive/Reaqtor.Reactive.HigherOrder/Reaqtor/Reactive/Expressions/IQuoted.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Reactive/Reaqtor.Reactive.HigherOrder/Reaqtor/Reactive/Expressions/Quoted.cs
+++ b/Reaqtor/Core/Reactive/Reaqtor.Reactive.HigherOrder/Reaqtor/Reactive/Expressions/Quoted.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Reactive/Reaqtor.Reactive.HigherOrder/Reaqtor/Reactive/Expressions/QuotedGroupedSubscribable.cs
+++ b/Reaqtor/Core/Reactive/Reaqtor.Reactive.HigherOrder/Reaqtor/Reactive/Expressions/QuotedGroupedSubscribable.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Reactive/Reaqtor.Reactive.HigherOrder/Reaqtor/Reactive/Expressions/QuotedSubscribable.cs
+++ b/Reaqtor/Core/Reactive/Reaqtor.Reactive.HigherOrder/Reaqtor/Reactive/Expressions/QuotedSubscribable.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Reactive/Reaqtor.Reactive.HigherOrder/Reaqtor/Reactive/HigherOrderSubscriptionFailedException.cs
+++ b/Reaqtor/Core/Reactive/Reaqtor.Reactive.HigherOrder/Reaqtor/Reactive/HigherOrderSubscriptionFailedException.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Reactive/Reaqtor.Reactive.HigherOrder/Reaqtor/Reactive/IPersistableSubscription.cs
+++ b/Reaqtor/Core/Reactive/Reaqtor.Reactive.HigherOrder/Reaqtor/Reactive/IPersistableSubscription.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Reactive/Reaqtor.Reactive.HigherOrder/Reaqtor/Reactive/Subjects/GroupedMultiSubjectProxy.cs
+++ b/Reaqtor/Core/Reactive/Reaqtor.Reactive.HigherOrder/Reaqtor/Reactive/Subjects/GroupedMultiSubjectProxy.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Reactive/Reaqtor.Reactive.HigherOrder/Reaqtor/Reactive/Subjects/MultiSubjectObserverProxy.cs
+++ b/Reaqtor/Core/Reactive/Reaqtor.Reactive.HigherOrder/Reaqtor/Reactive/Subjects/MultiSubjectObserverProxy.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Reactive/Reaqtor.Reactive.HigherOrder/Reaqtor/Reactive/Subjects/MultiSubjectProxy.cs
+++ b/Reaqtor/Core/Reactive/Reaqtor.Reactive.HigherOrder/Reaqtor/Reactive/Subjects/MultiSubjectProxy.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Reactive/Reaqtor.Reactive.HigherOrder/Reaqtor/Reactive/Subjects/MultiSubjectSubscriptionProxy.cs
+++ b/Reaqtor/Core/Reactive/Reaqtor.Reactive.HigherOrder/Reaqtor/Reactive/Subjects/MultiSubjectSubscriptionProxy.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Reactive/Tests.Reaqtor.Reactive.HigherOrder/Reaqtor/Reactive/Expressions/QuotationTests.cs
+++ b/Reaqtor/Core/Reactive/Tests.Reaqtor.Reactive.HigherOrder/Reaqtor/Reactive/Expressions/QuotationTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Reactive/Tests.Reaqtor.Reactive.HigherOrder/Reaqtor/Reactive/Subjects/MultiSubjectProxyTests.cs
+++ b/Reaqtor/Core/Reactive/Tests.Reaqtor.Reactive.HigherOrder/Reaqtor/Reactive/Subjects/MultiSubjectProxyTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Reactive/Tests.Reaqtor.Reactive.Linq.Hosted/GroupBy.cs
+++ b/Reaqtor/Core/Reactive/Tests.Reaqtor.Reactive.Linq.Hosted/GroupBy.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Reactive/Tests.Reaqtor.Reactive.Linq.Hosted/SelectMany.cs
+++ b/Reaqtor/Core/Reactive/Tests.Reaqtor.Reactive.Linq.Hosted/SelectMany.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Reactive/Tests.Reaqtor.Reactive.Linq.Hosted/Switch.cs
+++ b/Reaqtor/Core/Reactive/Tests.Reaqtor.Reactive.Linq.Hosted/Switch.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Reactive/Tests.Reaqtor.Reactive.Linq.Hosted/Throttle.cs
+++ b/Reaqtor/Core/Reactive/Tests.Reaqtor.Reactive.Linq.Hosted/Throttle.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Reactive/Tests.Reaqtor.Reactive.Linq.Hosted/Window.cs
+++ b/Reaqtor/Core/Reactive/Tests.Reaqtor.Reactive.Linq.Hosted/Window.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Reliable/Reaqtor.Reliable.Model/Properties/AssemblyInfo.cs
+++ b/Reaqtor/Core/Reliable/Reaqtor.Reliable.Model/Properties/AssemblyInfo.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Reliable/Reaqtor.Reliable.Model/Reaqtor/Reliable/Client/IReliableReactiveMultiSubject.cs
+++ b/Reaqtor/Core/Reliable/Reaqtor.Reliable.Model/Reaqtor/Reliable/Client/IReliableReactiveMultiSubject.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Reliable/Reaqtor.Reliable.Model/Reaqtor/Reliable/Client/IReliableReactiveObservable.cs
+++ b/Reaqtor/Core/Reliable/Reaqtor.Reliable.Model/Reaqtor/Reliable/Client/IReliableReactiveObservable.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Reliable/Reaqtor.Reliable.Model/Reaqtor/Reliable/Client/IReliableReactiveObserver.cs
+++ b/Reaqtor/Core/Reliable/Reaqtor.Reliable.Model/Reaqtor/Reliable/Client/IReliableReactiveObserver.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Reliable/Reaqtor.Reliable.Model/Reaqtor/Reliable/Client/IReliableReactiveSubjectFactory.cs
+++ b/Reaqtor/Core/Reliable/Reaqtor.Reliable.Model/Reaqtor/Reliable/Client/IReliableReactiveSubjectFactory.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Reliable/Reaqtor.Reliable.Model/Reaqtor/Reliable/Client/IReliableReactiveSubscription.cs
+++ b/Reaqtor/Core/Reliable/Reaqtor.Reliable.Model/Reaqtor/Reliable/Client/IReliableReactiveSubscription.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Reliable/Reaqtor.Reliable.Model/Reaqtor/Reliable/Client/IReliableReactiveSubscriptionFactory.cs
+++ b/Reaqtor/Core/Reliable/Reaqtor.Reliable.Model/Reaqtor/Reliable/Client/IReliableReactiveSubscriptionFactory.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Reliable/Reaqtor.Reliable.Model/Reaqtor/Reliable/Engine/IReliableReactiveClientEngineProvider.cs
+++ b/Reaqtor/Core/Reliable/Reaqtor.Reliable.Model/Reaqtor/Reliable/Engine/IReliableReactiveClientEngineProvider.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Reliable/Reaqtor.Reliable.Model/Reaqtor/Reliable/Engine/IReliableReactiveEngineProvider.cs
+++ b/Reaqtor/Core/Reliable/Reaqtor.Reliable.Model/Reaqtor/Reliable/Engine/IReliableReactiveEngineProvider.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Reliable/Reaqtor.Reliable.Model/Reaqtor/Reliable/Expressions/IReliableMultiQubject.cs
+++ b/Reaqtor/Core/Reliable/Reaqtor.Reliable.Model/Reaqtor/Reliable/Expressions/IReliableMultiQubject.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Reliable/Reaqtor.Reliable.Model/Reaqtor/Reliable/Expressions/IReliableQbservable.cs
+++ b/Reaqtor/Core/Reliable/Reaqtor.Reliable.Model/Reaqtor/Reliable/Expressions/IReliableQbservable.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Reliable/Reaqtor.Reliable.Model/Reaqtor/Reliable/Expressions/IReliableQbserver.cs
+++ b/Reaqtor/Core/Reliable/Reaqtor.Reliable.Model/Reaqtor/Reliable/Expressions/IReliableQbserver.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Reliable/Reaqtor.Reliable.Model/Reaqtor/Reliable/Expressions/IReliableQubjectFactory.cs
+++ b/Reaqtor/Core/Reliable/Reaqtor.Reliable.Model/Reaqtor/Reliable/Expressions/IReliableQubjectFactory.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Reliable/Reaqtor.Reliable.Model/Reaqtor/Reliable/Expressions/IReliableQubscription.cs
+++ b/Reaqtor/Core/Reliable/Reaqtor.Reliable.Model/Reaqtor/Reliable/Expressions/IReliableQubscription.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Reliable/Reaqtor.Reliable.Model/Reaqtor/Reliable/Expressions/IReliableQubscriptionFactory.cs
+++ b/Reaqtor/Core/Reliable/Reaqtor.Reliable.Model/Reaqtor/Reliable/Expressions/IReliableQubscriptionFactory.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Reliable/Reaqtor.Reliable.Model/Reaqtor/Reliable/Expressions/IReliableQueryProvider.cs
+++ b/Reaqtor/Core/Reliable/Reaqtor.Reliable.Model/Reaqtor/Reliable/Expressions/IReliableQueryProvider.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Reliable/Reaqtor.Reliable.Model/Reaqtor/Reliable/Expressions/IReliableReactive.cs
+++ b/Reaqtor/Core/Reliable/Reaqtor.Reliable.Model/Reaqtor/Reliable/Expressions/IReliableReactive.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Reliable/Reaqtor.Reliable.Model/Reaqtor/Reliable/Expressions/IReliableReactiveClient.cs
+++ b/Reaqtor/Core/Reliable/Reaqtor.Reliable.Model/Reaqtor/Reliable/Expressions/IReliableReactiveClient.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Reliable/Reaqtor.Reliable.Model/Reaqtor/Reliable/Expressions/IReliableReactiveExpressible.cs
+++ b/Reaqtor/Core/Reliable/Reaqtor.Reliable.Model/Reaqtor/Reliable/Expressions/IReliableReactiveExpressible.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Reliable/Reaqtor.Reliable.Model/Reaqtor/Reliable/IReliableExecutionEnvironment.cs
+++ b/Reaqtor/Core/Reliable/Reaqtor.Reliable.Model/Reaqtor/Reliable/IReliableExecutionEnvironment.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Reliable/Reaqtor.Reliable.Model/Reaqtor/Reliable/IReliableMultiSubject.cs
+++ b/Reaqtor/Core/Reliable/Reaqtor.Reliable.Model/Reaqtor/Reliable/IReliableMultiSubject.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Reliable/Reaqtor.Reliable.Model/Reaqtor/Reliable/IReliableObservable.cs
+++ b/Reaqtor/Core/Reliable/Reaqtor.Reliable.Model/Reaqtor/Reliable/IReliableObservable.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Reliable/Reaqtor.Reliable.Model/Reaqtor/Reliable/IReliableObserver.cs
+++ b/Reaqtor/Core/Reliable/Reaqtor.Reliable.Model/Reaqtor/Reliable/IReliableObserver.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Reliable/Reaqtor.Reliable.Model/Reaqtor/Reliable/IReliableSubjectFactory.cs
+++ b/Reaqtor/Core/Reliable/Reaqtor.Reliable.Model/Reaqtor/Reliable/IReliableSubjectFactory.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Reliable/Reaqtor.Reliable.Model/Reaqtor/Reliable/IReliableSubscribable.cs
+++ b/Reaqtor/Core/Reliable/Reaqtor.Reliable.Model/Reaqtor/Reliable/IReliableSubscribable.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Reliable/Reaqtor.Reliable.Model/Reaqtor/Reliable/IReliableSubscription.cs
+++ b/Reaqtor/Core/Reliable/Reaqtor.Reliable.Model/Reaqtor/Reliable/IReliableSubscription.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Reliable/Reaqtor.Reliable.Model/Reaqtor/Reliable/IReliableSubscriptionFactory.cs
+++ b/Reaqtor/Core/Reliable/Reaqtor.Reliable.Model/Reaqtor/Reliable/IReliableSubscriptionFactory.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Reliable/Reaqtor.Reliable/EventMetadata.Generated.cs
+++ b/Reaqtor/Core/Reliable/Reaqtor.Reliable/EventMetadata.Generated.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Reliable/Reaqtor.Reliable/Properties/AssemblyInfo.cs
+++ b/Reaqtor/Core/Reliable/Reaqtor.Reliable/Properties/AssemblyInfo.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Reliable/Reaqtor.Reliable/Reaqtor/Reliable/Client/ReliableReactiveMultiSubjectBase.cs
+++ b/Reaqtor/Core/Reliable/Reaqtor.Reliable/Reaqtor/Reliable/Client/ReliableReactiveMultiSubjectBase.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Reliable/Reaqtor.Reliable/Reaqtor/Reliable/Client/ReliableReactiveObservableBase.cs
+++ b/Reaqtor/Core/Reliable/Reaqtor.Reliable/Reaqtor/Reliable/Client/ReliableReactiveObservableBase.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Reliable/Reaqtor.Reliable/Reaqtor/Reliable/Client/ReliableReactiveObserverBase.cs
+++ b/Reaqtor/Core/Reliable/Reaqtor.Reliable/Reaqtor/Reliable/Client/ReliableReactiveObserverBase.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Reliable/Reaqtor.Reliable/Reaqtor/Reliable/Client/ReliableReactiveSubscriptionBase.cs
+++ b/Reaqtor/Core/Reliable/Reaqtor.Reliable/Reaqtor/Reliable/Client/ReliableReactiveSubscriptionBase.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Reliable/Reaqtor.Reliable/Reaqtor/Reliable/Expressions/ReliableQbservableBase.cs
+++ b/Reaqtor/Core/Reliable/Reaqtor.Reliable/Reaqtor/Reliable/Expressions/ReliableQbservableBase.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Reliable/Reaqtor.Reliable/Reaqtor/Reliable/Expressions/ReliableQbserverBase.cs
+++ b/Reaqtor/Core/Reliable/Reaqtor.Reliable/Reaqtor/Reliable/Expressions/ReliableQbserverBase.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Reliable/Reaqtor.Reliable/Reaqtor/Reliable/Expressions/ReliableQubjectBase.cs
+++ b/Reaqtor/Core/Reliable/Reaqtor.Reliable/Reaqtor/Reliable/Expressions/ReliableQubjectBase.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Reliable/Reaqtor.Reliable/Reaqtor/Reliable/Expressions/ReliableQubjectFactoryBase.cs
+++ b/Reaqtor/Core/Reliable/Reaqtor.Reliable/Reaqtor/Reliable/Expressions/ReliableQubjectFactoryBase.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Reliable/Reaqtor.Reliable/Reaqtor/Reliable/Expressions/ReliableQubscriptionBase.cs
+++ b/Reaqtor/Core/Reliable/Reaqtor.Reliable/Reaqtor/Reliable/Expressions/ReliableQubscriptionBase.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Reliable/Reaqtor.Reliable/Reaqtor/Reliable/Expressions/ReliableQubscriptionFactoryBase.cs
+++ b/Reaqtor/Core/Reliable/Reaqtor.Reliable/Reaqtor/Reliable/Expressions/ReliableQubscriptionFactoryBase.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Reliable/Reaqtor.Reliable/Reaqtor/Reliable/ReliableMultiSubject.cs
+++ b/Reaqtor/Core/Reliable/Reaqtor.Reliable/Reaqtor/Reliable/ReliableMultiSubject.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Reliable/Reaqtor.Reliable/Reaqtor/Reliable/ReliableMultiSubjectFactory.cs
+++ b/Reaqtor/Core/Reliable/Reaqtor.Reliable/Reaqtor/Reliable/ReliableMultiSubjectFactory.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Reliable/Reaqtor.Reliable/Reaqtor/Reliable/ReliableSubjectFactory.cs
+++ b/Reaqtor/Core/Reliable/Reaqtor.Reliable/Reaqtor/Reliable/ReliableSubjectFactory.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Reliable/Reaqtor.Reliable/Reaqtor/Reliable/ReliableSubscriptionBase.cs
+++ b/Reaqtor/Core/Reliable/Reaqtor.Reliable/Reaqtor/Reliable/ReliableSubscriptionBase.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Reliable/Reaqtor.Reliable/Reaqtor/Reliable/Service/KnownReliableQbservable.cs
+++ b/Reaqtor/Core/Reliable/Reaqtor.Reliable/Reaqtor/Reliable/Service/KnownReliableQbservable.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Reliable/Reaqtor.Reliable/Reaqtor/Reliable/Service/KnownReliableQbserver.cs
+++ b/Reaqtor/Core/Reliable/Reaqtor.Reliable/Reaqtor/Reliable/Service/KnownReliableQbserver.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Reliable/Reaqtor.Reliable/Reaqtor/Reliable/Service/KnownReliableQubject.cs
+++ b/Reaqtor/Core/Reliable/Reaqtor.Reliable/Reaqtor/Reliable/Service/KnownReliableQubject.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Reliable/Reaqtor.Reliable/Reaqtor/Reliable/Service/KnownReliableQubjectFactory.cs
+++ b/Reaqtor/Core/Reliable/Reaqtor.Reliable/Reaqtor/Reliable/Service/KnownReliableQubjectFactory.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Reliable/Reaqtor.Reliable/Reaqtor/Reliable/Service/KnownReliableQubscription.cs
+++ b/Reaqtor/Core/Reliable/Reaqtor.Reliable/Reaqtor/Reliable/Service/KnownReliableQubscription.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Reliable/Reaqtor.Reliable/Reaqtor/Reliable/Service/KnownReliableQubscriptionFactory.cs
+++ b/Reaqtor/Core/Reliable/Reaqtor.Reliable/Reaqtor/Reliable/Service/KnownReliableQubscriptionFactory.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Reliable/Reaqtor.Reliable/Reaqtor/Reliable/Service/ReliableQbservable.cs
+++ b/Reaqtor/Core/Reliable/Reaqtor.Reliable/Reaqtor/Reliable/Service/ReliableQbservable.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Reliable/Reaqtor.Reliable/Reaqtor/Reliable/Service/ReliableQbserver.cs
+++ b/Reaqtor/Core/Reliable/Reaqtor.Reliable/Reaqtor/Reliable/Service/ReliableQbserver.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Reliable/Reaqtor.Reliable/Reaqtor/Reliable/Service/ReliableQubject.cs
+++ b/Reaqtor/Core/Reliable/Reaqtor.Reliable/Reaqtor/Reliable/Service/ReliableQubject.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Reliable/Reaqtor.Reliable/Reaqtor/Reliable/Service/ReliableQubjectFactory.cs
+++ b/Reaqtor/Core/Reliable/Reaqtor.Reliable/Reaqtor/Reliable/Service/ReliableQubjectFactory.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Reliable/Reaqtor.Reliable/Reaqtor/Reliable/Service/ReliableQubscription.cs
+++ b/Reaqtor/Core/Reliable/Reaqtor.Reliable/Reaqtor/Reliable/Service/ReliableQubscription.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Reliable/Reaqtor.Reliable/Reaqtor/Reliable/Service/ReliableQubscriptionFactory.cs
+++ b/Reaqtor/Core/Reliable/Reaqtor.Reliable/Reaqtor/Reliable/Service/ReliableQubscriptionFactory.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Reliable/Reaqtor.Reliable/Reaqtor/Reliable/Service/ReliableQueryProvider.cs
+++ b/Reaqtor/Core/Reliable/Reaqtor.Reliable/Reaqtor/Reliable/Service/ReliableQueryProvider.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Reliable/Reaqtor.Reliable/Reaqtor/Reliable/Service/ReliableQueryProviderBase.cs
+++ b/Reaqtor/Core/Reliable/Reaqtor.Reliable/Reaqtor/Reliable/Service/ReliableQueryProviderBase.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Reliable/Reaqtor.Reliable/Reaqtor/Reliable/Service/ReliableReactiveClient.cs
+++ b/Reaqtor/Core/Reliable/Reaqtor.Reliable/Reaqtor/Reliable/Service/ReliableReactiveClient.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Reliable/Reaqtor.Reliable/Reaqtor/Reliable/Service/ReliableReactiveClientBase.cs
+++ b/Reaqtor/Core/Reliable/Reaqtor.Reliable/Reaqtor/Reliable/Service/ReliableReactiveClientBase.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Reliable/Reaqtor.Reliable/Reaqtor/Reliable/Service/ReliableReactiveServiceContext.cs
+++ b/Reaqtor/Core/Reliable/Reaqtor.Reliable/Reaqtor/Reliable/Service/ReliableReactiveServiceContext.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Reliable/Reaqtor.Reliable/Reaqtor/Reliable/Service/ReliableReactiveServiceContextBase.cs
+++ b/Reaqtor/Core/Reliable/Reaqtor.Reliable/Reaqtor/Reliable/Service/ReliableReactiveServiceContextBase.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Reliable/Reaqtor.Reliable/Versioning.cs
+++ b/Reaqtor/Core/Reliable/Reaqtor.Reliable/Versioning.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Reliable/Tests.Reaqtor.Reliable/Constants.cs
+++ b/Reaqtor/Core/Reliable/Tests.Reaqtor.Reliable/Constants.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Reliable/Tests.Reaqtor.Reliable/ReliableReactiveServiceContextTestBase.cs
+++ b/Reaqtor/Core/Reliable/Tests.Reaqtor.Reliable/ReliableReactiveServiceContextTestBase.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Reliable/Tests.Reaqtor.Reliable/ReliableReactiveServiceContextTests.cs
+++ b/Reaqtor/Core/Reliable/Tests.Reaqtor.Reliable/ReliableReactiveServiceContextTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Reliable/Tests.Reaqtor.Reliable/TestReliableServiceContext.cs
+++ b/Reaqtor/Core/Reliable/Tests.Reaqtor.Reliable/TestReliableServiceContext.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Service/Reaqtor.Service.Contracts/Properties/AssemblyInfo.cs
+++ b/Reaqtor/Core/Service/Reaqtor.Service.Contracts/Properties/AssemblyInfo.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Service/Reaqtor.Service.Contracts/Reaqtor/IReactiveClientServiceProvider.Generic.cs
+++ b/Reaqtor/Core/Service/Reaqtor.Service.Contracts/Reaqtor/IReactiveClientServiceProvider.Generic.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Service/Reaqtor.Service.Contracts/Reaqtor/IReactiveClientServiceProvider.cs
+++ b/Reaqtor/Core/Service/Reaqtor.Service.Contracts/Reaqtor/IReactiveClientServiceProvider.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Service/Reaqtor.Service.Contracts/Reaqtor/IReactiveDefinitionServiceProvider.Generic.cs
+++ b/Reaqtor/Core/Service/Reaqtor.Service.Contracts/Reaqtor/IReactiveDefinitionServiceProvider.Generic.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Service/Reaqtor.Service.Contracts/Reaqtor/IReactiveDefinitionServiceProvider.cs
+++ b/Reaqtor/Core/Service/Reaqtor.Service.Contracts/Reaqtor/IReactiveDefinitionServiceProvider.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Service/Reaqtor.Service.Contracts/Reaqtor/IReactiveMetadataServiceProvider.cs
+++ b/Reaqtor/Core/Service/Reaqtor.Service.Contracts/Reaqtor/IReactiveMetadataServiceProvider.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Service/Reaqtor.Service.Contracts/Reaqtor/IReactiveServiceProvider.Generic.cs
+++ b/Reaqtor/Core/Service/Reaqtor.Service.Contracts/Reaqtor/IReactiveServiceProvider.Generic.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Service/Reaqtor.Service.Contracts/Reaqtor/IReactiveServiceProvider.cs
+++ b/Reaqtor/Core/Service/Reaqtor.Service.Contracts/Reaqtor/IReactiveServiceProvider.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Service/Reaqtor.Service.Core/Properties/AssemblyInfo.cs
+++ b/Reaqtor/Core/Service/Reaqtor.Service.Core/Properties/AssemblyInfo.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Service/Reaqtor.Service.Core/Reaqtor/Internal/KnownQbservable.cs
+++ b/Reaqtor/Core/Service/Reaqtor.Service.Core/Reaqtor/Internal/KnownQbservable.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Service/Reaqtor.Service.Core/Reaqtor/Internal/KnownQbserver.cs
+++ b/Reaqtor/Core/Service/Reaqtor.Service.Core/Reaqtor/Internal/KnownQbserver.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Service/Reaqtor.Service.Core/Reaqtor/Internal/KnownQubject.cs
+++ b/Reaqtor/Core/Service/Reaqtor.Service.Core/Reaqtor/Internal/KnownQubject.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Service/Reaqtor.Service.Core/Reaqtor/Internal/KnownQubjectFactory.HigherArities.cs
+++ b/Reaqtor/Core/Service/Reaqtor.Service.Core/Reaqtor/Internal/KnownQubjectFactory.HigherArities.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Service/Reaqtor.Service.Core/Reaqtor/Internal/KnownQubjectFactory.cs
+++ b/Reaqtor/Core/Service/Reaqtor.Service.Core/Reaqtor/Internal/KnownQubjectFactory.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Service/Reaqtor.Service.Core/Reaqtor/Internal/KnownQubscription.cs
+++ b/Reaqtor/Core/Service/Reaqtor.Service.Core/Reaqtor/Internal/KnownQubscription.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Service/Reaqtor.Service.Core/Reaqtor/Internal/KnownQubscriptionFactory.HigherArities.cs
+++ b/Reaqtor/Core/Service/Reaqtor.Service.Core/Reaqtor/Internal/KnownQubscriptionFactory.HigherArities.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Service/Reaqtor.Service.Core/Reaqtor/Internal/KnownQubscriptionFactory.cs
+++ b/Reaqtor/Core/Service/Reaqtor.Service.Core/Reaqtor/Internal/KnownQubscriptionFactory.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Service/Reaqtor.Service.Core/Reaqtor/Internal/Qbservable.cs
+++ b/Reaqtor/Core/Service/Reaqtor.Service.Core/Reaqtor/Internal/Qbservable.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Service/Reaqtor.Service.Core/Reaqtor/Internal/Qbserver.cs
+++ b/Reaqtor/Core/Service/Reaqtor.Service.Core/Reaqtor/Internal/Qbserver.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Service/Reaqtor.Service.Core/Reaqtor/Internal/Qubject.cs
+++ b/Reaqtor/Core/Service/Reaqtor.Service.Core/Reaqtor/Internal/Qubject.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Service/Reaqtor.Service.Core/Reaqtor/Internal/QubjectFactory.HigherArities.cs
+++ b/Reaqtor/Core/Service/Reaqtor.Service.Core/Reaqtor/Internal/QubjectFactory.HigherArities.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Service/Reaqtor.Service.Core/Reaqtor/Internal/QubjectFactory.cs
+++ b/Reaqtor/Core/Service/Reaqtor.Service.Core/Reaqtor/Internal/QubjectFactory.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Service/Reaqtor.Service.Core/Reaqtor/Internal/Qubscription.cs
+++ b/Reaqtor/Core/Service/Reaqtor.Service.Core/Reaqtor/Internal/Qubscription.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Service/Reaqtor.Service.Core/Reaqtor/Internal/QubscriptionFactory.HigherArities.cs
+++ b/Reaqtor/Core/Service/Reaqtor.Service.Core/Reaqtor/Internal/QubscriptionFactory.HigherArities.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Service/Reaqtor.Service.Core/Reaqtor/Internal/QubscriptionFactory.cs
+++ b/Reaqtor/Core/Service/Reaqtor.Service.Core/Reaqtor/Internal/QubscriptionFactory.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Service/Reaqtor.Service.Core/Reaqtor/ReactiveClientBase.HigherArities.cs
+++ b/Reaqtor/Core/Service/Reaqtor.Service.Core/Reaqtor/ReactiveClientBase.HigherArities.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Service/Reaqtor.Service.Core/Reaqtor/ReactiveClientBase.cs
+++ b/Reaqtor/Core/Service/Reaqtor.Service.Core/Reaqtor/ReactiveClientBase.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Service/Reaqtor.Service.Core/Reaqtor/ReactiveDefinitionBase.HigherArities.cs
+++ b/Reaqtor/Core/Service/Reaqtor.Service.Core/Reaqtor/ReactiveDefinitionBase.HigherArities.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Service/Reaqtor.Service.Core/Reaqtor/ReactiveDefinitionBase.cs
+++ b/Reaqtor/Core/Service/Reaqtor.Service.Core/Reaqtor/ReactiveDefinitionBase.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Service/Reaqtor.Service.Core/Reaqtor/ReactiveMetadataBase.cs
+++ b/Reaqtor/Core/Service/Reaqtor.Service.Core/Reaqtor/ReactiveMetadataBase.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Service/Reaqtor.Service.Core/Reaqtor/ReactiveQueryProviderBase.HigherArities.cs
+++ b/Reaqtor/Core/Service/Reaqtor.Service.Core/Reaqtor/ReactiveQueryProviderBase.HigherArities.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Service/Reaqtor.Service.Core/Reaqtor/ReactiveQueryProviderBase.cs
+++ b/Reaqtor/Core/Service/Reaqtor.Service.Core/Reaqtor/ReactiveQueryProviderBase.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Service/Reaqtor.Service.Core/Reaqtor/UriToReactiveBinder.cs
+++ b/Reaqtor/Core/Service/Reaqtor.Service.Core/Reaqtor/UriToReactiveBinder.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Service/Reaqtor.Service.Model/Properties/AssemblyInfo.cs
+++ b/Reaqtor/Core/Service/Reaqtor.Service.Model/Properties/AssemblyInfo.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Service/Reaqtor.Service.Model/Reaqtor/IReactive.cs
+++ b/Reaqtor/Core/Service/Reaqtor.Service.Model/Reaqtor/IReactive.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Service/Reaqtor.Service.Model/Reaqtor/IReactiveClient.cs
+++ b/Reaqtor/Core/Service/Reaqtor.Service.Model/Reaqtor/IReactiveClient.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Service/Reaqtor.Service.Model/Reaqtor/IReactiveDefinition.cs
+++ b/Reaqtor/Core/Service/Reaqtor.Service.Model/Reaqtor/IReactiveDefinition.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Service/Reaqtor.Service.Model/Reaqtor/IReactiveMetadata.cs
+++ b/Reaqtor/Core/Service/Reaqtor.Service.Model/Reaqtor/IReactiveMetadata.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Service/Reaqtor.Service/Properties/AssemblyInfo.cs
+++ b/Reaqtor/Core/Service/Reaqtor.Service/Properties/AssemblyInfo.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Service/Reaqtor.Service/Reaqtor/ReactiveClient.cs
+++ b/Reaqtor/Core/Service/Reaqtor.Service/Reaqtor/ReactiveClient.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Service/Reaqtor.Service/Reaqtor/ReactiveDefinition.HigherArities.cs
+++ b/Reaqtor/Core/Service/Reaqtor.Service/Reaqtor/ReactiveDefinition.HigherArities.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Service/Reaqtor.Service/Reaqtor/ReactiveDefinition.cs
+++ b/Reaqtor/Core/Service/Reaqtor.Service/Reaqtor/ReactiveDefinition.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Service/Reaqtor.Service/Reaqtor/ReactiveMetadata.cs
+++ b/Reaqtor/Core/Service/Reaqtor.Service/Reaqtor/ReactiveMetadata.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Service/Reaqtor.Service/Reaqtor/ReactiveQueryProvider.cs
+++ b/Reaqtor/Core/Service/Reaqtor.Service/Reaqtor/ReactiveQueryProvider.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Service/Reaqtor.Service/Reaqtor/ReactiveServiceContext.cs
+++ b/Reaqtor/Core/Service/Reaqtor.Service/Reaqtor/ReactiveServiceContext.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Service/Reaqtor.Service/Reaqtor/ReactiveServiceContextBase.HigherArities.cs
+++ b/Reaqtor/Core/Service/Reaqtor.Service/Reaqtor/ReactiveServiceContextBase.HigherArities.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Service/Reaqtor.Service/Reaqtor/ReactiveServiceContextBase.cs
+++ b/Reaqtor/Core/Service/Reaqtor.Service/Reaqtor/ReactiveServiceContextBase.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Service/Tests.Reaqtor.Service.Core/Reaqtor/UriToReactiveBinderTests.cs
+++ b/Reaqtor/Core/Service/Tests.Reaqtor.Service.Core/Reaqtor/UriToReactiveBinderTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Service/Tests.Reaqtor.Service/Constants.cs
+++ b/Reaqtor/Core/Service/Tests.Reaqtor.Service/Constants.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Service/Tests.Reaqtor.Service/ReactiveServiceContextTestBase.cs
+++ b/Reaqtor/Core/Service/Tests.Reaqtor.Service/ReactiveServiceContextTestBase.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Service/Tests.Reaqtor.Service/ReactiveServiceContextTests.HigherArity.cs
+++ b/Reaqtor/Core/Service/Tests.Reaqtor.Service/ReactiveServiceContextTests.HigherArity.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Service/Tests.Reaqtor.Service/ReactiveServiceContextTests.cs
+++ b/Reaqtor/Core/Service/Tests.Reaqtor.Service/ReactiveServiceContextTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Service/Tests.Reaqtor.Service/TestServiceContext.cs
+++ b/Reaqtor/Core/Service/Tests.Reaqtor.Service/TestServiceContext.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Shared/Reaqtor.Shared.Core/GlobalSuppressions.cs
+++ b/Reaqtor/Core/Shared/Reaqtor.Shared.Core/GlobalSuppressions.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Shared/Reaqtor.Shared.Core/Properties/AssemblyInfo.cs
+++ b/Reaqtor/Core/Shared/Reaqtor.Shared.Core/Properties/AssemblyInfo.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Shared/Reaqtor.Shared.Core/Reaqtor/AsyncToSyncRewriter.cs
+++ b/Reaqtor/Core/Shared/Reaqtor.Shared.Core/Reaqtor/AsyncToSyncRewriter.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Shared/Reaqtor.Shared.Core/Reaqtor/ExpressionHelper.cs
+++ b/Reaqtor/Core/Shared/Reaqtor.Shared.Core/Reaqtor/ExpressionHelper.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Shared/Reaqtor.Shared.Core/Reaqtor/ReactiveExpressionServices.cs
+++ b/Reaqtor/Core/Shared/Reaqtor.Shared.Core/Reaqtor/ReactiveExpressionServices.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Shared/Reaqtor.Shared.Core/Reaqtor/SubstituteAndUnquoteRewriter.cs
+++ b/Reaqtor/Core/Shared/Reaqtor.Shared.Core/Reaqtor/SubstituteAndUnquoteRewriter.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Shared/Reaqtor.Shared.Core/Reaqtor/UriHelper.cs
+++ b/Reaqtor/Core/Shared/Reaqtor.Shared.Core/Reaqtor/UriHelper.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Shared/Reaqtor.Shared.Core/Reaqtor/UriToReactiveBinderBase.cs
+++ b/Reaqtor/Core/Shared/Reaqtor.Shared.Core/Reaqtor/UriToReactiveBinderBase.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Shared/Reaqtor.Shared.Core/System/Collections/Generic/ReadOnlyChainedDictionary.cs
+++ b/Reaqtor/Core/Shared/Reaqtor.Shared.Core/System/Collections/Generic/ReadOnlyChainedDictionary.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Shared/Reaqtor.Shared.Core/System/Linq/Expressions/ExpressionHeap.cs
+++ b/Reaqtor/Core/Shared/Reaqtor.Shared.Core/System/Linq/Expressions/ExpressionHeap.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Shared/Reaqtor.Shared.Core/System/Linq/QueryableDictionaryBase.cs
+++ b/Reaqtor/Core/Shared/Reaqtor.Shared.Core/System/Linq/QueryableDictionaryBase.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Shared/Reaqtor.Shared.Core/System/Runtime/CompilerServices/ConditionalWeakTableExtensions.cs
+++ b/Reaqtor/Core/Shared/Reaqtor.Shared.Core/System/Runtime/CompilerServices/ConditionalWeakTableExtensions.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Shared/Reaqtor.Shared.Model/GlobalSuppressions.cs
+++ b/Reaqtor/Core/Shared/Reaqtor.Shared.Model/GlobalSuppressions.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Shared/Reaqtor.Shared.Model/Properties/AssemblyInfo.cs
+++ b/Reaqtor/Core/Shared/Reaqtor.Shared.Model/Properties/AssemblyInfo.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Shared/Reaqtor.Shared.Model/Reaqtor/IKnownResource.cs
+++ b/Reaqtor/Core/Shared/Reaqtor.Shared.Model/Reaqtor/IKnownResource.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Shared/Reaqtor.Shared.Model/Reaqtor/IReactiveExpressionServices.cs
+++ b/Reaqtor/Core/Shared/Reaqtor.Shared.Model/Reaqtor/IReactiveExpressionServices.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Shared/Reaqtor.Shared.Model/Reaqtor/KnownResourceAttribute.cs
+++ b/Reaqtor/Core/Shared/Reaqtor.Shared.Model/Reaqtor/KnownResourceAttribute.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Shared/Reaqtor.Shared.Model/System/Linq/Expressions/IExpressible.cs
+++ b/Reaqtor/Core/Shared/Reaqtor.Shared.Model/System/Linq/Expressions/IExpressible.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Shared/Reaqtor.Shared.Model/System/Linq/IQueryableDictionary.cs
+++ b/Reaqtor/Core/Shared/Reaqtor.Shared.Model/System/Linq/IQueryableDictionary.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Shared/Tests.Reaqtor.Shared.Core/Reaqtor/AsyncToSyncRewriterTests.cs
+++ b/Reaqtor/Core/Shared/Tests.Reaqtor.Shared.Core/Reaqtor/AsyncToSyncRewriterTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Shared/Tests.Reaqtor.Shared.Core/Reaqtor/ReactiveExpressionServicesTests.cs
+++ b/Reaqtor/Core/Shared/Tests.Reaqtor.Shared.Core/Reaqtor/ReactiveExpressionServicesTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Shared/Tests.Reaqtor.Shared.Core/Reaqtor/ResourceNamingTests.cs
+++ b/Reaqtor/Core/Shared/Tests.Reaqtor.Shared.Core/Reaqtor/ResourceNamingTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Shared/Tests.Reaqtor.Shared.Core/Reaqtor/StructuralSubstitutingTypeComparatorTests.cs
+++ b/Reaqtor/Core/Shared/Tests.Reaqtor.Shared.Core/Reaqtor/StructuralSubstitutingTypeComparatorTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Shared/Tests.Reaqtor.Shared.Core/Reaqtor/StructuralTypeSubstitutionExpressionVisitorTests.cs
+++ b/Reaqtor/Core/Shared/Tests.Reaqtor.Shared.Core/Reaqtor/StructuralTypeSubstitutionExpressionVisitorTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Shared/Tests.Reaqtor.Shared.Core/Reaqtor/SubstituteAndUnquoteRewriterTests.cs
+++ b/Reaqtor/Core/Shared/Tests.Reaqtor.Shared.Core/Reaqtor/SubstituteAndUnquoteRewriterTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Shared/Tests.Reaqtor.Shared.Core/Reaqtor/UriHelperTests.cs
+++ b/Reaqtor/Core/Shared/Tests.Reaqtor.Shared.Core/Reaqtor/UriHelperTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Shared/Tests.Reaqtor.Shared.Core/System/Collections/Generic/ReadOnlyChainedDictionaryTests.cs
+++ b/Reaqtor/Core/Shared/Tests.Reaqtor.Shared.Core/System/Collections/Generic/ReadOnlyChainedDictionaryTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Shared/Tests.Reaqtor.Shared.Core/System/Linq/Expressions/ExpressionHeapTests.cs
+++ b/Reaqtor/Core/Shared/Tests.Reaqtor.Shared.Core/System/Linq/Expressions/ExpressionHeapTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Shared/Tests.Reaqtor.Shared.Core/System/Linq/QueryableDictionaryBaseTests.cs
+++ b/Reaqtor/Core/Shared/Tests.Reaqtor.Shared.Core/System/Linq/QueryableDictionaryBaseTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Testing/Reaqtor.ReificationFramework/Binder/IReactiveClientEnvironment.cs
+++ b/Reaqtor/Core/Testing/Reaqtor.ReificationFramework/Binder/IReactiveClientEnvironment.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Testing/Reaqtor.ReificationFramework/Binder/IReificationBinder.cs
+++ b/Reaqtor/Core/Testing/Reaqtor.ReificationFramework/Binder/IReificationBinder.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Testing/Reaqtor.ReificationFramework/Binder/ReactiveProxyReificationBinder.cs
+++ b/Reaqtor/Core/Testing/Reaqtor.ReificationFramework/Binder/ReactiveProxyReificationBinder.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Testing/Reaqtor.ReificationFramework/Binder/ReactiveProxyServiceOperationBinder.cs
+++ b/Reaqtor/Core/Testing/Reaqtor.ReificationFramework/Binder/ReactiveProxyServiceOperationBinder.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Testing/Reaqtor.ReificationFramework/Client/ReificationClientContext.cs
+++ b/Reaqtor/Core/Testing/Reaqtor.ReificationFramework/Client/ReificationClientContext.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Testing/Reaqtor.ReificationFramework/Client/ReificationConstants.cs
+++ b/Reaqtor/Core/Testing/Reaqtor.ReificationFramework/Client/ReificationConstants.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Testing/Reaqtor.ReificationFramework/Client/ReificationOperators.cs
+++ b/Reaqtor/Core/Testing/Reaqtor.ReificationFramework/Client/ReificationOperators.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Testing/Reaqtor.ReificationFramework/Internal/ExpressionHelpers.cs
+++ b/Reaqtor/Core/Testing/Reaqtor.ReificationFramework/Internal/ExpressionHelpers.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Testing/Reaqtor.ReificationFramework/Internal/ReificationServiceProvider.cs
+++ b/Reaqtor/Core/Testing/Reaqtor.ReificationFramework/Internal/ReificationServiceProvider.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Testing/Reaqtor.ReificationFramework/Operations/Async.cs
+++ b/Reaqtor/Core/Testing/Reaqtor.ReificationFramework/Operations/Async.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Testing/Reaqtor.ReificationFramework/Operations/Catch.cs
+++ b/Reaqtor/Core/Testing/Reaqtor.ReificationFramework/Operations/Catch.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Testing/Reaqtor.ReificationFramework/Operations/Chain.cs
+++ b/Reaqtor/Core/Testing/Reaqtor.ReificationFramework/Operations/Chain.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Testing/Reaqtor.ReificationFramework/Operations/DifferentialCheckpoint.cs
+++ b/Reaqtor/Core/Testing/Reaqtor.ReificationFramework/Operations/DifferentialCheckpoint.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Testing/Reaqtor.ReificationFramework/Operations/FullCheckpoint.cs
+++ b/Reaqtor/Core/Testing/Reaqtor.ReificationFramework/Operations/FullCheckpoint.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Testing/Reaqtor.ReificationFramework/Operations/IWildcardGenerator.cs
+++ b/Reaqtor/Core/Testing/Reaqtor.ReificationFramework/Operations/IWildcardGenerator.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Testing/Reaqtor.ReificationFramework/Operations/Instrument.cs
+++ b/Reaqtor/Core/Testing/Reaqtor.ReificationFramework/Operations/Instrument.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Testing/Reaqtor.ReificationFramework/Operations/LiftWildcards.cs
+++ b/Reaqtor/Core/Testing/Reaqtor.ReificationFramework/Operations/LiftWildcards.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Testing/Reaqtor.ReificationFramework/Operations/OperationBase.cs
+++ b/Reaqtor/Core/Testing/Reaqtor.ReificationFramework/Operations/OperationBase.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Testing/Reaqtor.ReificationFramework/Operations/QueryEngineOperation.cs
+++ b/Reaqtor/Core/Testing/Reaqtor.ReificationFramework/Operations/QueryEngineOperation.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Testing/Reaqtor.ReificationFramework/Operations/QueryEngineOperationKind.cs
+++ b/Reaqtor/Core/Testing/Reaqtor.ReificationFramework/Operations/QueryEngineOperationKind.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Testing/Reaqtor.ReificationFramework/Operations/QueryEngineOperationVisitor.Generic.cs
+++ b/Reaqtor/Core/Testing/Reaqtor.ReificationFramework/Operations/QueryEngineOperationVisitor.Generic.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Testing/Reaqtor.ReificationFramework/Operations/QueryEngineOperationVisitor.cs
+++ b/Reaqtor/Core/Testing/Reaqtor.ReificationFramework/Operations/QueryEngineOperationVisitor.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Testing/Reaqtor.ReificationFramework/Operations/Recovery.cs
+++ b/Reaqtor/Core/Testing/Reaqtor.ReificationFramework/Operations/Recovery.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Testing/Reaqtor.ReificationFramework/Operations/ReifiedOperation.cs
+++ b/Reaqtor/Core/Testing/Reaqtor.ReificationFramework/Operations/ReifiedOperation.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Testing/Reaqtor.ReificationFramework/Operations/ReifiedOperationBinder.cs
+++ b/Reaqtor/Core/Testing/Reaqtor.ReificationFramework/Operations/ReifiedOperationBinder.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Testing/Reaqtor.ReificationFramework/Operations/ReifiedOperationExtensions.cs
+++ b/Reaqtor/Core/Testing/Reaqtor.ReificationFramework/Operations/ReifiedOperationExtensions.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Testing/Reaqtor.ReificationFramework/Operations/ReifiedOperationKind.cs
+++ b/Reaqtor/Core/Testing/Reaqtor.ReificationFramework/Operations/ReifiedOperationKind.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Testing/Reaqtor.ReificationFramework/Operations/ReifiedOperationVisitor.Generic.cs
+++ b/Reaqtor/Core/Testing/Reaqtor.ReificationFramework/Operations/ReifiedOperationVisitor.Generic.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Testing/Reaqtor.ReificationFramework/Operations/ReifiedOperationVisitor.cs
+++ b/Reaqtor/Core/Testing/Reaqtor.ReificationFramework/Operations/ReifiedOperationVisitor.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Testing/Reaqtor.ReificationFramework/Operations/Repeat.cs
+++ b/Reaqtor/Core/Testing/Reaqtor.ReificationFramework/Operations/Repeat.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Testing/Reaqtor.ReificationFramework/Operations/RepeatUntil.cs
+++ b/Reaqtor/Core/Testing/Reaqtor.ReificationFramework/Operations/RepeatUntil.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Testing/Reaqtor.ReificationFramework/Operations/WildcardConsumer.cs
+++ b/Reaqtor/Core/Testing/Reaqtor.ReificationFramework/Operations/WildcardConsumer.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Testing/Reaqtor.ReificationFramework/Operations/WildcardGenerator.cs
+++ b/Reaqtor/Core/Testing/Reaqtor.ReificationFramework/Operations/WildcardGenerator.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Testing/Reaqtor.ReificationFramework/Operations/WildcardProducer.cs
+++ b/Reaqtor/Core/Testing/Reaqtor.ReificationFramework/Operations/WildcardProducer.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Testing/Reaqtor.ReificationFramework/Properties/AssemblyInfo.cs
+++ b/Reaqtor/Core/Testing/Reaqtor.ReificationFramework/Properties/AssemblyInfo.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Testing/Reaqtor.ReificationFramework/ReificationTestBase.cs
+++ b/Reaqtor/Core/Testing/Reaqtor.ReificationFramework/ReificationTestBase.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Testing/Reaqtor.ReifiedOperations/CreateObserver.cs
+++ b/Reaqtor/Core/Testing/Reaqtor.ReifiedOperations/CreateObserver.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Testing/Reaqtor.ReifiedOperations/CreateServiceOperation.cs
+++ b/Reaqtor/Core/Testing/Reaqtor.ReifiedOperations/CreateServiceOperation.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Testing/Reaqtor.ReifiedOperations/CreateStream.cs
+++ b/Reaqtor/Core/Testing/Reaqtor.ReifiedOperations/CreateStream.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Testing/Reaqtor.ReifiedOperations/CreateSubscription.cs
+++ b/Reaqtor/Core/Testing/Reaqtor.ReifiedOperations/CreateSubscription.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Testing/Reaqtor.ReifiedOperations/DefineObservable.cs
+++ b/Reaqtor/Core/Testing/Reaqtor.ReifiedOperations/DefineObservable.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Testing/Reaqtor.ReifiedOperations/DefineObserver.cs
+++ b/Reaqtor/Core/Testing/Reaqtor.ReifiedOperations/DefineObserver.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Testing/Reaqtor.ReifiedOperations/DefineServiceOperation.cs
+++ b/Reaqtor/Core/Testing/Reaqtor.ReifiedOperations/DefineServiceOperation.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Testing/Reaqtor.ReifiedOperations/DefineStreamFactory.cs
+++ b/Reaqtor/Core/Testing/Reaqtor.ReifiedOperations/DefineStreamFactory.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Testing/Reaqtor.ReifiedOperations/DefineSubscriptionFactory.cs
+++ b/Reaqtor/Core/Testing/Reaqtor.ReifiedOperations/DefineSubscriptionFactory.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Testing/Reaqtor.ReifiedOperations/DeleteMetadataOperation.cs
+++ b/Reaqtor/Core/Testing/Reaqtor.ReifiedOperations/DeleteMetadataOperation.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Testing/Reaqtor.ReifiedOperations/DeleteObservableMetadata.cs
+++ b/Reaqtor/Core/Testing/Reaqtor.ReifiedOperations/DeleteObservableMetadata.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Testing/Reaqtor.ReifiedOperations/DeleteObserverMetadata.cs
+++ b/Reaqtor/Core/Testing/Reaqtor.ReifiedOperations/DeleteObserverMetadata.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Testing/Reaqtor.ReifiedOperations/DeleteServiceOperation.cs
+++ b/Reaqtor/Core/Testing/Reaqtor.ReifiedOperations/DeleteServiceOperation.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Testing/Reaqtor.ReifiedOperations/DeleteStream.cs
+++ b/Reaqtor/Core/Testing/Reaqtor.ReifiedOperations/DeleteStream.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Testing/Reaqtor.ReifiedOperations/DeleteStreamFactoryMetadata.cs
+++ b/Reaqtor/Core/Testing/Reaqtor.ReifiedOperations/DeleteStreamFactoryMetadata.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Testing/Reaqtor.ReifiedOperations/DeleteStreamMetadata.cs
+++ b/Reaqtor/Core/Testing/Reaqtor.ReifiedOperations/DeleteStreamMetadata.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Testing/Reaqtor.ReifiedOperations/DeleteSubscription.cs
+++ b/Reaqtor/Core/Testing/Reaqtor.ReifiedOperations/DeleteSubscription.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Testing/Reaqtor.ReifiedOperations/DeleteSubscriptionFactoryMetadata.cs
+++ b/Reaqtor/Core/Testing/Reaqtor.ReifiedOperations/DeleteSubscriptionFactoryMetadata.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Testing/Reaqtor.ReifiedOperations/DeleteSubscriptionMetadata.cs
+++ b/Reaqtor/Core/Testing/Reaqtor.ReifiedOperations/DeleteSubscriptionMetadata.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Testing/Reaqtor.ReifiedOperations/InsertMetadataOperation.cs
+++ b/Reaqtor/Core/Testing/Reaqtor.ReifiedOperations/InsertMetadataOperation.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Testing/Reaqtor.ReifiedOperations/InsertObservableMetadata.cs
+++ b/Reaqtor/Core/Testing/Reaqtor.ReifiedOperations/InsertObservableMetadata.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Testing/Reaqtor.ReifiedOperations/InsertObserverMetadata.cs
+++ b/Reaqtor/Core/Testing/Reaqtor.ReifiedOperations/InsertObserverMetadata.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Testing/Reaqtor.ReifiedOperations/InsertStreamFactoryMetadata.cs
+++ b/Reaqtor/Core/Testing/Reaqtor.ReifiedOperations/InsertStreamFactoryMetadata.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Testing/Reaqtor.ReifiedOperations/InsertStreamMetadata.cs
+++ b/Reaqtor/Core/Testing/Reaqtor.ReifiedOperations/InsertStreamMetadata.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Testing/Reaqtor.ReifiedOperations/InsertSubscriptionFactoryMetadata.cs
+++ b/Reaqtor/Core/Testing/Reaqtor.ReifiedOperations/InsertSubscriptionFactoryMetadata.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Testing/Reaqtor.ReifiedOperations/InsertSubscriptionMetadata.cs
+++ b/Reaqtor/Core/Testing/Reaqtor.ReifiedOperations/InsertSubscriptionMetadata.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Testing/Reaqtor.ReifiedOperations/LookupMetadataOperation.cs
+++ b/Reaqtor/Core/Testing/Reaqtor.ReifiedOperations/LookupMetadataOperation.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Testing/Reaqtor.ReifiedOperations/LookupObservableMetadata.cs
+++ b/Reaqtor/Core/Testing/Reaqtor.ReifiedOperations/LookupObservableMetadata.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Testing/Reaqtor.ReifiedOperations/LookupObserverMetadata.cs
+++ b/Reaqtor/Core/Testing/Reaqtor.ReifiedOperations/LookupObserverMetadata.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Testing/Reaqtor.ReifiedOperations/LookupStreamFactoryMetadata.cs
+++ b/Reaqtor/Core/Testing/Reaqtor.ReifiedOperations/LookupStreamFactoryMetadata.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Testing/Reaqtor.ReifiedOperations/LookupStreamMetadata.cs
+++ b/Reaqtor/Core/Testing/Reaqtor.ReifiedOperations/LookupStreamMetadata.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Testing/Reaqtor.ReifiedOperations/LookupSubscriptionFactoryMetadata.cs
+++ b/Reaqtor/Core/Testing/Reaqtor.ReifiedOperations/LookupSubscriptionFactoryMetadata.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Testing/Reaqtor.ReifiedOperations/LookupSubscriptionMetadata.cs
+++ b/Reaqtor/Core/Testing/Reaqtor.ReifiedOperations/LookupSubscriptionMetadata.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Testing/Reaqtor.ReifiedOperations/MetadataOperation.cs
+++ b/Reaqtor/Core/Testing/Reaqtor.ReifiedOperations/MetadataOperation.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Testing/Reaqtor.ReifiedOperations/MetadataQuery.cs
+++ b/Reaqtor/Core/Testing/Reaqtor.ReifiedOperations/MetadataQuery.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Testing/Reaqtor.ReifiedOperations/ObserverOnCompleted.cs
+++ b/Reaqtor/Core/Testing/Reaqtor.ReifiedOperations/ObserverOnCompleted.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Testing/Reaqtor.ReifiedOperations/ObserverOnError.cs
+++ b/Reaqtor/Core/Testing/Reaqtor.ReifiedOperations/ObserverOnError.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Testing/Reaqtor.ReifiedOperations/ObserverOnNext.cs
+++ b/Reaqtor/Core/Testing/Reaqtor.ReifiedOperations/ObserverOnNext.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Testing/Reaqtor.ReifiedOperations/ObserverOperation.cs
+++ b/Reaqtor/Core/Testing/Reaqtor.ReifiedOperations/ObserverOperation.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Testing/Reaqtor.ReifiedOperations/Properties/AssemblyInfo.cs
+++ b/Reaqtor/Core/Testing/Reaqtor.ReifiedOperations/Properties/AssemblyInfo.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Testing/Reaqtor.ReifiedOperations/ServiceOperation.cs
+++ b/Reaqtor/Core/Testing/Reaqtor.ReifiedOperations/ServiceOperation.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Testing/Reaqtor.ReifiedOperations/ServiceOperationEqualityComparer.cs
+++ b/Reaqtor/Core/Testing/Reaqtor.ReifiedOperations/ServiceOperationEqualityComparer.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Testing/Reaqtor.ReifiedOperations/ServiceOperationKind.cs
+++ b/Reaqtor/Core/Testing/Reaqtor.ReifiedOperations/ServiceOperationKind.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Testing/Reaqtor.ReifiedOperations/ServiceOperationVisitor.Generic.cs
+++ b/Reaqtor/Core/Testing/Reaqtor.ReifiedOperations/ServiceOperationVisitor.Generic.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Testing/Reaqtor.ReifiedOperations/ServiceOperationVisitor.cs
+++ b/Reaqtor/Core/Testing/Reaqtor.ReifiedOperations/ServiceOperationVisitor.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Testing/Reaqtor.ReifiedOperations/StructuralServiceOperationEqualityComparer.cs
+++ b/Reaqtor/Core/Testing/Reaqtor.ReifiedOperations/StructuralServiceOperationEqualityComparer.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Testing/Reaqtor.ReifiedOperations/UndefineObservable.cs
+++ b/Reaqtor/Core/Testing/Reaqtor.ReifiedOperations/UndefineObservable.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Testing/Reaqtor.ReifiedOperations/UndefineObserver.cs
+++ b/Reaqtor/Core/Testing/Reaqtor.ReifiedOperations/UndefineObserver.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Testing/Reaqtor.ReifiedOperations/UndefineServiceOperation.cs
+++ b/Reaqtor/Core/Testing/Reaqtor.ReifiedOperations/UndefineServiceOperation.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Testing/Reaqtor.ReifiedOperations/UndefineStreamFactory.cs
+++ b/Reaqtor/Core/Testing/Reaqtor.ReifiedOperations/UndefineStreamFactory.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Testing/Reaqtor.ReifiedOperations/UndefineSubscriptionFactory.cs
+++ b/Reaqtor/Core/Testing/Reaqtor.ReifiedOperations/UndefineSubscriptionFactory.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Testing/Reaqtor.TestingFramework.Engine/AssertionTestEngineProvider.cs
+++ b/Reaqtor/Core/Testing/Reaqtor.TestingFramework.Engine/AssertionTestEngineProvider.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Testing/Reaqtor.TestingFramework.Engine/Properties/AssemblyInfo.cs
+++ b/Reaqtor/Core/Testing/Reaqtor.TestingFramework.Engine/Properties/AssemblyInfo.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Testing/Reaqtor.TestingFramework.Engine/SequentialAssertionTestEngineProvider.cs
+++ b/Reaqtor/Core/Testing/Reaqtor.TestingFramework.Engine/SequentialAssertionTestEngineProvider.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Testing/Reaqtor.TestingFramework.Engine/TestEngineProvider.cs
+++ b/Reaqtor/Core/Testing/Reaqtor.TestingFramework.Engine/TestEngineProvider.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Testing/Reaqtor.TestingFramework.Hosted/Properties/AssemblyInfo.cs
+++ b/Reaqtor/Core/Testing/Reaqtor.TestingFramework.Hosted/Properties/AssemblyInfo.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Testing/Reaqtor.TestingFramework.Hosted/TestExecutionEnvironment.BridgeFactory.cs
+++ b/Reaqtor/Core/Testing/Reaqtor.TestingFramework.Hosted/TestExecutionEnvironment.BridgeFactory.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Testing/Reaqtor.TestingFramework.Hosted/TestExecutionEnvironment.HigherOrder.cs
+++ b/Reaqtor/Core/Testing/Reaqtor.TestingFramework.Hosted/TestExecutionEnvironment.HigherOrder.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Testing/Reaqtor.TestingFramework.Hosted/TestExecutionEnvironment.IReactive.cs
+++ b/Reaqtor/Core/Testing/Reaqtor.TestingFramework.Hosted/TestExecutionEnvironment.IReactive.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Testing/Reaqtor.TestingFramework.Hosted/TestExecutionEnvironment.NotSoSimpleSubject.cs
+++ b/Reaqtor/Core/Testing/Reaqtor.TestingFramework.Hosted/TestExecutionEnvironment.NotSoSimpleSubject.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Testing/Reaqtor.TestingFramework.Hosted/TestExecutionEnvironment.NotSoSimpleUntypedSubject.cs
+++ b/Reaqtor/Core/Testing/Reaqtor.TestingFramework.Hosted/TestExecutionEnvironment.NotSoSimpleUntypedSubject.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Testing/Reaqtor.TestingFramework.Hosted/TestExecutionEnvironment.SimpleBridge.cs
+++ b/Reaqtor/Core/Testing/Reaqtor.TestingFramework.Hosted/TestExecutionEnvironment.SimpleBridge.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Testing/Reaqtor.TestingFramework.Hosted/TestExecutionEnvironment.SimpleSubjectFactory.cs
+++ b/Reaqtor/Core/Testing/Reaqtor.TestingFramework.Hosted/TestExecutionEnvironment.SimpleSubjectFactory.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Testing/Reaqtor.TestingFramework.Hosted/TestExecutionEnvironment.SimpleTunnel.cs
+++ b/Reaqtor/Core/Testing/Reaqtor.TestingFramework.Hosted/TestExecutionEnvironment.SimpleTunnel.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Testing/Reaqtor.TestingFramework.Hosted/TestExecutionEnvironment.SimpleUntypedSubjectFactory.cs
+++ b/Reaqtor/Core/Testing/Reaqtor.TestingFramework.Hosted/TestExecutionEnvironment.SimpleUntypedSubjectFactory.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Testing/Reaqtor.TestingFramework.Hosted/TestExecutionEnvironment.TunnelFactory.cs
+++ b/Reaqtor/Core/Testing/Reaqtor.TestingFramework.Hosted/TestExecutionEnvironment.TunnelFactory.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Testing/Reaqtor.TestingFramework.Hosted/TestExecutionEnvironment.cs
+++ b/Reaqtor/Core/Testing/Reaqtor.TestingFramework.Hosted/TestExecutionEnvironment.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Testing/Reaqtor.TestingFramework.Reliable/AssertionTestReliableEngineProvider.cs
+++ b/Reaqtor/Core/Testing/Reaqtor.TestingFramework.Reliable/AssertionTestReliableEngineProvider.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Testing/Reaqtor.TestingFramework.Reliable/Properties/AssemblyInfo.cs
+++ b/Reaqtor/Core/Testing/Reaqtor.TestingFramework.Reliable/Properties/AssemblyInfo.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Testing/Reaqtor.TestingFramework.Reliable/SequentialAssertionTestReliableEngineProvider.cs
+++ b/Reaqtor/Core/Testing/Reaqtor.TestingFramework.Reliable/SequentialAssertionTestReliableEngineProvider.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Testing/Reaqtor.TestingFramework.Reliable/TestReliableEngineProvider.cs
+++ b/Reaqtor/Core/Testing/Reaqtor.TestingFramework.Reliable/TestReliableEngineProvider.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Testing/Reaqtor.TestingFramework.Service/AssertionTestServiceProvider.cs
+++ b/Reaqtor/Core/Testing/Reaqtor.TestingFramework.Service/AssertionTestServiceProvider.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Testing/Reaqtor.TestingFramework.Service/Properties/AssemblyInfo.cs
+++ b/Reaqtor/Core/Testing/Reaqtor.TestingFramework.Service/Properties/AssemblyInfo.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Testing/Reaqtor.TestingFramework.Service/SequentialAssertionTestServiceProvider.cs
+++ b/Reaqtor/Core/Testing/Reaqtor.TestingFramework.Service/SequentialAssertionTestServiceProvider.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Testing/Reaqtor.TestingFramework.Service/TestServiceProvider.cs
+++ b/Reaqtor/Core/Testing/Reaqtor.TestingFramework.Service/TestServiceProvider.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Pearls/CSE/Client/KnownResourceAttribute.cs
+++ b/Reaqtor/Pearls/CSE/Client/KnownResourceAttribute.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Pearls/CSE/Client/Normalizer.cs
+++ b/Reaqtor/Pearls/CSE/Client/Normalizer.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Pearls/CSE/Compiler/ExpressionEqualityComparer.cs
+++ b/Reaqtor/Pearls/CSE/Compiler/ExpressionEqualityComparer.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Pearls/CSE/Compiler/TypeUnifier.cs
+++ b/Reaqtor/Pearls/CSE/Compiler/TypeUnifier.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Pearls/CSE/Misc/ConsoleLogger.cs
+++ b/Reaqtor/Pearls/CSE/Misc/ConsoleLogger.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Pearls/CSE/Misc/ILogger.cs
+++ b/Reaqtor/Pearls/CSE/Misc/ILogger.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Pearls/CSE/Optimizer/PredicateNormalizer.cs
+++ b/Reaqtor/Pearls/CSE/Optimizer/PredicateNormalizer.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Pearls/CSE/Optimizer/PredicateSimplifier.cs
+++ b/Reaqtor/Pearls/CSE/Optimizer/PredicateSimplifier.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Pearls/CSE/Optimizer/QueryOperatorNormalizer.cs
+++ b/Reaqtor/Pearls/CSE/Optimizer/QueryOperatorNormalizer.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Pearls/CSE/Optimizer/QueryOperatorOptimizer.cs
+++ b/Reaqtor/Pearls/CSE/Optimizer/QueryOperatorOptimizer.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Pearls/CSE/Program.cs
+++ b/Reaqtor/Pearls/CSE/Program.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Pearls/CSE/Rx/Observable.cs
+++ b/Reaqtor/Pearls/CSE/Rx/Observable.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Pearls/CSE/Rx/Observer.cs
+++ b/Reaqtor/Pearls/CSE/Rx/Observer.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Pearls/CSE/Rx/Subject.cs
+++ b/Reaqtor/Pearls/CSE/Rx/Subject.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Pearls/CSE/Service/Binder.cs
+++ b/Reaqtor/Pearls/CSE/Service/Binder.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Pearls/CSE/Service/Registry.cs
+++ b/Reaqtor/Pearls/CSE/Service/Registry.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Pearls/CSE/Service/Service.cs
+++ b/Reaqtor/Pearls/CSE/Service/Service.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Pearls/DelegatingBinder/Client/Client.cs
+++ b/Reaqtor/Pearls/DelegatingBinder/Client/Client.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Pearls/DelegatingBinder/Client/QueryLanguage.cs
+++ b/Reaqtor/Pearls/DelegatingBinder/Client/QueryLanguage.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Pearls/DelegatingBinder/Client/ResourceAttribute.cs
+++ b/Reaqtor/Pearls/DelegatingBinder/Client/ResourceAttribute.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Pearls/DelegatingBinder/Delegation/IDelegationTarget.cs
+++ b/Reaqtor/Pearls/DelegatingBinder/Delegation/IDelegationTarget.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Pearls/DelegatingBinder/Observers/Cout.cs
+++ b/Reaqtor/Pearls/DelegatingBinder/Observers/Cout.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Pearls/DelegatingBinder/Observers/Nop.cs
+++ b/Reaqtor/Pearls/DelegatingBinder/Observers/Nop.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Pearls/DelegatingBinder/Program.cs
+++ b/Reaqtor/Pearls/DelegatingBinder/Program.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Pearls/DelegatingBinder/Quoted/IQProvider.cs
+++ b/Reaqtor/Pearls/DelegatingBinder/Quoted/IQProvider.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Pearls/DelegatingBinder/Quoted/IQProviderBound.cs
+++ b/Reaqtor/Pearls/DelegatingBinder/Quoted/IQProviderBound.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Pearls/DelegatingBinder/Quoted/IQbservable.cs
+++ b/Reaqtor/Pearls/DelegatingBinder/Quoted/IQbservable.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Pearls/DelegatingBinder/Quoted/IQbserver.cs
+++ b/Reaqtor/Pearls/DelegatingBinder/Quoted/IQbserver.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Pearls/DelegatingBinder/Quoted/IQubject.cs
+++ b/Reaqtor/Pearls/DelegatingBinder/Quoted/IQubject.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Pearls/DelegatingBinder/Quoted/IQubjectFactory.cs
+++ b/Reaqtor/Pearls/DelegatingBinder/Quoted/IQubjectFactory.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Pearls/DelegatingBinder/Quoted/IQubscription.cs
+++ b/Reaqtor/Pearls/DelegatingBinder/Quoted/IQubscription.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Pearls/DelegatingBinder/Reactive/ISubjectFactory.cs
+++ b/Reaqtor/Pearls/DelegatingBinder/Reactive/ISubjectFactory.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Pearls/DelegatingBinder/Reactive/SubjectFactory.cs
+++ b/Reaqtor/Pearls/DelegatingBinder/Reactive/SubjectFactory.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Pearls/DelegatingBinder/Service/IService.cs
+++ b/Reaqtor/Pearls/DelegatingBinder/Service/IService.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Pearls/DelegatingBinder/Service/Service.cs
+++ b/Reaqtor/Pearls/DelegatingBinder/Service/Service.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Pearls/DelegatingBinder/Subjects/PartitionedSubject.cs
+++ b/Reaqtor/Pearls/DelegatingBinder/Subjects/PartitionedSubject.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Pearls/DelegatingBinder/Subjects/PartitionedSubjectFactory.cs
+++ b/Reaqtor/Pearls/DelegatingBinder/Subjects/PartitionedSubjectFactory.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Pearls/OperatorFusion/OperatorFusion/Compiler/CloseStateParameter.cs
+++ b/Reaqtor/Pearls/OperatorFusion/OperatorFusion/Compiler/CloseStateParameter.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Pearls/OperatorFusion/OperatorFusion/Compiler/Compiler.cs
+++ b/Reaqtor/Pearls/OperatorFusion/OperatorFusion/Compiler/Compiler.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Pearls/OperatorFusion/OperatorFusion/ConsoleObserver.cs
+++ b/Reaqtor/Pearls/OperatorFusion/OperatorFusion/ConsoleObserver.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Pearls/OperatorFusion/OperatorFusion/Disposable.cs
+++ b/Reaqtor/Pearls/OperatorFusion/OperatorFusion/Disposable.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Pearls/OperatorFusion/OperatorFusion/Operators/HoistOperations.cs
+++ b/Reaqtor/Pearls/OperatorFusion/OperatorFusion/Operators/HoistOperations.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Pearls/OperatorFusion/OperatorFusion/Operators/IFusionOperator.cs
+++ b/Reaqtor/Pearls/OperatorFusion/OperatorFusion/Operators/IFusionOperator.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Pearls/OperatorFusion/OperatorFusion/Operators/Linq/Impl/Count.cs
+++ b/Reaqtor/Pearls/OperatorFusion/OperatorFusion/Operators/Linq/Impl/Count.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Pearls/OperatorFusion/OperatorFusion/Operators/Linq/Impl/DistinctUntilChanged.cs
+++ b/Reaqtor/Pearls/OperatorFusion/OperatorFusion/Operators/Linq/Impl/DistinctUntilChanged.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Pearls/OperatorFusion/OperatorFusion/Operators/Linq/Impl/First.cs
+++ b/Reaqtor/Pearls/OperatorFusion/OperatorFusion/Operators/Linq/Impl/First.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Pearls/OperatorFusion/OperatorFusion/Operators/Linq/Impl/FirstOrDefault.cs
+++ b/Reaqtor/Pearls/OperatorFusion/OperatorFusion/Operators/Linq/Impl/FirstOrDefault.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Pearls/OperatorFusion/OperatorFusion/Operators/Linq/Impl/IgnoreElements.cs
+++ b/Reaqtor/Pearls/OperatorFusion/OperatorFusion/Operators/Linq/Impl/IgnoreElements.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Pearls/OperatorFusion/OperatorFusion/Operators/Linq/Impl/Last.cs
+++ b/Reaqtor/Pearls/OperatorFusion/OperatorFusion/Operators/Linq/Impl/Last.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Pearls/OperatorFusion/OperatorFusion/Operators/Linq/Impl/LongCount.cs
+++ b/Reaqtor/Pearls/OperatorFusion/OperatorFusion/Operators/Linq/Impl/LongCount.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Pearls/OperatorFusion/OperatorFusion/Operators/Linq/Impl/Select.cs
+++ b/Reaqtor/Pearls/OperatorFusion/OperatorFusion/Operators/Linq/Impl/Select.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Pearls/OperatorFusion/OperatorFusion/Operators/Linq/Impl/SelectIndexed.cs
+++ b/Reaqtor/Pearls/OperatorFusion/OperatorFusion/Operators/Linq/Impl/SelectIndexed.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Pearls/OperatorFusion/OperatorFusion/Operators/Linq/Impl/Sum.cs
+++ b/Reaqtor/Pearls/OperatorFusion/OperatorFusion/Operators/Linq/Impl/Sum.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Pearls/OperatorFusion/OperatorFusion/Operators/Linq/Impl/Take.cs
+++ b/Reaqtor/Pearls/OperatorFusion/OperatorFusion/Operators/Linq/Impl/Take.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Pearls/OperatorFusion/OperatorFusion/Operators/Linq/Impl/Where.cs
+++ b/Reaqtor/Pearls/OperatorFusion/OperatorFusion/Operators/Linq/Impl/Where.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Pearls/OperatorFusion/OperatorFusion/Operators/Linq/Impl/WhereIndexed.cs
+++ b/Reaqtor/Pearls/OperatorFusion/OperatorFusion/Operators/Linq/Impl/WhereIndexed.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Pearls/OperatorFusion/OperatorFusion/Operators/Linq/QueryLanguage.cs
+++ b/Reaqtor/Pearls/OperatorFusion/OperatorFusion/Operators/Linq/QueryLanguage.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Pearls/OperatorFusion/OperatorFusion/Operators/Operator.cs
+++ b/Reaqtor/Pearls/OperatorFusion/OperatorFusion/Operators/Operator.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Pearls/OperatorFusion/OperatorFusion/Operators/Sink.cs
+++ b/Reaqtor/Pearls/OperatorFusion/OperatorFusion/Operators/Sink.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Pearls/OperatorFusion/OperatorFusion/Operators/SinkOperator.cs
+++ b/Reaqtor/Pearls/OperatorFusion/OperatorFusion/Operators/SinkOperator.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Pearls/OperatorFusion/OperatorFusion/Program.cs
+++ b/Reaqtor/Pearls/OperatorFusion/OperatorFusion/Program.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Pearls/OperatorFusion/RuntimeLib/NopObserver.cs
+++ b/Reaqtor/Pearls/OperatorFusion/RuntimeLib/NopObserver.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Pearls/OperatorFusion/RuntimeLib/Sentinels.cs
+++ b/Reaqtor/Pearls/OperatorFusion/RuntimeLib/Sentinels.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Pearls/OperatorFusion/RuntimeLib/Sink.cs
+++ b/Reaqtor/Pearls/OperatorFusion/RuntimeLib/Sink.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Pearls/OperatorLocalStorage/Engine/CheckpointingQueryEngine.cs
+++ b/Reaqtor/Pearls/OperatorLocalStorage/Engine/CheckpointingQueryEngine.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Pearls/OperatorLocalStorage/Engine/QueryEngineContext.cs
+++ b/Reaqtor/Pearls/OperatorLocalStorage/Engine/QueryEngineContext.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Pearls/OperatorLocalStorage/Library/Nuqleon/Invariant.cs
+++ b/Reaqtor/Pearls/OperatorLocalStorage/Library/Nuqleon/Invariant.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Pearls/OperatorLocalStorage/Library/Nuqleon/Reactive/Serialization/IDeserializer.cs
+++ b/Reaqtor/Pearls/OperatorLocalStorage/Library/Nuqleon/Reactive/Serialization/IDeserializer.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Pearls/OperatorLocalStorage/Library/Nuqleon/Reactive/Serialization/IDeserializerFactory.cs
+++ b/Reaqtor/Pearls/OperatorLocalStorage/Library/Nuqleon/Reactive/Serialization/IDeserializerFactory.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Pearls/OperatorLocalStorage/Library/Nuqleon/Reactive/Serialization/ISerializationFactory.cs
+++ b/Reaqtor/Pearls/OperatorLocalStorage/Library/Nuqleon/Reactive/Serialization/ISerializationFactory.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Pearls/OperatorLocalStorage/Library/Nuqleon/Reactive/Serialization/ISerializer.cs
+++ b/Reaqtor/Pearls/OperatorLocalStorage/Library/Nuqleon/Reactive/Serialization/ISerializer.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Pearls/OperatorLocalStorage/Library/Nuqleon/Reactive/Serialization/ISerializerFactory.cs
+++ b/Reaqtor/Pearls/OperatorLocalStorage/Library/Nuqleon/Reactive/Serialization/ISerializerFactory.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Pearls/OperatorLocalStorage/Library/Nuqleon/Reactive/Storage/DictionarySnapshotVisitor.cs
+++ b/Reaqtor/Pearls/OperatorLocalStorage/Library/Nuqleon/Reactive/Storage/DictionarySnapshotVisitor.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Pearls/OperatorLocalStorage/Library/Nuqleon/Reactive/Storage/Edit.cs
+++ b/Reaqtor/Pearls/OperatorLocalStorage/Library/Nuqleon/Reactive/Storage/Edit.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Pearls/OperatorLocalStorage/Library/Nuqleon/Reactive/Storage/EventualObject.cs
+++ b/Reaqtor/Pearls/OperatorLocalStorage/Library/Nuqleon/Reactive/Storage/EventualObject.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Pearls/OperatorLocalStorage/Library/Nuqleon/Reactive/Storage/IPersistable.cs
+++ b/Reaqtor/Pearls/OperatorLocalStorage/Library/Nuqleon/Reactive/Storage/IPersistable.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Pearls/OperatorLocalStorage/Library/Nuqleon/Reactive/Storage/IPersisted.cs
+++ b/Reaqtor/Pearls/OperatorLocalStorage/Library/Nuqleon/Reactive/Storage/IPersisted.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Pearls/OperatorLocalStorage/Library/Nuqleon/Reactive/Storage/IPersistedArray.cs
+++ b/Reaqtor/Pearls/OperatorLocalStorage/Library/Nuqleon/Reactive/Storage/IPersistedArray.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Pearls/OperatorLocalStorage/Library/Nuqleon/Reactive/Storage/IPersistedDictionary.cs
+++ b/Reaqtor/Pearls/OperatorLocalStorage/Library/Nuqleon/Reactive/Storage/IPersistedDictionary.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Pearls/OperatorLocalStorage/Library/Nuqleon/Reactive/Storage/IPersistedLinkedList.cs
+++ b/Reaqtor/Pearls/OperatorLocalStorage/Library/Nuqleon/Reactive/Storage/IPersistedLinkedList.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Pearls/OperatorLocalStorage/Library/Nuqleon/Reactive/Storage/IPersistedList.cs
+++ b/Reaqtor/Pearls/OperatorLocalStorage/Library/Nuqleon/Reactive/Storage/IPersistedList.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Pearls/OperatorLocalStorage/Library/Nuqleon/Reactive/Storage/IPersistedObjectSpace.cs
+++ b/Reaqtor/Pearls/OperatorLocalStorage/Library/Nuqleon/Reactive/Storage/IPersistedObjectSpace.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Pearls/OperatorLocalStorage/Library/Nuqleon/Reactive/Storage/IPersistedQueue.cs
+++ b/Reaqtor/Pearls/OperatorLocalStorage/Library/Nuqleon/Reactive/Storage/IPersistedQueue.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Pearls/OperatorLocalStorage/Library/Nuqleon/Reactive/Storage/IPersistedSet.cs
+++ b/Reaqtor/Pearls/OperatorLocalStorage/Library/Nuqleon/Reactive/Storage/IPersistedSet.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Pearls/OperatorLocalStorage/Library/Nuqleon/Reactive/Storage/IPersistedSortedDictionary.cs
+++ b/Reaqtor/Pearls/OperatorLocalStorage/Library/Nuqleon/Reactive/Storage/IPersistedSortedDictionary.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Pearls/OperatorLocalStorage/Library/Nuqleon/Reactive/Storage/IPersistedSortedSet.cs
+++ b/Reaqtor/Pearls/OperatorLocalStorage/Library/Nuqleon/Reactive/Storage/IPersistedSortedSet.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Pearls/OperatorLocalStorage/Library/Nuqleon/Reactive/Storage/IPersistedStack.cs
+++ b/Reaqtor/Pearls/OperatorLocalStorage/Library/Nuqleon/Reactive/Storage/IPersistedStack.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Pearls/OperatorLocalStorage/Library/Nuqleon/Reactive/Storage/IPersistedValue.cs
+++ b/Reaqtor/Pearls/OperatorLocalStorage/Library/Nuqleon/Reactive/Storage/IPersistedValue.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Pearls/OperatorLocalStorage/Library/Nuqleon/Reactive/Storage/ISnapshot.cs
+++ b/Reaqtor/Pearls/OperatorLocalStorage/Library/Nuqleon/Reactive/Storage/ISnapshot.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Pearls/OperatorLocalStorage/Library/Nuqleon/Reactive/Storage/ISnapshotVisitor.cs
+++ b/Reaqtor/Pearls/OperatorLocalStorage/Library/Nuqleon/Reactive/Storage/ISnapshotVisitor.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Pearls/OperatorLocalStorage/Library/Nuqleon/Reactive/Storage/ITransactionalDictionary.cs
+++ b/Reaqtor/Pearls/OperatorLocalStorage/Library/Nuqleon/Reactive/Storage/ITransactionalDictionary.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Pearls/OperatorLocalStorage/Library/Nuqleon/Reactive/Storage/IntegerKey.cs
+++ b/Reaqtor/Pearls/OperatorLocalStorage/Library/Nuqleon/Reactive/Storage/IntegerKey.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Pearls/OperatorLocalStorage/Library/Nuqleon/Reactive/Storage/Map.cs
+++ b/Reaqtor/Pearls/OperatorLocalStorage/Library/Nuqleon/Reactive/Storage/Map.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Pearls/OperatorLocalStorage/Library/Nuqleon/Reactive/Storage/Maybe.cs
+++ b/Reaqtor/Pearls/OperatorLocalStorage/Library/Nuqleon/Reactive/Storage/Maybe.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Pearls/OperatorLocalStorage/Library/Nuqleon/Reactive/Storage/PersistableKind.cs
+++ b/Reaqtor/Pearls/OperatorLocalStorage/Library/Nuqleon/Reactive/Storage/PersistableKind.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Pearls/OperatorLocalStorage/Library/Nuqleon/Reactive/Storage/PersistedBase.cs
+++ b/Reaqtor/Pearls/OperatorLocalStorage/Library/Nuqleon/Reactive/Storage/PersistedBase.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Pearls/OperatorLocalStorage/Library/Nuqleon/Reactive/Storage/PersistedObjectSpace.Array.cs
+++ b/Reaqtor/Pearls/OperatorLocalStorage/Library/Nuqleon/Reactive/Storage/PersistedObjectSpace.Array.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Pearls/OperatorLocalStorage/Library/Nuqleon/Reactive/Storage/PersistedObjectSpace.Descriptor.cs
+++ b/Reaqtor/Pearls/OperatorLocalStorage/Library/Nuqleon/Reactive/Storage/PersistedObjectSpace.Descriptor.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Pearls/OperatorLocalStorage/Library/Nuqleon/Reactive/Storage/PersistedObjectSpace.Dictionary.Sorted.cs
+++ b/Reaqtor/Pearls/OperatorLocalStorage/Library/Nuqleon/Reactive/Storage/PersistedObjectSpace.Dictionary.Sorted.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Pearls/OperatorLocalStorage/Library/Nuqleon/Reactive/Storage/PersistedObjectSpace.Dictionary.Unsorted.cs
+++ b/Reaqtor/Pearls/OperatorLocalStorage/Library/Nuqleon/Reactive/Storage/PersistedObjectSpace.Dictionary.Unsorted.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Pearls/OperatorLocalStorage/Library/Nuqleon/Reactive/Storage/PersistedObjectSpace.Dictionary.cs
+++ b/Reaqtor/Pearls/OperatorLocalStorage/Library/Nuqleon/Reactive/Storage/PersistedObjectSpace.Dictionary.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Pearls/OperatorLocalStorage/Library/Nuqleon/Reactive/Storage/PersistedObjectSpace.Heap.cs
+++ b/Reaqtor/Pearls/OperatorLocalStorage/Library/Nuqleon/Reactive/Storage/PersistedObjectSpace.Heap.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Pearls/OperatorLocalStorage/Library/Nuqleon/Reactive/Storage/PersistedObjectSpace.HeapBase.cs
+++ b/Reaqtor/Pearls/OperatorLocalStorage/Library/Nuqleon/Reactive/Storage/PersistedObjectSpace.HeapBase.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Pearls/OperatorLocalStorage/Library/Nuqleon/Reactive/Storage/PersistedObjectSpace.ItemReader.cs
+++ b/Reaqtor/Pearls/OperatorLocalStorage/Library/Nuqleon/Reactive/Storage/PersistedObjectSpace.ItemReader.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Pearls/OperatorLocalStorage/Library/Nuqleon/Reactive/Storage/PersistedObjectSpace.ItemWriter.cs
+++ b/Reaqtor/Pearls/OperatorLocalStorage/Library/Nuqleon/Reactive/Storage/PersistedObjectSpace.ItemWriter.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Pearls/OperatorLocalStorage/Library/Nuqleon/Reactive/Storage/PersistedObjectSpace.LinkedList.cs
+++ b/Reaqtor/Pearls/OperatorLocalStorage/Library/Nuqleon/Reactive/Storage/PersistedObjectSpace.LinkedList.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Pearls/OperatorLocalStorage/Library/Nuqleon/Reactive/Storage/PersistedObjectSpace.List.cs
+++ b/Reaqtor/Pearls/OperatorLocalStorage/Library/Nuqleon/Reactive/Storage/PersistedObjectSpace.List.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Pearls/OperatorLocalStorage/Library/Nuqleon/Reactive/Storage/PersistedObjectSpace.PersistableBase.cs
+++ b/Reaqtor/Pearls/OperatorLocalStorage/Library/Nuqleon/Reactive/Storage/PersistedObjectSpace.PersistableBase.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Pearls/OperatorLocalStorage/Library/Nuqleon/Reactive/Storage/PersistedObjectSpace.Queue.cs
+++ b/Reaqtor/Pearls/OperatorLocalStorage/Library/Nuqleon/Reactive/Storage/PersistedObjectSpace.Queue.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Pearls/OperatorLocalStorage/Library/Nuqleon/Reactive/Storage/PersistedObjectSpace.Registry.cs
+++ b/Reaqtor/Pearls/OperatorLocalStorage/Library/Nuqleon/Reactive/Storage/PersistedObjectSpace.Registry.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Pearls/OperatorLocalStorage/Library/Nuqleon/Reactive/Storage/PersistedObjectSpace.Set.Sorted.cs
+++ b/Reaqtor/Pearls/OperatorLocalStorage/Library/Nuqleon/Reactive/Storage/PersistedObjectSpace.Set.Sorted.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Pearls/OperatorLocalStorage/Library/Nuqleon/Reactive/Storage/PersistedObjectSpace.Set.Unsorted.cs
+++ b/Reaqtor/Pearls/OperatorLocalStorage/Library/Nuqleon/Reactive/Storage/PersistedObjectSpace.Set.Unsorted.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Pearls/OperatorLocalStorage/Library/Nuqleon/Reactive/Storage/PersistedObjectSpace.Stack.cs
+++ b/Reaqtor/Pearls/OperatorLocalStorage/Library/Nuqleon/Reactive/Storage/PersistedObjectSpace.Stack.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Pearls/OperatorLocalStorage/Library/Nuqleon/Reactive/Storage/PersistedObjectSpace.Value.cs
+++ b/Reaqtor/Pearls/OperatorLocalStorage/Library/Nuqleon/Reactive/Storage/PersistedObjectSpace.Value.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Pearls/OperatorLocalStorage/Library/Nuqleon/Reactive/Storage/PersistedObjectSpace.cs
+++ b/Reaqtor/Pearls/OperatorLocalStorage/Library/Nuqleon/Reactive/Storage/PersistedObjectSpace.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Pearls/OperatorLocalStorage/Library/Nuqleon/Reactive/Storage/StateChangedManager.cs
+++ b/Reaqtor/Pearls/OperatorLocalStorage/Library/Nuqleon/Reactive/Storage/StateChangedManager.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Pearls/OperatorLocalStorage/Library/Nuqleon/Reactive/Storage/StateReaderWriterExtensions.cs
+++ b/Reaqtor/Pearls/OperatorLocalStorage/Library/Nuqleon/Reactive/Storage/StateReaderWriterExtensions.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Pearls/OperatorLocalStorage/Library/Nuqleon/Reactive/Storage/TransactionalDictionary.cs
+++ b/Reaqtor/Pearls/OperatorLocalStorage/Library/Nuqleon/Reactive/Storage/TransactionalDictionary.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Pearls/OperatorLocalStorage/Library/Nuqleon/Reactive/Storage/VolatilePersistedObjectSpace.cs
+++ b/Reaqtor/Pearls/OperatorLocalStorage/Library/Nuqleon/Reactive/Storage/VolatilePersistedObjectSpace.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Pearls/OperatorLocalStorage/Library/System/Collections/Generic/IArray.cs
+++ b/Reaqtor/Pearls/OperatorLocalStorage/Library/System/Collections/Generic/IArray.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Pearls/OperatorLocalStorage/Library/System/Collections/Generic/ILinkedList.cs
+++ b/Reaqtor/Pearls/OperatorLocalStorage/Library/System/Collections/Generic/ILinkedList.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Pearls/OperatorLocalStorage/Library/System/Collections/Generic/ILinkedListNode.cs
+++ b/Reaqtor/Pearls/OperatorLocalStorage/Library/System/Collections/Generic/ILinkedListNode.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Pearls/OperatorLocalStorage/Library/System/Collections/Generic/IQueue.cs
+++ b/Reaqtor/Pearls/OperatorLocalStorage/Library/System/Collections/Generic/IQueue.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Pearls/OperatorLocalStorage/Library/System/Collections/Generic/IReadOnlyLinkedList.cs
+++ b/Reaqtor/Pearls/OperatorLocalStorage/Library/System/Collections/Generic/IReadOnlyLinkedList.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Pearls/OperatorLocalStorage/Library/System/Collections/Generic/IReadOnlyLinkedListNode.cs
+++ b/Reaqtor/Pearls/OperatorLocalStorage/Library/System/Collections/Generic/IReadOnlyLinkedListNode.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Pearls/OperatorLocalStorage/Library/System/Collections/Generic/ISortedSet.cs
+++ b/Reaqtor/Pearls/OperatorLocalStorage/Library/System/Collections/Generic/ISortedSet.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Pearls/OperatorLocalStorage/Library/System/Collections/Generic/IStack.cs
+++ b/Reaqtor/Pearls/OperatorLocalStorage/Library/System/Collections/Generic/IStack.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Pearls/OperatorLocalStorage/Library/System/IReadOnlyValue.cs
+++ b/Reaqtor/Pearls/OperatorLocalStorage/Library/System/IReadOnlyValue.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Pearls/OperatorLocalStorage/Library/System/IValue.cs
+++ b/Reaqtor/Pearls/OperatorLocalStorage/Library/System/IValue.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Pearls/OperatorLocalStorage/OperatorLocalStorage/ArtifactDefinitionHelpers.cs
+++ b/Reaqtor/Pearls/OperatorLocalStorage/OperatorLocalStorage/ArtifactDefinitionHelpers.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Pearls/OperatorLocalStorage/OperatorLocalStorage/EngineIntegrationTests.CastVisitor.cs
+++ b/Reaqtor/Pearls/OperatorLocalStorage/OperatorLocalStorage/EngineIntegrationTests.CastVisitor.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Pearls/OperatorLocalStorage/OperatorLocalStorage/EngineIntegrationTests.Registry.cs
+++ b/Reaqtor/Pearls/OperatorLocalStorage/OperatorLocalStorage/EngineIntegrationTests.Registry.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Pearls/OperatorLocalStorage/OperatorLocalStorage/EngineIntegrationTests.Resolver.cs
+++ b/Reaqtor/Pearls/OperatorLocalStorage/OperatorLocalStorage/EngineIntegrationTests.Resolver.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Pearls/OperatorLocalStorage/OperatorLocalStorage/EngineIntegrationTests.Sink.cs
+++ b/Reaqtor/Pearls/OperatorLocalStorage/OperatorLocalStorage/EngineIntegrationTests.Sink.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Pearls/OperatorLocalStorage/OperatorLocalStorage/EngineIntegrationTests.Source.cs
+++ b/Reaqtor/Pearls/OperatorLocalStorage/OperatorLocalStorage/EngineIntegrationTests.Source.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Pearls/OperatorLocalStorage/OperatorLocalStorage/EngineIntegrationTests.StreamManager.cs
+++ b/Reaqtor/Pearls/OperatorLocalStorage/OperatorLocalStorage/EngineIntegrationTests.StreamManager.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Pearls/OperatorLocalStorage/OperatorLocalStorage/EngineIntegrationTests.cs
+++ b/Reaqtor/Pearls/OperatorLocalStorage/OperatorLocalStorage/EngineIntegrationTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Pearls/OperatorLocalStorage/OperatorLocalStorage/Program.cs
+++ b/Reaqtor/Pearls/OperatorLocalStorage/OperatorLocalStorage/Program.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Pearls/OperatorLocalStorage/OperatorLocalStorage/StoreExtensions.cs
+++ b/Reaqtor/Pearls/OperatorLocalStorage/OperatorLocalStorage/StoreExtensions.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Pearls/OperatorLocalStorage/Operators/Nuqleon/Reactive/Buffer.cs
+++ b/Reaqtor/Pearls/OperatorLocalStorage/Operators/Nuqleon/Reactive/Buffer.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Pearls/OperatorLocalStorage/Operators/Versioning.cs
+++ b/Reaqtor/Pearls/OperatorLocalStorage/Operators/Versioning.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Pearls/OperatorLocalStorage/Tests/ArrayTests.cs
+++ b/Reaqtor/Pearls/OperatorLocalStorage/Tests/ArrayTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Pearls/OperatorLocalStorage/Tests/IntegerKeyTests.cs
+++ b/Reaqtor/Pearls/OperatorLocalStorage/Tests/IntegerKeyTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Pearls/OperatorLocalStorage/Tests/ListTests.cs
+++ b/Reaqtor/Pearls/OperatorLocalStorage/Tests/ListTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Pearls/OperatorLocalStorage/Tests/MaybeTests.cs
+++ b/Reaqtor/Pearls/OperatorLocalStorage/Tests/MaybeTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Pearls/OperatorLocalStorage/Tests/MsTestAssert.cs
+++ b/Reaqtor/Pearls/OperatorLocalStorage/Tests/MsTestAssert.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Pearls/OperatorLocalStorage/Tests/PersistedTestBase.cs
+++ b/Reaqtor/Pearls/OperatorLocalStorage/Tests/PersistedTestBase.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Pearls/OperatorLocalStorage/Tests/QueueTests.cs
+++ b/Reaqtor/Pearls/OperatorLocalStorage/Tests/QueueTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Pearls/OperatorLocalStorage/Tests/ReifiedOperations/ArrayOperation.cs
+++ b/Reaqtor/Pearls/OperatorLocalStorage/Tests/ReifiedOperations/ArrayOperation.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Pearls/OperatorLocalStorage/Tests/ReifiedOperations/AssertOperation.cs
+++ b/Reaqtor/Pearls/OperatorLocalStorage/Tests/ReifiedOperations/AssertOperation.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Pearls/OperatorLocalStorage/Tests/ReifiedOperations/CollectionOperation.cs
+++ b/Reaqtor/Pearls/OperatorLocalStorage/Tests/ReifiedOperations/CollectionOperation.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Pearls/OperatorLocalStorage/Tests/ReifiedOperations/DictionaryOperation.cs
+++ b/Reaqtor/Pearls/OperatorLocalStorage/Tests/ReifiedOperations/DictionaryOperation.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Pearls/OperatorLocalStorage/Tests/ReifiedOperations/EnumerableOperation.cs
+++ b/Reaqtor/Pearls/OperatorLocalStorage/Tests/ReifiedOperations/EnumerableOperation.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Pearls/OperatorLocalStorage/Tests/ReifiedOperations/IAssert.cs
+++ b/Reaqtor/Pearls/OperatorLocalStorage/Tests/ReifiedOperations/IAssert.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Pearls/OperatorLocalStorage/Tests/ReifiedOperations/IOperation.cs
+++ b/Reaqtor/Pearls/OperatorLocalStorage/Tests/ReifiedOperations/IOperation.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Pearls/OperatorLocalStorage/Tests/ReifiedOperations/IReifiedResultOperation.cs
+++ b/Reaqtor/Pearls/OperatorLocalStorage/Tests/ReifiedOperations/IReifiedResultOperation.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Pearls/OperatorLocalStorage/Tests/ReifiedOperations/IResultOperation.cs
+++ b/Reaqtor/Pearls/OperatorLocalStorage/Tests/ReifiedOperations/IResultOperation.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Pearls/OperatorLocalStorage/Tests/ReifiedOperations/ListOperation.cs
+++ b/Reaqtor/Pearls/OperatorLocalStorage/Tests/ReifiedOperations/ListOperation.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Pearls/OperatorLocalStorage/Tests/ReifiedOperations/Operation.cs
+++ b/Reaqtor/Pearls/OperatorLocalStorage/Tests/ReifiedOperations/Operation.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Pearls/OperatorLocalStorage/Tests/ReifiedOperations/OperationBase.cs
+++ b/Reaqtor/Pearls/OperatorLocalStorage/Tests/ReifiedOperations/OperationBase.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Pearls/OperatorLocalStorage/Tests/ReifiedOperations/PersistedArrayOperation.cs
+++ b/Reaqtor/Pearls/OperatorLocalStorage/Tests/ReifiedOperations/PersistedArrayOperation.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Pearls/OperatorLocalStorage/Tests/ReifiedOperations/PersistedDictionaryOperation.cs
+++ b/Reaqtor/Pearls/OperatorLocalStorage/Tests/ReifiedOperations/PersistedDictionaryOperation.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Pearls/OperatorLocalStorage/Tests/ReifiedOperations/PersistedListOperation.cs
+++ b/Reaqtor/Pearls/OperatorLocalStorage/Tests/ReifiedOperations/PersistedListOperation.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Pearls/OperatorLocalStorage/Tests/ReifiedOperations/PersistedOperation.cs
+++ b/Reaqtor/Pearls/OperatorLocalStorage/Tests/ReifiedOperations/PersistedOperation.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Pearls/OperatorLocalStorage/Tests/ReifiedOperations/PersistedQueueOperation.cs
+++ b/Reaqtor/Pearls/OperatorLocalStorage/Tests/ReifiedOperations/PersistedQueueOperation.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Pearls/OperatorLocalStorage/Tests/ReifiedOperations/PersistedSetOperation.cs
+++ b/Reaqtor/Pearls/OperatorLocalStorage/Tests/ReifiedOperations/PersistedSetOperation.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Pearls/OperatorLocalStorage/Tests/ReifiedOperations/PersistedSortedDictionaryOperation.cs
+++ b/Reaqtor/Pearls/OperatorLocalStorage/Tests/ReifiedOperations/PersistedSortedDictionaryOperation.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Pearls/OperatorLocalStorage/Tests/ReifiedOperations/PersistedSortedSetOperation.cs
+++ b/Reaqtor/Pearls/OperatorLocalStorage/Tests/ReifiedOperations/PersistedSortedSetOperation.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Pearls/OperatorLocalStorage/Tests/ReifiedOperations/PersistedStackOperation.cs
+++ b/Reaqtor/Pearls/OperatorLocalStorage/Tests/ReifiedOperations/PersistedStackOperation.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Pearls/OperatorLocalStorage/Tests/ReifiedOperations/PersistedValueOperation.cs
+++ b/Reaqtor/Pearls/OperatorLocalStorage/Tests/ReifiedOperations/PersistedValueOperation.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Pearls/OperatorLocalStorage/Tests/ReifiedOperations/QueueOperation.cs
+++ b/Reaqtor/Pearls/OperatorLocalStorage/Tests/ReifiedOperations/QueueOperation.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Pearls/OperatorLocalStorage/Tests/ReifiedOperations/ReadOnlyCollectionOperation.cs
+++ b/Reaqtor/Pearls/OperatorLocalStorage/Tests/ReifiedOperations/ReadOnlyCollectionOperation.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Pearls/OperatorLocalStorage/Tests/ReifiedOperations/ReadOnlyListOperation.cs
+++ b/Reaqtor/Pearls/OperatorLocalStorage/Tests/ReifiedOperations/ReadOnlyListOperation.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Pearls/OperatorLocalStorage/Tests/ReifiedOperations/ResultOperation.cs
+++ b/Reaqtor/Pearls/OperatorLocalStorage/Tests/ReifiedOperations/ResultOperation.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Pearls/OperatorLocalStorage/Tests/ReifiedOperations/SetOperation.cs
+++ b/Reaqtor/Pearls/OperatorLocalStorage/Tests/ReifiedOperations/SetOperation.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Pearls/OperatorLocalStorage/Tests/ReifiedOperations/SortedDictionaryOperation.cs
+++ b/Reaqtor/Pearls/OperatorLocalStorage/Tests/ReifiedOperations/SortedDictionaryOperation.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Pearls/OperatorLocalStorage/Tests/ReifiedOperations/SortedSetOperation.cs
+++ b/Reaqtor/Pearls/OperatorLocalStorage/Tests/ReifiedOperations/SortedSetOperation.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Pearls/OperatorLocalStorage/Tests/ReifiedOperations/StackOperation.cs
+++ b/Reaqtor/Pearls/OperatorLocalStorage/Tests/ReifiedOperations/StackOperation.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Pearls/OperatorLocalStorage/Tests/ReifiedOperations/ValueOperation.cs
+++ b/Reaqtor/Pearls/OperatorLocalStorage/Tests/ReifiedOperations/ValueOperation.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Pearls/OperatorLocalStorage/Tests/SortedDictionaryTests.cs
+++ b/Reaqtor/Pearls/OperatorLocalStorage/Tests/SortedDictionaryTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Pearls/OperatorLocalStorage/Tests/SortedSetTests.cs
+++ b/Reaqtor/Pearls/OperatorLocalStorage/Tests/SortedSetTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Pearls/OperatorLocalStorage/Tests/StackTests.cs
+++ b/Reaqtor/Pearls/OperatorLocalStorage/Tests/StackTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Pearls/OperatorLocalStorage/Tests/StateChangeManagerTests.cs
+++ b/Reaqtor/Pearls/OperatorLocalStorage/Tests/StateChangeManagerTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Pearls/OperatorLocalStorage/Tests/TransactionalDictionaryTests.cs
+++ b/Reaqtor/Pearls/OperatorLocalStorage/Tests/TransactionalDictionaryTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Pearls/OperatorLocalStorage/Tests/ValueTests.cs
+++ b/Reaqtor/Pearls/OperatorLocalStorage/Tests/ValueTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Pearls/OperatorLocalStorage/Utilities/AddOrUpdateStateWriterOperation.cs
+++ b/Reaqtor/Pearls/OperatorLocalStorage/Utilities/AddOrUpdateStateWriterOperation.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Pearls/OperatorLocalStorage/Utilities/DeleteStateWriterOperation.cs
+++ b/Reaqtor/Pearls/OperatorLocalStorage/Utilities/DeleteStateWriterOperation.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Pearls/OperatorLocalStorage/Utilities/Reader.cs
+++ b/Reaqtor/Pearls/OperatorLocalStorage/Utilities/Reader.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Pearls/OperatorLocalStorage/Utilities/SerializationFactory.cs
+++ b/Reaqtor/Pearls/OperatorLocalStorage/Utilities/SerializationFactory.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Pearls/OperatorLocalStorage/Utilities/StateWriterOperation.cs
+++ b/Reaqtor/Pearls/OperatorLocalStorage/Utilities/StateWriterOperation.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Pearls/OperatorLocalStorage/Utilities/StateWriterOperationKind.cs
+++ b/Reaqtor/Pearls/OperatorLocalStorage/Utilities/StateWriterOperationKind.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Pearls/OperatorLocalStorage/Utilities/Store.cs
+++ b/Reaqtor/Pearls/OperatorLocalStorage/Utilities/Store.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Pearls/OperatorLocalStorage/Utilities/Writer.cs
+++ b/Reaqtor/Pearls/OperatorLocalStorage/Utilities/Writer.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Pearls/PartitionedSubject/PartitionedSubject.cs
+++ b/Reaqtor/Pearls/PartitionedSubject/PartitionedSubject.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Pearls/PartitionedSubject/Program.cs
+++ b/Reaqtor/Pearls/PartitionedSubject/Program.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Pearls/PartitionedSubject/Rx/ListObserver.cs
+++ b/Reaqtor/Pearls/PartitionedSubject/Rx/ListObserver.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Pearls/PartitionedSubject/Rx/NopObserver.cs
+++ b/Reaqtor/Pearls/PartitionedSubject/Rx/NopObserver.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Pearls/PartitionedSubject/Rx/Sentinels.cs
+++ b/Reaqtor/Pearls/PartitionedSubject/Rx/Sentinels.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Pearls/PartitionedSubject/Rx/UnorderedFastSubject.cs
+++ b/Reaqtor/Pearls/PartitionedSubject/Rx/UnorderedFastSubject.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/IoT/Reaqtor.IoT/Client/Extensions.cs
+++ b/Reaqtor/Samples/IoT/Reaqtor.IoT/Client/Extensions.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/IoT/Reaqtor.IoT/Client/Operators.Generated.cs
+++ b/Reaqtor/Samples/IoT/Reaqtor.IoT/Client/Operators.Generated.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/IoT/Reaqtor.IoT/Client/Operators.cs
+++ b/Reaqtor/Samples/IoT/Reaqtor.IoT/Client/Operators.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/IoT/Reaqtor.IoT/Client/ReactorContext.cs
+++ b/Reaqtor/Samples/IoT/Reaqtor.IoT/Client/ReactorContext.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/IoT/Reaqtor.IoT/Program.cs
+++ b/Reaqtor/Samples/IoT/Reaqtor.IoT/Program.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/IoT/Reaqtor.IoT/Service/Engine/InMemoryKeyValueStore.cs
+++ b/Reaqtor/Samples/IoT/Reaqtor.IoT/Service/Engine/InMemoryKeyValueStore.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/IoT/Reaqtor.IoT/Service/Engine/IngressEgressManager.cs
+++ b/Reaqtor/Samples/IoT/Reaqtor.IoT/Service/Engine/IngressEgressManager.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/IoT/Reaqtor.IoT/Service/Engine/QueryEngine.cs
+++ b/Reaqtor/Samples/IoT/Reaqtor.IoT/Service/Engine/QueryEngine.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/IoT/Reaqtor.IoT/Service/Plugins/ConsoleObserver.cs
+++ b/Reaqtor/Samples/IoT/Reaqtor.IoT/Service/Plugins/ConsoleObserver.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/IoT/Reaqtor.IoT/Service/Plugins/EgressObserver.cs
+++ b/Reaqtor/Samples/IoT/Reaqtor.IoT/Service/Plugins/EgressObserver.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/IoT/Reaqtor.IoT/Service/Plugins/IngressObservable.cs
+++ b/Reaqtor/Samples/IoT/Reaqtor.IoT/Service/Plugins/IngressObservable.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/IoT/Reaqtor.IoT/Service/Plugins/TimerObservable.cs
+++ b/Reaqtor/Samples/IoT/Reaqtor.IoT/Service/Plugins/TimerObservable.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/IoT/Reaqtor.IoT/Utilities/MiniRx.cs
+++ b/Reaqtor/Samples/IoT/Reaqtor.IoT/Utilities/MiniRx.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Client.Library/Constants.Extended.Generated.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Client.Library/Constants.Extended.Generated.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Client.Library/Constants.Extended.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Client.Library/Constants.Extended.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Client.Library/Constants.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Client.Library/Constants.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Client.Library/ExpressionServices/DetupletizingExpressionServices.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Client.Library/ExpressionServices/DetupletizingExpressionServices.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Client.Library/ExpressionServices/ExpressionServices.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Client.Library/ExpressionServices/ExpressionServices.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Client.Library/ExpressionServices/TupletizingExpressionServices.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Client.Library/ExpressionServices/TupletizingExpressionServices.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Client.Library/Internal/DataModelHelpers.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Client.Library/Internal/DataModelHelpers.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Client.Library/Operators.Extended.Generated.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Client.Library/Operators.Extended.Generated.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Client.Library/Operators.Extended.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Client.Library/Operators.Extended.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Client.Library/Operators.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Client.Library/Operators.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Client.Library/ReactiveServiceProvider.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Client.Library/ReactiveServiceProvider.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Client.Library/RemotingClientContext.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Client.Library/RemotingClientContext.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Client.Library/RemotingServiceProvider.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Client.Library/RemotingServiceProvider.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Demo/Program.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Demo/Program.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Deployable/Deployable.Generated.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Deployable/Deployable.Generated.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Deployable/Deployable.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Deployable/Deployable.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Deployable/Observables/FirehoseObservable.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Deployable/Observables/FirehoseObservable.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Deployable/Observables/FirehoseObservableManager.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Deployable/Observables/FirehoseObservableManager.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Deployable/Observables/FirehoseSubscribable.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Deployable/Observables/FirehoseSubscribable.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Deployable/Observables/FirehoseSubscriptionManager.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Deployable/Observables/FirehoseSubscriptionManager.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Deployable/Observables/GarbageCollectorObservable.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Deployable/Observables/GarbageCollectorObservable.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Deployable/Observers/ConsoleObserver.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Deployable/Observers/ConsoleObserver.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Deployable/Observers/Egress/Binder.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Deployable/Observers/Egress/Binder.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Deployable/Observers/Egress/QuotedObservers.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Deployable/Observers/Egress/QuotedObservers.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Deployable/Observers/Egress/Requoter.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Deployable/Observers/Egress/Requoter.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Deployable/Observers/ICountable.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Deployable/Observers/ICountable.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Deployable/Observers/ThroughputObserver.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Deployable/Observers/ThroughputObserver.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Deployable/Observers/TraceObserver.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Deployable/Observers/TraceObserver.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Deployable/Streams/IImmutableBindingHolder.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Deployable/Streams/IImmutableBindingHolder.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Deployable/Streams/IKeySelector.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Deployable/Streams/IKeySelector.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Deployable/Streams/IPartitionableSubscribable.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Deployable/Streams/IPartitionableSubscribable.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Deployable/Streams/IPartitionableSubscribable{T}.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Deployable/Streams/IPartitionableSubscribable{T}.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Deployable/Streams/IPartitionedMultiSubject.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Deployable/Streams/IPartitionedMultiSubject.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Deployable/Streams/IPartitionedMultiSubject{T}.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Deployable/Streams/IPartitionedMultiSubject{T}.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Deployable/Streams/IRefCountingDictionary.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Deployable/Streams/IRefCountingDictionary.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Deployable/Streams/KeyBinding.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Deployable/Streams/KeyBinding.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Deployable/Streams/LambdaKeySelector.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Deployable/Streams/LambdaKeySelector.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Deployable/Streams/PartitionDelegator.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Deployable/Streams/PartitionDelegator.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Deployable/Streams/PartitionableSubscribable.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Deployable/Streams/PartitionableSubscribable.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Deployable/Streams/PartitionableSubscribableBase.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Deployable/Streams/PartitionableSubscribableBase.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Deployable/Streams/PartitionableSubscribableExtensions.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Deployable/Streams/PartitionableSubscribableExtensions.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Deployable/Streams/PartitionedMultisubject.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Deployable/Streams/PartitionedMultisubject.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Deployable/Streams/PartitionedMultisubject{T}.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Deployable/Streams/PartitionedMultisubject{T}.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Deployable/Streams/PartitionedSubscribableExtensions.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Deployable/Streams/PartitionedSubscribableExtensions.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Deployable/Streams/ReadOnlyListExtensions.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Deployable/Streams/ReadOnlyListExtensions.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Deployable/Streams/RefCountingDictionary.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Deployable/Streams/RefCountingDictionary.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Deployable/Streams/SimplePartitionableSubscribable.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Deployable/Streams/SimplePartitionableSubscribable.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Deployable/Streams/TypeErasedKeyBinding.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Deployable/Streams/TypeErasedKeyBinding.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Deployable/Streams/WrappedSubscription.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Deployable/Streams/WrappedSubscription.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Deployable/Tracer.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Deployable/Tracer.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.KeyValueStore/KeyValueStoreConnection.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.KeyValueStore/KeyValueStoreConnection.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.KeyValueStoreHost/Program.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.KeyValueStoreHost/Program.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Messaging/MessagingConnection.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Messaging/MessagingConnection.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.MessagingHost/Program.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.MessagingHost/Program.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Metadata/StorageConnection.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Metadata/StorageConnection.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.MetadataHost/Program.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.MetadataHost/Program.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.MultiRoleHost/Program.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.MultiRoleHost/Program.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Platform.AppDomain/AppDomainKeyValueStoreService.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Platform.AppDomain/AppDomainKeyValueStoreService.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Platform.AppDomain/AppDomainMessagingService.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Platform.AppDomain/AppDomainMessagingService.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Platform.AppDomain/AppDomainMetadataService.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Platform.AppDomain/AppDomainMetadataService.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Platform.AppDomain/AppDomainQueryCoordinator.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Platform.AppDomain/AppDomainQueryCoordinator.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Platform.AppDomain/AppDomainQueryEvaluator.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Platform.AppDomain/AppDomainQueryEvaluator.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Platform.AppDomain/AppDomainReactiveEnvironment.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Platform.AppDomain/AppDomainReactiveEnvironment.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Platform.AppDomain/AppDomainReactivePlatform.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Platform.AppDomain/AppDomainReactivePlatform.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Platform.AppDomain/AppDomainRunnable.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Platform.AppDomain/AppDomainRunnable.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Platform.AppDomain/AppDomainStateStoreService.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Platform.AppDomain/AppDomainStateStoreService.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Platform.AppDomain/Helpers.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Platform.AppDomain/Helpers.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Platform.InMemory/InMemoryKeyValueStoreService.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Platform.InMemory/InMemoryKeyValueStoreService.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Platform.InMemory/InMemoryMessagingService.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Platform.InMemory/InMemoryMessagingService.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Platform.InMemory/InMemoryMetadataService.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Platform.InMemory/InMemoryMetadataService.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Platform.InMemory/InMemoryQueryCoordinator.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Platform.InMemory/InMemoryQueryCoordinator.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Platform.InMemory/InMemoryQueryEvaluator.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Platform.InMemory/InMemoryQueryEvaluator.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Platform.InMemory/InMemoryReactiveEnvironment.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Platform.InMemory/InMemoryReactiveEnvironment.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Platform.InMemory/InMemoryReactivePlatform.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Platform.InMemory/InMemoryReactivePlatform.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Platform.InMemory/InMemoryRunnable.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Platform.InMemory/InMemoryRunnable.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Platform.InMemory/InMemoryStateStoreService.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Platform.InMemory/InMemoryStateStoreService.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Platform.Tcp/Helpers.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Platform.Tcp/Helpers.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Platform.Tcp/ITcpReactivePlatformSettings.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Platform.Tcp/ITcpReactivePlatformSettings.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Platform.Tcp/ProcessRunnable.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Platform.Tcp/ProcessRunnable.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Platform.Tcp/TcpKeyValueStoreService.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Platform.Tcp/TcpKeyValueStoreService.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Platform.Tcp/TcpMessagingService.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Platform.Tcp/TcpMessagingService.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Platform.Tcp/TcpMetadataService.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Platform.Tcp/TcpMetadataService.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Platform.Tcp/TcpMultiRoleInstance.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Platform.Tcp/TcpMultiRoleInstance.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Platform.Tcp/TcpMultiRoleReactiveEnvironment.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Platform.Tcp/TcpMultiRoleReactiveEnvironment.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Platform.Tcp/TcpMultiRoleReactivePlatform.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Platform.Tcp/TcpMultiRoleReactivePlatform.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Platform.Tcp/TcpMultiRoleRunnable.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Platform.Tcp/TcpMultiRoleRunnable.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Platform.Tcp/TcpQueryCoordinator.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Platform.Tcp/TcpQueryCoordinator.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Platform.Tcp/TcpQueryEvaluator.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Platform.Tcp/TcpQueryEvaluator.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Platform.Tcp/TcpReactiveEnvironment.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Platform.Tcp/TcpReactiveEnvironment.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Platform.Tcp/TcpReactivePlatform.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Platform.Tcp/TcpReactivePlatform.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Platform.Tcp/TcpReactivePlatformSettings.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Platform.Tcp/TcpReactivePlatformSettings.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Platform.Tcp/TcpRemoteServiceHost.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Platform.Tcp/TcpRemoteServiceHost.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Platform.Tcp/TcpRunnable.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Platform.Tcp/TcpRunnable.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Platform.Tcp/TcpStateStoreService.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Platform.Tcp/TcpStateStoreService.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Platform/Client/AsObservableExtensions.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Platform/Client/AsObservableExtensions.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Platform/Client/AsyncClientAction.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Platform/Client/AsyncClientAction.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Platform/Client/ClientAction.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Platform/Client/ClientAction.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Platform/Client/IReactivePlatformClient.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Platform/Client/IReactivePlatformClient.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Platform/Client/ReactivePlatformClient.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Platform/Client/ReactivePlatformClient.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Platform/Client/ReactivePlatformClientBase.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Platform/Client/ReactivePlatformClientBase.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Platform/Constants.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Platform/Constants.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Platform/Environment/IKeyValueStoreService.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Platform/Environment/IKeyValueStoreService.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Platform/Environment/IReactiveEnvironment.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Platform/Environment/IReactiveEnvironment.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Platform/Environment/IReactiveMessagingService.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Platform/Environment/IReactiveMessagingService.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Platform/Environment/IReactiveMetadataService.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Platform/Environment/IReactiveMetadataService.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Platform/Environment/IReactiveStateStoreService.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Platform/Environment/IReactiveStateStoreService.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Platform/Environment/MessageRouter.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Platform/Environment/MessageRouter.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Platform/Environment/ReactiveEnvironment.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Platform/Environment/ReactiveEnvironment.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Platform/Environment/ReactiveEnvironmentBase.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Platform/Environment/ReactiveEnvironmentBase.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Platform/Firehose/FirehoseObserver.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Platform/Firehose/FirehoseObserver.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Platform/IDeployable.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Platform/IDeployable.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Platform/IReactiveService.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Platform/IReactiveService.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Platform/IRunnable.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Platform/IRunnable.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Platform/Metadata/AzureTable/AzureMetadataQueryProvider.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Platform/Metadata/AzureTable/AzureMetadataQueryProvider.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Platform/Metadata/AzureTable/AzureMetadataServiceProvider.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Platform/Metadata/AzureTable/AzureMetadataServiceProvider.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Platform/Metadata/AzureTable/AzureQueryableDictionary.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Platform/Metadata/AzureTable/AzureQueryableDictionary.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Platform/Metadata/AzureTable/AzureReactiveMetadata.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Platform/Metadata/AzureTable/AzureReactiveMetadata.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Platform/Metadata/AzureTable/AzureReactiveMetadataProxy.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Platform/Metadata/AzureTable/AzureReactiveMetadataProxy.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Platform/Metadata/AzureTable/AzureStorageResolver.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Platform/Metadata/AzureTable/AzureStorageResolver.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Platform/Metadata/AzureTable/AzureTable.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Platform/Metadata/AzureTable/AzureTable.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Platform/Metadata/AzureTable/AzureTableClient.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Platform/Metadata/AzureTable/AzureTableClient.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Platform/Metadata/AzureTable/AzureTableServiceContext.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Platform/Metadata/AzureTable/AzureTableServiceContext.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Platform/Metadata/Entities/Async/AsyncReactiveDefinedResourceTableEntity.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Platform/Metadata/Entities/Async/AsyncReactiveDefinedResourceTableEntity.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Platform/Metadata/Entities/Async/AsyncReactiveObservableTableEntity.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Platform/Metadata/Entities/Async/AsyncReactiveObservableTableEntity.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Platform/Metadata/Entities/Async/AsyncReactiveObserverTableEntity.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Platform/Metadata/Entities/Async/AsyncReactiveObserverTableEntity.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Platform/Metadata/Entities/Async/AsyncReactiveProcessResourceTableEntity.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Platform/Metadata/Entities/Async/AsyncReactiveProcessResourceTableEntity.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Platform/Metadata/Entities/Async/AsyncReactiveResourceTableEntity.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Platform/Metadata/Entities/Async/AsyncReactiveResourceTableEntity.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Platform/Metadata/Entities/Async/AsyncReactiveStreamFactoryTableEntity.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Platform/Metadata/Entities/Async/AsyncReactiveStreamFactoryTableEntity.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Platform/Metadata/Entities/Async/AsyncReactiveStreamTableEntity.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Platform/Metadata/Entities/Async/AsyncReactiveStreamTableEntity.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Platform/Metadata/Entities/Async/AsyncReactiveSubscriptionFactoryTableEntity.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Platform/Metadata/Entities/Async/AsyncReactiveSubscriptionFactoryTableEntity.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Platform/Metadata/Entities/Async/AsyncReactiveSubscriptionTableEntity.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Platform/Metadata/Entities/Async/AsyncReactiveSubscriptionTableEntity.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Platform/Metadata/Entities/DeletionKnownTableEntity.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Platform/Metadata/Entities/DeletionKnownTableEntity.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Platform/Metadata/Entities/KnownTableEntity.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Platform/Metadata/Entities/KnownTableEntity.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Platform/Metadata/Entities/ReactiveDefinedResourceTableEntity.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Platform/Metadata/Entities/ReactiveDefinedResourceTableEntity.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Platform/Metadata/Entities/ReactiveObservableTableEntity.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Platform/Metadata/Entities/ReactiveObservableTableEntity.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Platform/Metadata/Entities/ReactiveObserverTableEntity.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Platform/Metadata/Entities/ReactiveObserverTableEntity.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Platform/Metadata/Entities/ReactiveProcessResourceTableEntity.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Platform/Metadata/Entities/ReactiveProcessResourceTableEntity.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Platform/Metadata/Entities/ReactiveResourceTableEntity.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Platform/Metadata/Entities/ReactiveResourceTableEntity.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Platform/Metadata/Entities/ReactiveStreamFactoryTableEntity.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Platform/Metadata/Entities/ReactiveStreamFactoryTableEntity.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Platform/Metadata/Entities/ReactiveStreamTableEntity.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Platform/Metadata/Entities/ReactiveStreamTableEntity.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Platform/Metadata/Entities/ReactiveSubscriptionFactoryTableEntity.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Platform/Metadata/Entities/ReactiveSubscriptionFactoryTableEntity.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Platform/Metadata/Entities/ReactiveSubscriptionTableEntity.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Platform/Metadata/Entities/ReactiveSubscriptionTableEntity.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Platform/Metadata/Internal/AzureTableQueryKeyMatchRewriter.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Platform/Metadata/Internal/AzureTableQueryKeyMatchRewriter.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Platform/Metadata/Internal/AzureTableQueryKeyValueUnlifter.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Platform/Metadata/Internal/AzureTableQueryKeyValueUnlifter.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Platform/Metadata/Internal/AzureTableQueryRewriter.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Platform/Metadata/Internal/AzureTableQueryRewriter.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Platform/Metadata/Internal/AzureTableQuerySplitter.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Platform/Metadata/Internal/AzureTableQuerySplitter.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Platform/Metadata/Internal/DistributedQuery.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Platform/Metadata/Internal/DistributedQuery.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Platform/Metadata/Internal/Inliner.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Platform/Metadata/Internal/Inliner.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Platform/Metadata/Internal/MetadataQuery.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Platform/Metadata/Internal/MetadataQuery.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Platform/Metadata/Internal/PropertyComparisonValueFinder.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Platform/Metadata/Internal/PropertyComparisonValueFinder.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Platform/Metadata/Internal/QueryableExtensions.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Platform/Metadata/Internal/QueryableExtensions.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Platform/Metadata/StorageAbstractions/DeleteTableOperation.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Platform/Metadata/StorageAbstractions/DeleteTableOperation.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Platform/Metadata/StorageAbstractions/IStorageResolver.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Platform/Metadata/StorageAbstractions/IStorageResolver.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Platform/Metadata/StorageAbstractions/ITable.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Platform/Metadata/StorageAbstractions/ITable.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Platform/Metadata/StorageAbstractions/ITableClient.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Platform/Metadata/StorageAbstractions/ITableClient.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Platform/Metadata/StorageAbstractions/ITableOperation.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Platform/Metadata/StorageAbstractions/ITableOperation.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Platform/Metadata/StorageAbstractions/ITableServiceContext.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Platform/Metadata/StorageAbstractions/ITableServiceContext.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Platform/Metadata/StorageAbstractions/InsertTableOperation.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Platform/Metadata/StorageAbstractions/InsertTableOperation.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Platform/Metadata/StorageAbstractions/ReactiveProcessingStorageException.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Platform/Metadata/StorageAbstractions/ReactiveProcessingStorageException.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Platform/Metadata/StorageAbstractions/RetrieveTableOperation.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Platform/Metadata/StorageAbstractions/RetrieveTableOperation.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Platform/Metadata/StorageAbstractions/TableOperationBase.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Platform/Metadata/StorageAbstractions/TableOperationBase.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Platform/Metadata/StorageConnectionQueryable.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Platform/Metadata/StorageConnectionQueryable.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Platform/Metadata/StorageConnectionTable.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Platform/Metadata/StorageConnectionTable.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Platform/Metadata/StorageConnectionTableClient.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Platform/Metadata/StorageConnectionTableClient.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Platform/Metadata/StorageConnectionTableServiceContext.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Platform/Metadata/StorageConnectionTableServiceContext.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Platform/Platform/IReactivePlatform.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Platform/Platform/IReactivePlatform.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Platform/Platform/IReactivePlatformService.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Platform/Platform/IReactivePlatformService.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Platform/Platform/IReactiveQueryCoordinator.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Platform/Platform/IReactiveQueryCoordinator.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Platform/Platform/IReactiveQueryEvaluator.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Platform/Platform/IReactiveQueryEvaluator.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Platform/Platform/ReactivePlatformBase.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Platform/Platform/ReactivePlatformBase.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Platform/Platform/ReactivePlatformServiceBase.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Platform/Platform/ReactivePlatformServiceBase.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Platform/Platform/ReactiveQueryEvaluatorBase.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Platform/Platform/ReactiveQueryEvaluatorBase.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Platform/ReactivePlatformDeployer.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Platform/ReactivePlatformDeployer.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Platform/ReactiveServiceBase.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Platform/ReactiveServiceBase.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Platform/ReactiveServiceType.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Platform/ReactiveServiceType.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Platform/Tools/Contract.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Platform/Tools/Contract.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Platform/Tools/HashingHelper.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Platform/Tools/HashingHelper.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Protocol/Configuration/IReactivePlatformConfiguration.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Protocol/Configuration/IReactivePlatformConfiguration.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Protocol/Configuration/MetadataStorageType.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Protocol/Configuration/MetadataStorageType.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Protocol/Configuration/SchedulerType.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Protocol/Configuration/SchedulerType.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Protocol/Configuration/ServiceInstanceHelpers.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Protocol/Configuration/ServiceInstanceHelpers.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Protocol/Configuration/TraceListenerType.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Protocol/Configuration/TraceListenerType.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Protocol/FaultHandling/BaseException.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Protocol/FaultHandling/BaseException.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Protocol/Notification/NotificationKind.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Protocol/Notification/NotificationKind.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Protocol/Notification/ObserverNotification.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Protocol/Notification/ObserverNotification.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Protocol/Protocol/Command/CommandNoun.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Protocol/Protocol/Command/CommandNoun.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Protocol/Protocol/Command/CommandTextFactory.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Protocol/Protocol/Command/CommandTextFactory.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Protocol/Protocol/Command/CommandTextParser.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Protocol/Protocol/Command/CommandTextParser.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Protocol/Protocol/Command/CommandVerb.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Protocol/Protocol/Command/CommandVerb.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Protocol/Protocol/Command/DataModelNewCommandData.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Protocol/Protocol/Command/DataModelNewCommandData.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Protocol/Protocol/Command/Generated/IReactiveServiceCommandRemoting.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Protocol/Protocol/Command/Generated/IReactiveServiceCommandRemoting.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Protocol/Protocol/Command/Generated/ReactiveServiceCommandProxy.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Protocol/Protocol/Command/Generated/ReactiveServiceCommandProxy.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Protocol/Protocol/Command/Generated/ReactiveServiceCommandService.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Protocol/Protocol/Command/Generated/ReactiveServiceCommandService.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Protocol/Protocol/Command/ICommandResponseFactory.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Protocol/Protocol/Command/ICommandResponseFactory.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Protocol/Protocol/Command/ICommandResponseParser.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Protocol/Protocol/Command/ICommandResponseParser.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Protocol/Protocol/Command/ICommandTextFactory.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Protocol/Protocol/Command/ICommandTextFactory.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Protocol/Protocol/Command/ICommandTextParser.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Protocol/Protocol/Command/ICommandTextParser.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Protocol/Protocol/Command/IReactiveServiceCommand.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Protocol/Protocol/Command/IReactiveServiceCommand.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Protocol/Protocol/Command/IReactiveServiceConnection.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Protocol/Protocol/Command/IReactiveServiceConnection.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Protocol/Protocol/Command/NewCommandData.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Protocol/Protocol/Command/NewCommandData.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Protocol/Protocol/Command/ReactiveServiceConnection.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Protocol/Protocol/Command/ReactiveServiceConnection.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Protocol/Protocol/INotification.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Protocol/Protocol/INotification.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Protocol/Protocol/IRemoteAction.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Protocol/Protocol/IRemoteAction.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Protocol/Protocol/RemoteSchedulerTask.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Protocol/Protocol/RemoteSchedulerTask.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Protocol/Protocol/StorageEntity.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Protocol/Protocol/StorageEntity.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Protocol/Protocol/StorageEntityProperty.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Protocol/Protocol/StorageEntityProperty.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Protocol/Services/IKeyValueStoreConnection.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Protocol/Services/IKeyValueStoreConnection.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Protocol/Services/IReactiveConnection.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Protocol/Services/IReactiveConnection.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Protocol/Services/IReactiveMessagingConnection.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Protocol/Services/IReactiveMessagingConnection.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Protocol/Services/IReactiveQueryEvaluatorConnection.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Protocol/Services/IReactiveQueryEvaluatorConnection.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Protocol/Services/IReactiveStateStoreConnection.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Protocol/Services/IReactiveStateStoreConnection.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Protocol/Services/IReactiveStorageConnection.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Protocol/Services/IReactiveStorageConnection.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Protocol/Services/IRemotingReactiveServiceConnection.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Protocol/Services/IRemotingReactiveServiceConnection.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Protocol/Services/ITransactionalKeyValueStoreConnection.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Protocol/Services/ITransactionalKeyValueStoreConnection.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Protocol/Services/KeyValueStoreConnection.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Protocol/Services/KeyValueStoreConnection.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Protocol/Services/LocalReactiveServiceConnection.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Protocol/Services/LocalReactiveServiceConnection.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Protocol/Services/ReactiveConnectionBase.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Protocol/Services/ReactiveConnectionBase.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Protocol/Services/RemotingReactiveServiceConnectionBase.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Protocol/Services/RemotingReactiveServiceConnectionBase.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.QueryCoordinator/QueryCoordinatorHostException.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.QueryCoordinator/QueryCoordinatorHostException.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.QueryCoordinator/QueryCoordinatorServiceConnection.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.QueryCoordinator/QueryCoordinatorServiceConnection.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.QueryCoordinator/QueryCoordinatorServiceProvider.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.QueryCoordinator/QueryCoordinatorServiceProvider.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.QueryCoordinatorHost/Program.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.QueryCoordinatorHost/Program.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.QueryEvaluator/Checkpointing/CompressionUtils.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.QueryEvaluator/Checkpointing/CompressionUtils.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.QueryEvaluator/Checkpointing/StateStoreConnectionStateReader.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.QueryEvaluator/Checkpointing/StateStoreConnectionStateReader.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.QueryEvaluator/Checkpointing/StateStoreConnectionStateWriter.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.QueryEvaluator/Checkpointing/StateStoreConnectionStateWriter.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.QueryEvaluator/Expressions/ExpressionRewriteHelpers.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.QueryEvaluator/Expressions/ExpressionRewriteHelpers.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.QueryEvaluator/Expressions/MockQueryEvaluatorUriToReactiveProxyBinder.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.QueryEvaluator/Expressions/MockQueryEvaluatorUriToReactiveProxyBinder.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.QueryEvaluator/HostOperatorContext.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.QueryEvaluator/HostOperatorContext.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.QueryEvaluator/KeyValueStore/KeyValueStore.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.QueryEvaluator/KeyValueStore/KeyValueStore.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.QueryEvaluator/MetadataCaching/CallContextLocal.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.QueryEvaluator/MetadataCaching/CallContextLocal.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.QueryEvaluator/MetadataCaching/IReactiveMetadataCache.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.QueryEvaluator/MetadataCaching/IReactiveMetadataCache.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.QueryEvaluator/MetadataCaching/IReactiveMetadataInMemory.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.QueryEvaluator/MetadataCaching/IReactiveMetadataInMemory.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.QueryEvaluator/MetadataCaching/IScoped.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.QueryEvaluator/MetadataCaching/IScoped.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.QueryEvaluator/MetadataCaching/LeveledCacheQueryableDictionary.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.QueryEvaluator/MetadataCaching/LeveledCacheQueryableDictionary.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.QueryEvaluator/MetadataCaching/ReactiveMetadataCache.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.QueryEvaluator/MetadataCaching/ReactiveMetadataCache.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.QueryEvaluator/MetadataCaching/ReactiveMetadataInMemory.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.QueryEvaluator/MetadataCaching/ReactiveMetadataInMemory.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.QueryEvaluator/MetadataCaching/TryFunc.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.QueryEvaluator/MetadataCaching/TryFunc.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.QueryEvaluator/MockReactiveServiceResolver.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.QueryEvaluator/MockReactiveServiceResolver.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.QueryEvaluator/Operators/HostOperatorConstants.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.QueryEvaluator/Operators/HostOperatorConstants.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.QueryEvaluator/Operators/HostOperators.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.QueryEvaluator/Operators/HostOperators.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.QueryEvaluator/Operators/SubscriptionCleanup.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.QueryEvaluator/Operators/SubscriptionCleanup.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.QueryEvaluator/Operators/ToReliableObservable.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.QueryEvaluator/Operators/ToReliableObservable.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.QueryEvaluator/QueryEvaluatorQueryEngine.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.QueryEvaluator/QueryEvaluatorQueryEngine.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.QueryEvaluator/QueryEvaluatorServiceConnection.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.QueryEvaluator/QueryEvaluatorServiceConnection.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.QueryEvaluator/QueryEvaluatorServiceProvider.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.QueryEvaluator/QueryEvaluatorServiceProvider.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.QueryEvaluator/SchedulerProxy.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.QueryEvaluator/SchedulerProxy.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.QueryEvaluatorHost/Program.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.QueryEvaluatorHost/Program.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Reactor.Client.Library/Agents/AgentsClient.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Reactor.Client.Library/Agents/AgentsClient.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Reactor.Client.Library/Agents/AgentsTestsContext.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Reactor.Client.Library/Agents/AgentsTestsContext.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Reactor.Client.Library/Agents/Constants.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Reactor.Client.Library/Agents/Constants.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Reactor.Client.Library/Agents/FlightsBvtProjection.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Reactor.Client.Library/Agents/FlightsBvtProjection.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Reactor.Client.Library/Agents/ReactiveProcessingActions.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Reactor.Client.Library/Agents/ReactiveProcessingActions.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Reactor.Client.Library/Agents/SubscriptionContext.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Reactor.Client.Library/Agents/SubscriptionContext.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Reactor.Client.Library/Generated/AltClientOccupation.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Reactor.Client.Library/Generated/AltClientOccupation.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Reactor.Client.Library/Generated/AltClientPerson.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Reactor.Client.Library/Generated/AltClientPerson.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Reactor.Client.Library/Generated/ClientFamily.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Reactor.Client.Library/Generated/ClientFamily.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Reactor.Client.Library/Generated/ClientOccupation.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Reactor.Client.Library/Generated/ClientOccupation.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Reactor.Client.Library/Generated/ClientPerson.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Reactor.Client.Library/Generated/ClientPerson.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Reactor.Client.Library/Generated/ClientPersonObservableParameters.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Reactor.Client.Library/Generated/ClientPersonObservableParameters.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Reactor.Client.Library/Generated/FlightStatus.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Reactor.Client.Library/Generated/FlightStatus.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Reactor.Client.Library/Generated/FlightStatusAirport.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Reactor.Client.Library/Generated/FlightStatusAirport.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Reactor.Client.Library/Generated/FlightStatusParameters.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Reactor.Client.Library/Generated/FlightStatusParameters.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Reactor.Client.Library/Generated/FlightStatusSegment.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Reactor.Client.Library/Generated/FlightStatusSegment.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Reactor.Client.Library/Generated/GeoCoordinateSignal.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Reactor.Client.Library/Generated/GeoCoordinateSignal.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Reactor.Client.Library/Generated/GeoCoordinateUserSignal.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Reactor.Client.Library/Generated/GeoCoordinateUserSignal.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Reactor.Client.Library/Generated/GeoCoordinateValue.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Reactor.Client.Library/Generated/GeoCoordinateValue.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Reactor.Client.Library/Generated/HttpData.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Reactor.Client.Library/Generated/HttpData.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Reactor.Client.Library/Generated/HttpPost.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Reactor.Client.Library/Generated/HttpPost.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Reactor.Client.Library/Generated/HttpVerb.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Reactor.Client.Library/Generated/HttpVerb.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Reactor.Client.Library/Generated/NewsArticle.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Reactor.Client.Library/Generated/NewsArticle.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Reactor.Client.Library/Generated/NewsCluster.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Reactor.Client.Library/Generated/NewsCluster.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Reactor.Client.Library/Generated/NewsInfo.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Reactor.Client.Library/Generated/NewsInfo.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Reactor.Client.Library/Generated/NewsLocal.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Reactor.Client.Library/Generated/NewsLocal.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Reactor.Client.Library/Generated/NewsParameters.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Reactor.Client.Library/Generated/NewsParameters.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Reactor.Client.Library/Generated/NewsResult.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Reactor.Client.Library/Generated/NewsResult.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Reactor.Client.Library/Generated/RetryData.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Reactor.Client.Library/Generated/RetryData.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Reactor.Client.Library/Generated/SerializationProtocol.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Reactor.Client.Library/Generated/SerializationProtocol.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Reactor.Client.Library/Generated/TrafficFlowInfo.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Reactor.Client.Library/Generated/TrafficFlowInfo.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Reactor.Client.Library/Generated/TrafficFlowParameters.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Reactor.Client.Library/Generated/TrafficFlowParameters.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Reactor.Client.Library/Generated/TrafficIncidentInfo.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Reactor.Client.Library/Generated/TrafficIncidentInfo.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Reactor.Client.Library/Generated/TrafficInfo.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Reactor.Client.Library/Generated/TrafficInfo.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Reactor.Client.Library/Generated/TrafficParameters.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Reactor.Client.Library/Generated/TrafficParameters.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Reactor.Client/DemoAttribute.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Reactor.Client/DemoAttribute.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Reactor.Client/Entities.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Reactor.Client/Entities.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Reactor.Client/Extensions.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Reactor.Client/Extensions.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Reactor.Client/Json.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Reactor.Client/Json.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Reactor.Client/PMS.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Reactor.Client/PMS.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Reactor.Client/Program.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Reactor.Client/Program.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Reactor.Deployable/Constants.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Reactor.Deployable/Constants.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Reactor.Deployable/Deployable.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Reactor.Deployable/Deployable.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Reactor.Deployable/DomainFeeds/DataModels/FlightStatus/FlightStatus.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Reactor.Deployable/DomainFeeds/DataModels/FlightStatus/FlightStatus.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Reactor.Deployable/DomainFeeds/DataModels/FlightStatus/FlightStatusAirport.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Reactor.Deployable/DomainFeeds/DataModels/FlightStatus/FlightStatusAirport.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Reactor.Deployable/DomainFeeds/DataModels/FlightStatus/FlightStatusParameters.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Reactor.Deployable/DomainFeeds/DataModels/FlightStatus/FlightStatusParameters.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Reactor.Deployable/DomainFeeds/DataModels/FlightStatus/FlightStatusSegment.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Reactor.Deployable/DomainFeeds/DataModels/FlightStatus/FlightStatusSegment.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Reactor.Deployable/DomainFeeds/DataModels/News/NewsArticle.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Reactor.Deployable/DomainFeeds/DataModels/News/NewsArticle.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Reactor.Deployable/DomainFeeds/DataModels/News/NewsCluster.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Reactor.Deployable/DomainFeeds/DataModels/News/NewsCluster.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Reactor.Deployable/DomainFeeds/DataModels/News/NewsInfo.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Reactor.Deployable/DomainFeeds/DataModels/News/NewsInfo.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Reactor.Deployable/DomainFeeds/DataModels/News/NewsLocal.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Reactor.Deployable/DomainFeeds/DataModels/News/NewsLocal.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Reactor.Deployable/DomainFeeds/DataModels/News/NewsParameters.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Reactor.Deployable/DomainFeeds/DataModels/News/NewsParameters.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Reactor.Deployable/DomainFeeds/DataModels/News/NewsResult.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Reactor.Deployable/DomainFeeds/DataModels/News/NewsResult.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Reactor.Deployable/DomainFeeds/DataModels/Traffic/TrafficConfiguration.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Reactor.Deployable/DomainFeeds/DataModels/Traffic/TrafficConfiguration.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Reactor.Deployable/DomainFeeds/DataModels/Traffic/TrafficConstants.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Reactor.Deployable/DomainFeeds/DataModels/Traffic/TrafficConstants.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Reactor.Deployable/DomainFeeds/DataModels/Traffic/TrafficFlowInfo.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Reactor.Deployable/DomainFeeds/DataModels/Traffic/TrafficFlowInfo.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Reactor.Deployable/DomainFeeds/DataModels/Traffic/TrafficFlowParameters.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Reactor.Deployable/DomainFeeds/DataModels/Traffic/TrafficFlowParameters.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Reactor.Deployable/DomainFeeds/DataModels/Traffic/TrafficIncidentInfo.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Reactor.Deployable/DomainFeeds/DataModels/Traffic/TrafficIncidentInfo.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Reactor.Deployable/DomainFeeds/DataModels/Traffic/TrafficInfo.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Reactor.Deployable/DomainFeeds/DataModels/Traffic/TrafficInfo.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Reactor.Deployable/DomainFeeds/DataModels/Traffic/TrafficParameters.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Reactor.Deployable/DomainFeeds/DataModels/Traffic/TrafficParameters.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Reactor.Deployable/DomainFeeds/DataModels/Traffic/TrafficStatusInfo.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Reactor.Deployable/DomainFeeds/DataModels/Traffic/TrafficStatusInfo.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Reactor.Deployable/DomainFeeds/DataModels/Traffic/ZmqTrafficPayload.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Reactor.Deployable/DomainFeeds/DataModels/Traffic/ZmqTrafficPayload.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Reactor.Deployable/DomainFeeds/DataModels/Weather/WeatherAlert.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Reactor.Deployable/DomainFeeds/DataModels/Weather/WeatherAlert.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Reactor.Deployable/DomainFeeds/DataModels/Weather/WeatherAlertParameters.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Reactor.Deployable/DomainFeeds/DataModels/Weather/WeatherAlertParameters.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Reactor.Deployable/DomainFeeds/DomainFeedsDeployable.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Reactor.Deployable/DomainFeeds/DomainFeedsDeployable.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Reactor.Deployable/DomainFeeds/MetadataRegistry.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Reactor.Deployable/DomainFeeds/MetadataRegistry.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Reactor.Deployable/DomainFeeds/Observables/FlightStatusObservable.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Reactor.Deployable/DomainFeeds/Observables/FlightStatusObservable.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Reactor.Deployable/DomainFeeds/Observables/MockFlightStatusObservable.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Reactor.Deployable/DomainFeeds/Observables/MockFlightStatusObservable.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Reactor.Deployable/DomainFeeds/Observables/MockNewsObservable.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Reactor.Deployable/DomainFeeds/Observables/MockNewsObservable.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Reactor.Deployable/DomainFeeds/Observables/MockWeatherAlertObservable.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Reactor.Deployable/DomainFeeds/Observables/MockWeatherAlertObservable.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Reactor.Deployable/DomainFeeds/Observables/NewsObservable.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Reactor.Deployable/DomainFeeds/Observables/NewsObservable.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Reactor.Deployable/DomainFeeds/Observables/SyntheticTrafficObservable.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Reactor.Deployable/DomainFeeds/Observables/SyntheticTrafficObservable.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Reactor.Deployable/DomainFeeds/Observables/TrafficObservable.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Reactor.Deployable/DomainFeeds/Observables/TrafficObservable.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Reactor.Deployable/DomainFeeds/Observables/WeatherAlertObservable.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Reactor.Deployable/DomainFeeds/Observables/WeatherAlertObservable.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Reactor.Deployable/Entities/Occupation.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Reactor.Deployable/Entities/Occupation.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Reactor.Deployable/Entities/Person.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Reactor.Deployable/Entities/Person.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Reactor.Deployable/Entities/PersonObservableParameters.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Reactor.Deployable/Entities/PersonObservableParameters.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Reactor.Deployable/Observables/PersonObservable.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Reactor.Deployable/Observables/PersonObservable.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Reactor.Deployable/Observables/RangeObservable.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Reactor.Deployable/Observables/RangeObservable.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Reactor.Deployable/Observers/HttpObserver.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Reactor.Deployable/Observers/HttpObserver.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Reactor.Deployable/Observers/HttpVerbExtensions.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Reactor.Deployable/Observers/HttpVerbExtensions.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Reactor.Tcp.Host/Program.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Reactor.Tcp.Host/Program.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.ReificationFramework/Internal/ConfiguredQueryEvaluatorServiceConnection.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.ReificationFramework/Internal/ConfiguredQueryEvaluatorServiceConnection.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.ReificationFramework/Internal/ExpressionHelpers.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.ReificationFramework/Internal/ExpressionHelpers.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.ReificationFramework/Internal/ServiceOperationBinder.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.ReificationFramework/Internal/ServiceOperationBinder.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.ReificationFramework/ReactiveServiceConnectionEnvironment.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.ReificationFramework/ReactiveServiceConnectionEnvironment.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.ReificationFramework/ReactiveServiceConnectionReificationBinder.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.ReificationFramework/ReactiveServiceConnectionReificationBinder.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Samples/DomainFeeds.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Samples/DomainFeeds.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Samples/Models/CarrierCredential.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Samples/Models/CarrierCredential.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Samples/Models/CasiEvent.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Samples/Models/CasiEvent.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Samples/Models/DeliveryInfo.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Samples/Models/DeliveryInfo.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Samples/Models/DeliveryParameters.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Samples/Models/DeliveryParameters.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Samples/Models/DeliveryV2Info.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Samples/Models/DeliveryV2Info.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Samples/Models/DeliveryV2Parameters.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Samples/Models/DeliveryV2Parameters.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Samples/Models/DeliveryV2Status.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Samples/Models/DeliveryV2Status.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Samples/Models/FlightStatus.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Samples/Models/FlightStatus.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Samples/Models/FlightStatusAirport.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Samples/Models/FlightStatusAirport.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Samples/Models/FlightStatusParameters.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Samples/Models/FlightStatusParameters.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Samples/Models/FlightStatusSegment.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Samples/Models/FlightStatusSegment.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Samples/Models/GameOutcome.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Samples/Models/GameOutcome.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Samples/Models/GameState.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Samples/Models/GameState.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Samples/Models/League.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Samples/Models/League.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Samples/Models/MsnjvAlert.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Samples/Models/MsnjvAlert.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Samples/Models/MsnjvAlertParameters.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Samples/Models/MsnjvAlertParameters.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Samples/Models/NewsArticle.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Samples/Models/NewsArticle.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Samples/Models/NewsCluster.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Samples/Models/NewsCluster.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Samples/Models/NewsInfo.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Samples/Models/NewsInfo.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Samples/Models/NewsLocal.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Samples/Models/NewsLocal.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Samples/Models/NewsParameters.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Samples/Models/NewsParameters.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Samples/Models/NewsResult.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Samples/Models/NewsResult.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Samples/Models/TeamBasedGameAlert.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Samples/Models/TeamBasedGameAlert.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Samples/Models/TrafficConstants.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Samples/Models/TrafficConstants.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Samples/Models/TrafficFlowInfo.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Samples/Models/TrafficFlowInfo.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Samples/Models/TrafficFlowParameters.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Samples/Models/TrafficFlowParameters.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Samples/Models/TrafficIncidentInfo.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Samples/Models/TrafficIncidentInfo.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Samples/Models/TrafficInfo.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Samples/Models/TrafficInfo.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Samples/Models/TrafficParameters.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Samples/Models/TrafficParameters.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Samples/Models/TrafficStatusInfo.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Samples/Models/TrafficStatusInfo.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Samples/Models/V2/Airline.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Samples/Models/V2/Airline.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Samples/Models/V2/Airport.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Samples/Models/V2/Airport.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Samples/Models/V2/FlightInfo.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Samples/Models/V2/FlightInfo.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Samples/Models/V2/FlightStatus.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Samples/Models/V2/FlightStatus.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Samples/Models/V2/OnTimeStatus.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Samples/Models/V2/OnTimeStatus.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Samples/Models/V2/TrafficInput.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Samples/Models/V2/TrafficInput.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Samples/Models/V2/TrafficNotification.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Samples/Models/V2/TrafficNotification.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Samples/Models/V2/WayPoint.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Samples/Models/V2/WayPoint.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Samples/Models/V2/WeatherAlert.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Samples/Models/V2/WeatherAlert.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Samples/Models/WeatherAlert.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Samples/Models/WeatherAlert.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Samples/Models/WeatherAlertParameters.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Samples/Models/WeatherAlertParameters.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.StateStore/EnumerableEx.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.StateStore/EnumerableEx.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.StateStore/InMemoryStateStore.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.StateStore/InMemoryStateStore.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.StateStore/StateStoreConnection.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.StateStore/StateStoreConnection.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.StateStoreHost/Program.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.StateStoreHost/Program.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.TestingFramework/AssertionHelpers/MetadataEntityType.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.TestingFramework/AssertionHelpers/MetadataEntityType.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.TestingFramework/AssertionHelpers/MetadataState.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.TestingFramework/AssertionHelpers/MetadataState.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.TestingFramework/AssertionHelpers/ObserverState.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.TestingFramework/AssertionHelpers/ObserverState.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.TestingFramework/Helpers.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.TestingFramework/Helpers.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.TestingFramework/Notifications/ITestObserver.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.TestingFramework/Notifications/ITestObserver.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.TestingFramework/Notifications/ObserverMessage.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.TestingFramework/Notifications/ObserverMessage.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.TestingFramework/Notifications/RecordedNotificationEqualityComparer.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.TestingFramework/Notifications/RecordedNotificationEqualityComparer.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.TestingFramework/RemotingTestBase.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.TestingFramework/RemotingTestBase.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.TestingFramework/Schedulers/SchedulerExtensions.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.TestingFramework/Schedulers/SchedulerExtensions.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.TestingFramework/Schedulers/VirtualTimeAgenda.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.TestingFramework/Schedulers/VirtualTimeAgenda.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.TestingFramework/Schedulers/VirtualTimeEvent.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.TestingFramework/Schedulers/VirtualTimeEvent.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.TestingFramework/TestClient/ITestReactivePlatformClient.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.TestingFramework/TestClient/ITestReactivePlatformClient.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.TestingFramework/TestClient/ITestableQbservable.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.TestingFramework/TestClient/ITestableQbservable.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.TestingFramework/TestClient/TestReactivePlatformClient.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.TestingFramework/TestClient/TestReactivePlatformClient.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.TestingFramework/TestClient/TestableQbservable.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.TestingFramework/TestClient/TestableQbservable.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.TestingFramework/TestClient/TestableQbserver.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.TestingFramework/TestClient/TestableQbserver.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.TestingFramework/TestDeployables/AssertStateTransitionCanary.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.TestingFramework/TestDeployables/AssertStateTransitionCanary.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.TestingFramework/TestDeployables/Constants.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.TestingFramework/TestDeployables/Constants.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.TestingFramework/TestDeployables/StatefulAugmentation.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.TestingFramework/TestDeployables/StatefulAugmentation.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.TestingFramework/TestDeployables/TestDeployable.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.TestingFramework/TestDeployables/TestDeployable.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.TestingFramework/TestDeployables/TestDeployableExtensions.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.TestingFramework/TestDeployables/TestDeployableExtensions.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.TestingFramework/TestDeployables/TestFirehoseObservable.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.TestingFramework/TestDeployables/TestFirehoseObservable.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.TestingFramework/TestDeployables/TestObserver.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.TestingFramework/TestDeployables/TestObserver.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.TestingFramework/TestDeployables/TimelineObservable.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.TestingFramework/TestDeployables/TimelineObservable.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.TestingFramework/TestPlatform/AppDomainTestPlatform.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.TestingFramework/TestPlatform/AppDomainTestPlatform.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.TestingFramework/TestPlatform/InMemoryTestPlatform.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.TestingFramework/TestPlatform/InMemoryTestPlatform.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.TestingFramework/TestPlatform/TestObserverStoreConnection.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.TestingFramework/TestPlatform/TestObserverStoreConnection.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.TestingFramework/TestPlatform/TestQueryEvaluatorServiceConnection.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.TestingFramework/TestPlatform/TestQueryEvaluatorServiceConnection.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.TestingFramework/TestPlatform/TestSubscriptionStoreConnection.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.TestingFramework/TestPlatform/TestSubscriptionStoreConnection.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.TestingFramework/TestPlatform/TimelineStoreConnection.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.TestingFramework/TestPlatform/TimelineStoreConnection.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.TestingFramework/Versioning.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.TestingFramework/Versioning.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.VersioningTests/Program.cs
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.VersioningTests/Program.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Tests.Reaqtor.Remoting.Glitching/Operators/Aggregate.cs
+++ b/Reaqtor/Samples/Remoting/Tests.Reaqtor.Remoting.Glitching/Operators/Aggregate.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Tests.Reaqtor.Remoting.Glitching/Operators/All.cs
+++ b/Reaqtor/Samples/Remoting/Tests.Reaqtor.Remoting.Glitching/Operators/All.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Tests.Reaqtor.Remoting.Glitching/Operators/Any.cs
+++ b/Reaqtor/Samples/Remoting/Tests.Reaqtor.Remoting.Glitching/Operators/Any.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Tests.Reaqtor.Remoting.Glitching/Operators/Average.cs
+++ b/Reaqtor/Samples/Remoting/Tests.Reaqtor.Remoting.Glitching/Operators/Average.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Tests.Reaqtor.Remoting.Glitching/Operators/Buffer.cs
+++ b/Reaqtor/Samples/Remoting/Tests.Reaqtor.Remoting.Glitching/Operators/Buffer.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Tests.Reaqtor.Remoting.Glitching/Operators/Count.cs
+++ b/Reaqtor/Samples/Remoting/Tests.Reaqtor.Remoting.Glitching/Operators/Count.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Tests.Reaqtor.Remoting.Glitching/Operators/DeclarativeExtensions.cs
+++ b/Reaqtor/Samples/Remoting/Tests.Reaqtor.Remoting.Glitching/Operators/DeclarativeExtensions.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Tests.Reaqtor.Remoting.Glitching/Operators/DelaySubscription.cs
+++ b/Reaqtor/Samples/Remoting/Tests.Reaqtor.Remoting.Glitching/Operators/DelaySubscription.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Tests.Reaqtor.Remoting.Glitching/Operators/DistinctUntilChanged.cs
+++ b/Reaqtor/Samples/Remoting/Tests.Reaqtor.Remoting.Glitching/Operators/DistinctUntilChanged.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Tests.Reaqtor.Remoting.Glitching/Operators/Empty.cs
+++ b/Reaqtor/Samples/Remoting/Tests.Reaqtor.Remoting.Glitching/Operators/Empty.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Tests.Reaqtor.Remoting.Glitching/Operators/FirstAsync.cs
+++ b/Reaqtor/Samples/Remoting/Tests.Reaqtor.Remoting.Glitching/Operators/FirstAsync.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Tests.Reaqtor.Remoting.Glitching/Operators/GroupBy.cs
+++ b/Reaqtor/Samples/Remoting/Tests.Reaqtor.Remoting.Glitching/Operators/GroupBy.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Tests.Reaqtor.Remoting.Glitching/Operators/IsEmpty.cs
+++ b/Reaqtor/Samples/Remoting/Tests.Reaqtor.Remoting.Glitching/Operators/IsEmpty.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Tests.Reaqtor.Remoting.Glitching/Operators/LongCount.cs
+++ b/Reaqtor/Samples/Remoting/Tests.Reaqtor.Remoting.Glitching/Operators/LongCount.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Tests.Reaqtor.Remoting.Glitching/Operators/Max.cs
+++ b/Reaqtor/Samples/Remoting/Tests.Reaqtor.Remoting.Glitching/Operators/Max.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Tests.Reaqtor.Remoting.Glitching/Operators/Merge.cs
+++ b/Reaqtor/Samples/Remoting/Tests.Reaqtor.Remoting.Glitching/Operators/Merge.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Tests.Reaqtor.Remoting.Glitching/Operators/Min.cs
+++ b/Reaqtor/Samples/Remoting/Tests.Reaqtor.Remoting.Glitching/Operators/Min.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Tests.Reaqtor.Remoting.Glitching/Operators/MinMax.cs
+++ b/Reaqtor/Samples/Remoting/Tests.Reaqtor.Remoting.Glitching/Operators/MinMax.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Tests.Reaqtor.Remoting.Glitching/Operators/Never.cs
+++ b/Reaqtor/Samples/Remoting/Tests.Reaqtor.Remoting.Glitching/Operators/Never.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Tests.Reaqtor.Remoting.Glitching/Operators/OperatorTestBase.cs
+++ b/Reaqtor/Samples/Remoting/Tests.Reaqtor.Remoting.Glitching/Operators/OperatorTestBase.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Tests.Reaqtor.Remoting.Glitching/Operators/Regressions.cs
+++ b/Reaqtor/Samples/Remoting/Tests.Reaqtor.Remoting.Glitching/Operators/Regressions.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Tests.Reaqtor.Remoting.Glitching/Operators/Retry.cs
+++ b/Reaqtor/Samples/Remoting/Tests.Reaqtor.Remoting.Glitching/Operators/Retry.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Tests.Reaqtor.Remoting.Glitching/Operators/Return.cs
+++ b/Reaqtor/Samples/Remoting/Tests.Reaqtor.Remoting.Glitching/Operators/Return.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Tests.Reaqtor.Remoting.Glitching/Operators/Sample.cs
+++ b/Reaqtor/Samples/Remoting/Tests.Reaqtor.Remoting.Glitching/Operators/Sample.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Tests.Reaqtor.Remoting.Glitching/Operators/Scan.cs
+++ b/Reaqtor/Samples/Remoting/Tests.Reaqtor.Remoting.Glitching/Operators/Scan.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Tests.Reaqtor.Remoting.Glitching/Operators/Select.cs
+++ b/Reaqtor/Samples/Remoting/Tests.Reaqtor.Remoting.Glitching/Operators/Select.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Tests.Reaqtor.Remoting.Glitching/Operators/SelectMany.cs
+++ b/Reaqtor/Samples/Remoting/Tests.Reaqtor.Remoting.Glitching/Operators/SelectMany.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Tests.Reaqtor.Remoting.Glitching/Operators/SequenceEqual.cs
+++ b/Reaqtor/Samples/Remoting/Tests.Reaqtor.Remoting.Glitching/Operators/SequenceEqual.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Tests.Reaqtor.Remoting.Glitching/Operators/Skip.cs
+++ b/Reaqtor/Samples/Remoting/Tests.Reaqtor.Remoting.Glitching/Operators/Skip.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Tests.Reaqtor.Remoting.Glitching/Operators/SkipUntil.cs
+++ b/Reaqtor/Samples/Remoting/Tests.Reaqtor.Remoting.Glitching/Operators/SkipUntil.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Tests.Reaqtor.Remoting.Glitching/Operators/SkipWhile.cs
+++ b/Reaqtor/Samples/Remoting/Tests.Reaqtor.Remoting.Glitching/Operators/SkipWhile.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Tests.Reaqtor.Remoting.Glitching/Operators/StartWith.cs
+++ b/Reaqtor/Samples/Remoting/Tests.Reaqtor.Remoting.Glitching/Operators/StartWith.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Tests.Reaqtor.Remoting.Glitching/Operators/Sum.cs
+++ b/Reaqtor/Samples/Remoting/Tests.Reaqtor.Remoting.Glitching/Operators/Sum.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Tests.Reaqtor.Remoting.Glitching/Operators/Switch.cs
+++ b/Reaqtor/Samples/Remoting/Tests.Reaqtor.Remoting.Glitching/Operators/Switch.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Tests.Reaqtor.Remoting.Glitching/Operators/Take.cs
+++ b/Reaqtor/Samples/Remoting/Tests.Reaqtor.Remoting.Glitching/Operators/Take.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Tests.Reaqtor.Remoting.Glitching/Operators/TakeUntil.cs
+++ b/Reaqtor/Samples/Remoting/Tests.Reaqtor.Remoting.Glitching/Operators/TakeUntil.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Tests.Reaqtor.Remoting.Glitching/Operators/TakeWhile.cs
+++ b/Reaqtor/Samples/Remoting/Tests.Reaqtor.Remoting.Glitching/Operators/TakeWhile.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Tests.Reaqtor.Remoting.Glitching/Operators/Throttle.cs
+++ b/Reaqtor/Samples/Remoting/Tests.Reaqtor.Remoting.Glitching/Operators/Throttle.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Tests.Reaqtor.Remoting.Glitching/Operators/Throw.cs
+++ b/Reaqtor/Samples/Remoting/Tests.Reaqtor.Remoting.Glitching/Operators/Throw.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Tests.Reaqtor.Remoting.Glitching/Operators/ToList.cs
+++ b/Reaqtor/Samples/Remoting/Tests.Reaqtor.Remoting.Glitching/Operators/ToList.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Tests.Reaqtor.Remoting.Glitching/Operators/Where.cs
+++ b/Reaqtor/Samples/Remoting/Tests.Reaqtor.Remoting.Glitching/Operators/Where.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Tests.Reaqtor.Remoting.Glitching/Operators/Window.cs
+++ b/Reaqtor/Samples/Remoting/Tests.Reaqtor.Remoting.Glitching/Operators/Window.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Tests.Reaqtor.Remoting.Glitching/TestHelpers.cs
+++ b/Reaqtor/Samples/Remoting/Tests.Reaqtor.Remoting.Glitching/TestHelpers.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Tests.Reaqtor.Remoting.Glitching/TestHelpersTests.cs
+++ b/Reaqtor/Samples/Remoting/Tests.Reaqtor.Remoting.Glitching/TestHelpersTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Tests.Reaqtor.Remoting.Glitching/Versioning/StateVersionTestCase.cs
+++ b/Reaqtor/Samples/Remoting/Tests.Reaqtor.Remoting.Glitching/Versioning/StateVersionTestCase.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Tests.Reaqtor.Remoting.Glitching/Versioning/StateVersionTestStore.cs
+++ b/Reaqtor/Samples/Remoting/Tests.Reaqtor.Remoting.Glitching/Versioning/StateVersionTestStore.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Tests.Reaqtor.Remoting/DetupletizingExpressionServicesTests.cs
+++ b/Reaqtor/Samples/Remoting/Tests.Reaqtor.Remoting/DetupletizingExpressionServicesTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Tests.Reaqtor.Remoting/Extensions.cs
+++ b/Reaqtor/Samples/Remoting/Tests.Reaqtor.Remoting/Extensions.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Tests.Reaqtor.Remoting/ObserverNotificationTests.cs
+++ b/Reaqtor/Samples/Remoting/Tests.Reaqtor.Remoting/ObserverNotificationTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Remoting/Tests.Reaqtor.Remoting/RemotingTest.cs
+++ b/Reaqtor/Samples/Remoting/Tests.Reaqtor.Remoting/RemotingTest.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Shebang/Reaqtor.Shebang.Client/ClientContext.cs
+++ b/Reaqtor/Samples/Shebang/Reaqtor.Shebang.Client/ClientContext.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Shebang/Reaqtor.Shebang.Client/QueryOperators.cs
+++ b/Reaqtor/Samples/Shebang/Reaqtor.Shebang.Client/QueryOperators.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Shebang/Reaqtor.Shebang.Service/Engine/CustomOperatorContext.cs
+++ b/Reaqtor/Samples/Shebang/Reaqtor.Shebang.Service/Engine/CustomOperatorContext.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Shebang/Reaqtor.Shebang.Service/Engine/DefaultQuotedTypeConversionTargets.cs
+++ b/Reaqtor/Samples/Shebang/Reaqtor.Shebang.Service/Engine/DefaultQuotedTypeConversionTargets.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Shebang/Reaqtor.Shebang.Service/Engine/EmptyReactiveMetadata.cs
+++ b/Reaqtor/Samples/Shebang/Reaqtor.Shebang.Service/Engine/EmptyReactiveMetadata.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Shebang/Reaqtor.Shebang.Service/Engine/IQueryEngineStateStore.cs
+++ b/Reaqtor/Samples/Shebang/Reaqtor.Shebang.Service/Engine/IQueryEngineStateStore.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Shebang/Reaqtor.Shebang.Service/Engine/LocalReactiveServiceProvider.cs
+++ b/Reaqtor/Samples/Shebang/Reaqtor.Shebang.Service/Engine/LocalReactiveServiceProvider.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Shebang/Reaqtor.Shebang.Service/Engine/NopReactiveServiceResolver.cs
+++ b/Reaqtor/Samples/Shebang/Reaqtor.Shebang.Service/Engine/NopReactiveServiceResolver.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Shebang/Reaqtor.Shebang.Service/Engine/QueryEngine.cs
+++ b/Reaqtor/Samples/Shebang/Reaqtor.Shebang.Service/Engine/QueryEngine.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Shebang/Reaqtor.Shebang.Service/Engine/QueryEngineFactory.cs
+++ b/Reaqtor/Samples/Shebang/Reaqtor.Shebang.Service/Engine/QueryEngineFactory.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Shebang/Reaqtor.Shebang.Service/Linq/Extensions.cs
+++ b/Reaqtor/Samples/Shebang/Reaqtor.Shebang.Service/Linq/Extensions.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Shebang/Reaqtor.Shebang.Service/Linq/QueryOperators.cs
+++ b/Reaqtor/Samples/Shebang/Reaqtor.Shebang.Service/Linq/QueryOperators.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Shebang/Reaqtor.Shebang.Service/Plugins/ConsoleObserver.cs
+++ b/Reaqtor/Samples/Shebang/Reaqtor.Shebang.Service/Plugins/ConsoleObserver.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Shebang/Reaqtor.Shebang.Service/Plugins/TimerObservable.cs
+++ b/Reaqtor/Samples/Shebang/Reaqtor.Shebang.Service/Plugins/TimerObservable.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Samples/Shebang/Reaqtor.Shebang.Service/Store/InMemoryKeyValueStore.cs
+++ b/Reaqtor/Samples/Shebang/Reaqtor.Shebang.Service/Store/InMemoryKeyValueStore.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 


### PR DESCRIPTION
Getting rid of spurious changes when editing files in Visual Studio because the `.editorconfig` file specifies `utf-8-bom` as the `charset`. Lengthy discussions can be had on the topic of "To BOM or not to BOM" but this PR gets the whole repo aligned with what's in `.editorconfig` (which itself mirrors what many other projects have). Future PRs should no longer have these seemingly no-op edits on the first line of the files.