### PR TITLE
Allow extensibility of expression factories.

### DIFF
--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices/Expressions/ExpressionFactory.generated.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices/Expressions/ExpressionFactory.generated.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 
@@ -11,14 +11,17 @@ namespace System.Linq.Expressions
     /// <summary>
     /// Factory for expression trees that uses the default factory methods on <see cref="T:System.Linq.Expressions.Expression" />.
     /// </summary>
-    public sealed class ExpressionFactory : IExpressionFactory
+    public class ExpressionFactory : IExpressionFactory
     {
         /// <summary>
-        /// Gets the singleton instance of the factory.
+        /// Gets a singleton instance of the factory.
         /// </summary>
-        public static readonly IExpressionFactory Instance = new ExpressionFactory();
+        public static readonly ExpressionFactory Instance = new();
 
-        private ExpressionFactory() {}
+        /// <summary>
+        /// Default constructor.
+        /// </summary>
+        protected ExpressionFactory() {}
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.BinaryExpression" /> that represents an arithmetic addition operation that does not have overflow checking.</summary>
         /// <param name="left">A <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Left" /> property equal to.</param>
@@ -27,7 +30,7 @@ namespace System.Linq.Expressions
         /// <exception cref="T:System.ArgumentNullException">
         ///   <paramref name="left" /> or <paramref name="right" /> is <see langword="null" />.</exception>
         /// <exception cref="T:System.InvalidOperationException">The addition operator is not defined for <paramref name="left" />.Type and <paramref name="right" />.Type.</exception>
-        public BinaryExpression Add(Expression left, Expression right) => Expression.Add(left, right);
+        public virtual BinaryExpression Add(Expression left, Expression right) => Expression.Add(left, right);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.BinaryExpression" /> that represents an arithmetic addition operation that does not have overflow checking. The implementing method can be specified.</summary>
         /// <param name="left">A <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Left" /> property equal to.</param>
@@ -40,20 +43,20 @@ namespace System.Linq.Expressions
         ///   <paramref name="method" /> is not <see langword="null" /> and the method it represents returns <see langword="void" />, is not <see langword="static" /> (<see langword="Shared" /> in Visual Basic), or does not take exactly two arguments.</exception>
         /// <exception cref="T:System.InvalidOperationException">
         ///   <paramref name="method" /> is <see langword="null" /> and the addition operator is not defined for <paramref name="left" />.Type and <paramref name="right" />.Type.</exception>
-        public BinaryExpression Add(Expression left, Expression right, MethodInfo method) => Expression.Add(left, right, method);
+        public virtual BinaryExpression Add(Expression left, Expression right, MethodInfo method) => Expression.Add(left, right, method);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.BinaryExpression" /> that represents an addition assignment operation that does not have overflow checking.</summary>
         /// <param name="left">An <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Left" /> property equal to.</param>
         /// <param name="right">An <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Right" /> property equal to.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.BinaryExpression" /> that has the <see cref="P:System.Linq.Expressions.Expression.NodeType" /> property equal to <see cref="F:System.Linq.Expressions.ExpressionType.AddAssign" /> and the <see cref="P:System.Linq.Expressions.BinaryExpression.Left" /> and <see cref="P:System.Linq.Expressions.BinaryExpression.Right" /> properties set to the specified values.</returns>
-        public BinaryExpression AddAssign(Expression left, Expression right) => Expression.AddAssign(left, right);
+        public virtual BinaryExpression AddAssign(Expression left, Expression right) => Expression.AddAssign(left, right);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.BinaryExpression" /> that represents an addition assignment operation that does not have overflow checking.</summary>
         /// <param name="left">An <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Left" /> property equal to.</param>
         /// <param name="right">An <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Right" /> property equal to.</param>
         /// <param name="method">A <see cref="T:System.Reflection.MethodInfo" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Method" /> property equal to.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.BinaryExpression" /> that has the <see cref="P:System.Linq.Expressions.Expression.NodeType" /> property equal to <see cref="F:System.Linq.Expressions.ExpressionType.AddAssign" /> and the <see cref="P:System.Linq.Expressions.BinaryExpression.Left" />, <see cref="P:System.Linq.Expressions.BinaryExpression.Right" />, and <see cref="P:System.Linq.Expressions.BinaryExpression.Method" /> properties set to the specified values.</returns>
-        public BinaryExpression AddAssign(Expression left, Expression right, MethodInfo method) => Expression.AddAssign(left, right, method);
+        public virtual BinaryExpression AddAssign(Expression left, Expression right, MethodInfo method) => Expression.AddAssign(left, right, method);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.BinaryExpression" /> that represents an addition assignment operation that does not have overflow checking.</summary>
         /// <param name="left">An <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Left" /> property equal to.</param>
@@ -61,20 +64,20 @@ namespace System.Linq.Expressions
         /// <param name="method">A <see cref="T:System.Reflection.MethodInfo" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Method" /> property equal to.</param>
         /// <param name="conversion">A <see cref="T:System.Linq.Expressions.LambdaExpression" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Conversion" /> property equal to.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.BinaryExpression" /> that has the <see cref="P:System.Linq.Expressions.Expression.NodeType" /> property equal to <see cref="F:System.Linq.Expressions.ExpressionType.AddAssign" /> and the <see cref="P:System.Linq.Expressions.BinaryExpression.Left" />, <see cref="P:System.Linq.Expressions.BinaryExpression.Right" />, <see cref="P:System.Linq.Expressions.BinaryExpression.Method" />, and <see cref="P:System.Linq.Expressions.BinaryExpression.Conversion" /> properties set to the specified values.</returns>
-        public BinaryExpression AddAssign(Expression left, Expression right, MethodInfo method, LambdaExpression conversion) => Expression.AddAssign(left, right, method, conversion);
+        public virtual BinaryExpression AddAssign(Expression left, Expression right, MethodInfo method, LambdaExpression conversion) => Expression.AddAssign(left, right, method, conversion);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.BinaryExpression" /> that represents an addition assignment operation that has overflow checking.</summary>
         /// <param name="left">An <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Left" /> property equal to.</param>
         /// <param name="right">An <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Right" /> property equal to.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.BinaryExpression" /> that has the <see cref="P:System.Linq.Expressions.Expression.NodeType" /> property equal to <see cref="F:System.Linq.Expressions.ExpressionType.AddAssignChecked" /> and the <see cref="P:System.Linq.Expressions.BinaryExpression.Left" /> and <see cref="P:System.Linq.Expressions.BinaryExpression.Right" /> properties set to the specified values.</returns>
-        public BinaryExpression AddAssignChecked(Expression left, Expression right) => Expression.AddAssignChecked(left, right);
+        public virtual BinaryExpression AddAssignChecked(Expression left, Expression right) => Expression.AddAssignChecked(left, right);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.BinaryExpression" /> that represents an addition assignment operation that has overflow checking.</summary>
         /// <param name="left">An <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Left" /> property equal to.</param>
         /// <param name="right">An <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Right" /> property equal to.</param>
         /// <param name="method">A <see cref="T:System.Reflection.MethodInfo" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Method" /> property equal to.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.BinaryExpression" /> that has the <see cref="P:System.Linq.Expressions.Expression.NodeType" /> property equal to <see cref="F:System.Linq.Expressions.ExpressionType.AddAssignChecked" /> and the <see cref="P:System.Linq.Expressions.BinaryExpression.Left" />, <see cref="P:System.Linq.Expressions.BinaryExpression.Right" />, and <see cref="P:System.Linq.Expressions.BinaryExpression.Method" /> properties set to the specified values.</returns>
-        public BinaryExpression AddAssignChecked(Expression left, Expression right, MethodInfo method) => Expression.AddAssignChecked(left, right, method);
+        public virtual BinaryExpression AddAssignChecked(Expression left, Expression right, MethodInfo method) => Expression.AddAssignChecked(left, right, method);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.BinaryExpression" /> that represents an addition assignment operation that has overflow checking.</summary>
         /// <param name="left">An <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Left" /> property equal to.</param>
@@ -82,7 +85,7 @@ namespace System.Linq.Expressions
         /// <param name="method">A <see cref="T:System.Reflection.MethodInfo" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Method" /> property equal to.</param>
         /// <param name="conversion">A <see cref="T:System.Linq.Expressions.LambdaExpression" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Conversion" /> property equal to.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.BinaryExpression" /> that has the <see cref="P:System.Linq.Expressions.Expression.NodeType" /> property equal to <see cref="F:System.Linq.Expressions.ExpressionType.AddAssignChecked" /> and the <see cref="P:System.Linq.Expressions.BinaryExpression.Left" />, <see cref="P:System.Linq.Expressions.BinaryExpression.Right" />, <see cref="P:System.Linq.Expressions.BinaryExpression.Method" />, and <see cref="P:System.Linq.Expressions.BinaryExpression.Conversion" /> properties set to the specified values.</returns>
-        public BinaryExpression AddAssignChecked(Expression left, Expression right, MethodInfo method, LambdaExpression conversion) => Expression.AddAssignChecked(left, right, method, conversion);
+        public virtual BinaryExpression AddAssignChecked(Expression left, Expression right, MethodInfo method, LambdaExpression conversion) => Expression.AddAssignChecked(left, right, method, conversion);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.BinaryExpression" /> that represents an arithmetic addition operation that has overflow checking.</summary>
         /// <param name="left">A <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Left" /> property equal to.</param>
@@ -91,7 +94,7 @@ namespace System.Linq.Expressions
         /// <exception cref="T:System.ArgumentNullException">
         ///   <paramref name="left" /> or <paramref name="right" /> is <see langword="null" />.</exception>
         /// <exception cref="T:System.InvalidOperationException">The addition operator is not defined for <paramref name="left" />.Type and <paramref name="right" />.Type.</exception>
-        public BinaryExpression AddChecked(Expression left, Expression right) => Expression.AddChecked(left, right);
+        public virtual BinaryExpression AddChecked(Expression left, Expression right) => Expression.AddChecked(left, right);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.BinaryExpression" /> that represents an arithmetic addition operation that has overflow checking. The implementing method can be specified.</summary>
         /// <param name="left">A <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Left" /> property equal to.</param>
@@ -104,7 +107,7 @@ namespace System.Linq.Expressions
         ///   <paramref name="method" /> is not <see langword="null" /> and the method it represents returns <see langword="void" />, is not <see langword="static" /> (<see langword="Shared" /> in Visual Basic), or does not take exactly two arguments.</exception>
         /// <exception cref="T:System.InvalidOperationException">
         ///   <paramref name="method" /> is <see langword="null" /> and the addition operator is not defined for <paramref name="left" />.Type and <paramref name="right" />.Type.</exception>
-        public BinaryExpression AddChecked(Expression left, Expression right, MethodInfo method) => Expression.AddChecked(left, right, method);
+        public virtual BinaryExpression AddChecked(Expression left, Expression right, MethodInfo method) => Expression.AddChecked(left, right, method);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.BinaryExpression" /> that represents a bitwise <see langword="AND" /> operation.</summary>
         /// <param name="left">A <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Left" /> property equal to.</param>
@@ -113,7 +116,7 @@ namespace System.Linq.Expressions
         /// <exception cref="T:System.ArgumentNullException">
         ///   <paramref name="left" /> or <paramref name="right" /> is <see langword="null" />.</exception>
         /// <exception cref="T:System.InvalidOperationException">The bitwise <see langword="AND" /> operator is not defined for <paramref name="left" />.Type and <paramref name="right" />.Type.</exception>
-        public BinaryExpression And(Expression left, Expression right) => Expression.And(left, right);
+        public virtual BinaryExpression And(Expression left, Expression right) => Expression.And(left, right);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.BinaryExpression" /> that represents a bitwise <see langword="AND" /> operation. The implementing method can be specified.</summary>
         /// <param name="left">An <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Left" /> property equal to.</param>
@@ -126,7 +129,7 @@ namespace System.Linq.Expressions
         ///   <paramref name="method" /> is not <see langword="null" /> and the method it represents returns <see langword="void" />, is not <see langword="static" /> (<see langword="Shared" /> in Visual Basic), or does not take exactly two arguments.</exception>
         /// <exception cref="T:System.InvalidOperationException">
         ///   <paramref name="method" /> is <see langword="null" /> and the bitwise <see langword="AND" /> operator is not defined for <paramref name="left" />.Type and <paramref name="right" />.Type.</exception>
-        public BinaryExpression And(Expression left, Expression right, MethodInfo method) => Expression.And(left, right, method);
+        public virtual BinaryExpression And(Expression left, Expression right, MethodInfo method) => Expression.And(left, right, method);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.BinaryExpression" /> that represents a conditional <see langword="AND" /> operation that evaluates the second operand only if the first operand evaluates to <see langword="true" />.</summary>
         /// <param name="left">A <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Left" /> property equal to.</param>
@@ -136,7 +139,7 @@ namespace System.Linq.Expressions
         ///   <paramref name="left" /> or <paramref name="right" /> is <see langword="null" />.</exception>
         /// <exception cref="T:System.InvalidOperationException">The bitwise <see langword="AND" /> operator is not defined for <paramref name="left" />.Type and <paramref name="right" />.Type.-or-
         ///               <paramref name="left" />.Type and <paramref name="right" />.Type are not the same Boolean type.</exception>
-        public BinaryExpression AndAlso(Expression left, Expression right) => Expression.AndAlso(left, right);
+        public virtual BinaryExpression AndAlso(Expression left, Expression right) => Expression.AndAlso(left, right);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.BinaryExpression" /> that represents a conditional <see langword="AND" /> operation that evaluates the second operand only if the first operand is resolved to true. The implementing method can be specified.</summary>
         /// <param name="left">A <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Left" /> property equal to.</param>
@@ -150,20 +153,20 @@ namespace System.Linq.Expressions
         /// <exception cref="T:System.InvalidOperationException">
         ///   <paramref name="method" /> is <see langword="null" /> and the bitwise <see langword="AND" /> operator is not defined for <paramref name="left" />.Type and <paramref name="right" />.Type.-or-
         ///               <paramref name="method" /> is <see langword="null" /> and <paramref name="left" />.Type and <paramref name="right" />.Type are not the same Boolean type.</exception>
-        public BinaryExpression AndAlso(Expression left, Expression right, MethodInfo method) => Expression.AndAlso(left, right, method);
+        public virtual BinaryExpression AndAlso(Expression left, Expression right, MethodInfo method) => Expression.AndAlso(left, right, method);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.BinaryExpression" /> that represents a bitwise AND assignment operation.</summary>
         /// <param name="left">An <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Left" /> property equal to.</param>
         /// <param name="right">An <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Right" /> property equal to.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.BinaryExpression" /> that has the <see cref="P:System.Linq.Expressions.Expression.NodeType" /> property equal to <see cref="F:System.Linq.Expressions.ExpressionType.AndAssign" /> and the <see cref="P:System.Linq.Expressions.BinaryExpression.Left" /> and <see cref="P:System.Linq.Expressions.BinaryExpression.Right" /> properties set to the specified values.</returns>
-        public BinaryExpression AndAssign(Expression left, Expression right) => Expression.AndAssign(left, right);
+        public virtual BinaryExpression AndAssign(Expression left, Expression right) => Expression.AndAssign(left, right);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.BinaryExpression" /> that represents a bitwise AND assignment operation.</summary>
         /// <param name="left">An <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Left" /> property equal to.</param>
         /// <param name="right">An <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Right" /> property equal to.</param>
         /// <param name="method">A <see cref="T:System.Reflection.MethodInfo" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Method" /> property equal to.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.BinaryExpression" /> that has the <see cref="P:System.Linq.Expressions.Expression.NodeType" /> property equal to <see cref="F:System.Linq.Expressions.ExpressionType.AndAssign" /> and the <see cref="P:System.Linq.Expressions.BinaryExpression.Left" />, <see cref="P:System.Linq.Expressions.BinaryExpression.Right" />, and <see cref="P:System.Linq.Expressions.BinaryExpression.Method" /> properties set to the specified values.</returns>
-        public BinaryExpression AndAssign(Expression left, Expression right, MethodInfo method) => Expression.AndAssign(left, right, method);
+        public virtual BinaryExpression AndAssign(Expression left, Expression right, MethodInfo method) => Expression.AndAssign(left, right, method);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.BinaryExpression" /> that represents a bitwise AND assignment operation.</summary>
         /// <param name="left">An <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Left" /> property equal to.</param>
@@ -171,19 +174,19 @@ namespace System.Linq.Expressions
         /// <param name="method">A <see cref="T:System.Reflection.MethodInfo" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Method" /> property equal to.</param>
         /// <param name="conversion">A <see cref="T:System.Linq.Expressions.LambdaExpression" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Conversion" /> property equal to.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.BinaryExpression" /> that has the <see cref="P:System.Linq.Expressions.Expression.NodeType" /> property equal to <see cref="F:System.Linq.Expressions.ExpressionType.AndAssign" /> and the <see cref="P:System.Linq.Expressions.BinaryExpression.Left" />, <see cref="P:System.Linq.Expressions.BinaryExpression.Right" />, <see cref="P:System.Linq.Expressions.BinaryExpression.Method" />, and <see cref="P:System.Linq.Expressions.BinaryExpression.Conversion" /> properties set to the specified values.</returns>
-        public BinaryExpression AndAssign(Expression left, Expression right, MethodInfo method, LambdaExpression conversion) => Expression.AndAssign(left, right, method, conversion);
+        public virtual BinaryExpression AndAssign(Expression left, Expression right, MethodInfo method, LambdaExpression conversion) => Expression.AndAssign(left, right, method, conversion);
 
         /// <summary>Creates an <see cref="T:System.Linq.Expressions.IndexExpression" /> to access an array.</summary>
         /// <param name="array">An expression representing the array to index.</param>
         /// <param name="indexes">An array that contains expressions used to index the array.</param>
         /// <returns>The created <see cref="T:System.Linq.Expressions.IndexExpression" />.</returns>
-        public IndexExpression ArrayAccess(Expression array, Expression[] indexes) => Expression.ArrayAccess(array, indexes);
+        public virtual IndexExpression ArrayAccess(Expression array, Expression[] indexes) => Expression.ArrayAccess(array, indexes);
 
         /// <summary>Creates an <see cref="T:System.Linq.Expressions.IndexExpression" /> to access a multidimensional array.</summary>
         /// <param name="array">An expression that represents the multidimensional array.</param>
         /// <param name="indexes">An <see cref="T:System.Collections.Generic.IEnumerable`1" /> containing expressions used to index the array.</param>
         /// <returns>The created <see cref="T:System.Linq.Expressions.IndexExpression" />.</returns>
-        public IndexExpression ArrayAccess(Expression array, IEnumerable<Expression> indexes) => Expression.ArrayAccess(array, indexes);
+        public virtual IndexExpression ArrayAccess(Expression array, IEnumerable<Expression> indexes) => Expression.ArrayAccess(array, indexes);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.MethodCallExpression" /> that represents applying an array index operator to a multidimensional array.</summary>
         /// <param name="array">An array of <see cref="T:System.Linq.Expressions.Expression" /> instances - indexes for the array index operation.</param>
@@ -193,7 +196,7 @@ namespace System.Linq.Expressions
         ///   <paramref name="array" /> or <paramref name="indexes" /> is <see langword="null" />.</exception>
         /// <exception cref="T:System.ArgumentException">
         ///   <paramref name="array" />.Type does not represent an array type.-or-The rank of <paramref name="array" />.Type does not match the number of elements in <paramref name="indexes" />.-or-The <see cref="P:System.Linq.Expressions.Expression.Type" /> property of one or more elements of <paramref name="indexes" /> does not represent the <see cref="T:System.Int32" /> type.</exception>
-        public MethodCallExpression ArrayIndex(Expression array, Expression[] indexes) => Expression.ArrayIndex(array, indexes);
+        public virtual MethodCallExpression ArrayIndex(Expression array, Expression[] indexes) => Expression.ArrayIndex(array, indexes);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.MethodCallExpression" /> that represents applying an array index operator to an array of rank more than one.</summary>
         /// <param name="array">An <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.MethodCallExpression.Object" /> property equal to.</param>
@@ -203,7 +206,7 @@ namespace System.Linq.Expressions
         ///   <paramref name="array" /> or <paramref name="indexes" /> is <see langword="null" />.</exception>
         /// <exception cref="T:System.ArgumentException">
         ///   <paramref name="array" />.Type does not represent an array type.-or-The rank of <paramref name="array" />.Type does not match the number of elements in <paramref name="indexes" />.-or-The <see cref="P:System.Linq.Expressions.Expression.Type" /> property of one or more elements of <paramref name="indexes" /> does not represent the <see cref="T:System.Int32" /> type.</exception>
-        public MethodCallExpression ArrayIndex(Expression array, IEnumerable<Expression> indexes) => Expression.ArrayIndex(array, indexes);
+        public virtual MethodCallExpression ArrayIndex(Expression array, IEnumerable<Expression> indexes) => Expression.ArrayIndex(array, indexes);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.BinaryExpression" /> that represents applying an array index operator to an array of rank one.</summary>
         /// <param name="array">A <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Left" /> property equal to.</param>
@@ -215,7 +218,7 @@ namespace System.Linq.Expressions
         ///   <paramref name="array" />.Type does not represent an array type.-or-
         ///               <paramref name="array" />.Type represents an array type whose rank is not 1.-or-
         ///               <paramref name="index" />.Type does not represent the <see cref="T:System.Int32" /> type.</exception>
-        public BinaryExpression ArrayIndex(Expression array, Expression index) => Expression.ArrayIndex(array, index);
+        public virtual BinaryExpression ArrayIndex(Expression array, Expression index) => Expression.ArrayIndex(array, index);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.UnaryExpression" /> that represents an expression for obtaining the length of a one-dimensional array.</summary>
         /// <param name="array">An <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.UnaryExpression.Operand" /> property equal to.</param>
@@ -224,13 +227,13 @@ namespace System.Linq.Expressions
         ///   <paramref name="array" /> is <see langword="null" />.</exception>
         /// <exception cref="T:System.ArgumentException">
         ///   <paramref name="array" />.Type does not represent an array type.</exception>
-        public UnaryExpression ArrayLength(Expression array) => Expression.ArrayLength(array);
+        public virtual UnaryExpression ArrayLength(Expression array) => Expression.ArrayLength(array);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.BinaryExpression" /> that represents an assignment operation.</summary>
         /// <param name="left">An <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Left" /> property equal to.</param>
         /// <param name="right">An <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Right" /> property equal to.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.BinaryExpression" /> that has the <see cref="P:System.Linq.Expressions.Expression.NodeType" /> property equal to <see cref="F:System.Linq.Expressions.ExpressionType.Assign" /> and the <see cref="P:System.Linq.Expressions.BinaryExpression.Left" /> and <see cref="P:System.Linq.Expressions.BinaryExpression.Right" /> properties set to the specified values.</returns>
-        public BinaryExpression Assign(Expression left, Expression right) => Expression.Assign(left, right);
+        public virtual BinaryExpression Assign(Expression left, Expression right) => Expression.Assign(left, right);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.MemberAssignment" /> that represents the initialization of a field or property.</summary>
         /// <param name="member">A <see cref="T:System.Reflection.MemberInfo" /> to set the <see cref="P:System.Linq.Expressions.MemberBinding.Member" /> property equal to.</param>
@@ -241,7 +244,7 @@ namespace System.Linq.Expressions
         /// <exception cref="T:System.ArgumentException">
         ///   <paramref name="member" /> does not represent a field or property.-or-The property represented by <paramref name="member" /> does not have a <see langword="set" /> accessor.-or-
         ///               <paramref name="expression" />.Type is not assignable to the type of the field or property that <paramref name="member" /> represents.</exception>
-        public MemberAssignment Bind(MemberInfo member, Expression expression) => Expression.Bind(member, expression);
+        public virtual MemberAssignment Bind(MemberInfo member, Expression expression) => Expression.Bind(member, expression);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.MemberAssignment" /> that represents the initialization of a member by using a property accessor method.</summary>
         /// <param name="propertyAccessor">A <see cref="T:System.Reflection.MethodInfo" /> that represents a property accessor method.</param>
@@ -252,68 +255,68 @@ namespace System.Linq.Expressions
         /// <exception cref="T:System.ArgumentException">
         ///   <paramref name="propertyAccessor" /> does not represent a property accessor method.-or-The property accessed by <paramref name="propertyAccessor" /> does not have a <see langword="set" /> accessor.-or-
         ///               <paramref name="expression" />.Type is not assignable to the type of the field or property that <paramref name="propertyAccessor" /> represents.</exception>
-        public MemberAssignment Bind(MethodInfo propertyAccessor, Expression expression) => Expression.Bind(propertyAccessor, expression);
+        public virtual MemberAssignment Bind(MethodInfo propertyAccessor, Expression expression) => Expression.Bind(propertyAccessor, expression);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.BlockExpression" /> that contains the given expressions and has no variables.</summary>
         /// <param name="expressions">The expressions in the block.</param>
         /// <returns>The created <see cref="T:System.Linq.Expressions.BlockExpression" />.</returns>
-        public BlockExpression Block(Expression[] expressions) => Expression.Block(expressions);
+        public virtual BlockExpression Block(Expression[] expressions) => Expression.Block(expressions);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.BlockExpression" /> that contains the given expressions and has no variables.</summary>
         /// <param name="expressions">The expressions in the block.</param>
         /// <returns>The created <see cref="T:System.Linq.Expressions.BlockExpression" />.</returns>
-        public BlockExpression Block(IEnumerable<Expression> expressions) => Expression.Block(expressions);
+        public virtual BlockExpression Block(IEnumerable<Expression> expressions) => Expression.Block(expressions);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.BlockExpression" /> that contains two expressions and has no variables.</summary>
         /// <param name="arg0">The first expression in the block.</param>
         /// <param name="arg1">The second expression in the block.</param>
         /// <returns>The created <see cref="T:System.Linq.Expressions.BlockExpression" />.</returns>
-        public BlockExpression Block(Expression arg0, Expression arg1) => Expression.Block(arg0, arg1);
+        public virtual BlockExpression Block(Expression arg0, Expression arg1) => Expression.Block(arg0, arg1);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.BlockExpression" /> that contains the given expressions, has no variables and has specific result type.</summary>
         /// <param name="type">The result type of the block.</param>
         /// <param name="expressions">The expressions in the block.</param>
         /// <returns>The created <see cref="T:System.Linq.Expressions.BlockExpression" />.</returns>
-        public BlockExpression Block(Type type, Expression[] expressions) => Expression.Block(type, expressions);
+        public virtual BlockExpression Block(Type type, Expression[] expressions) => Expression.Block(type, expressions);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.BlockExpression" /> that contains the given expressions, has no variables and has specific result type.</summary>
         /// <param name="type">The result type of the block.</param>
         /// <param name="expressions">The expressions in the block.</param>
         /// <returns>The created <see cref="T:System.Linq.Expressions.BlockExpression" />.</returns>
-        public BlockExpression Block(Type type, IEnumerable<Expression> expressions) => Expression.Block(type, expressions);
+        public virtual BlockExpression Block(Type type, IEnumerable<Expression> expressions) => Expression.Block(type, expressions);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.BlockExpression" /> that contains the given variables and expressions.</summary>
         /// <param name="variables">The variables in the block.</param>
         /// <param name="expressions">The expressions in the block.</param>
         /// <returns>The created <see cref="T:System.Linq.Expressions.BlockExpression" />.</returns>
-        public BlockExpression Block(IEnumerable<ParameterExpression> variables, Expression[] expressions) => Expression.Block(variables, expressions);
+        public virtual BlockExpression Block(IEnumerable<ParameterExpression> variables, Expression[] expressions) => Expression.Block(variables, expressions);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.BlockExpression" /> that contains the given variables and expressions.</summary>
         /// <param name="variables">The variables in the block.</param>
         /// <param name="expressions">The expressions in the block.</param>
         /// <returns>The created <see cref="T:System.Linq.Expressions.BlockExpression" />.</returns>
-        public BlockExpression Block(IEnumerable<ParameterExpression> variables, IEnumerable<Expression> expressions) => Expression.Block(variables, expressions);
+        public virtual BlockExpression Block(IEnumerable<ParameterExpression> variables, IEnumerable<Expression> expressions) => Expression.Block(variables, expressions);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.BlockExpression" /> that contains three expressions and has no variables.</summary>
         /// <param name="arg0">The first expression in the block.</param>
         /// <param name="arg1">The second expression in the block.</param>
         /// <param name="arg2">The third expression in the block.</param>
         /// <returns>The created <see cref="T:System.Linq.Expressions.BlockExpression" />.</returns>
-        public BlockExpression Block(Expression arg0, Expression arg1, Expression arg2) => Expression.Block(arg0, arg1, arg2);
+        public virtual BlockExpression Block(Expression arg0, Expression arg1, Expression arg2) => Expression.Block(arg0, arg1, arg2);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.BlockExpression" /> that contains the given variables and expressions.</summary>
         /// <param name="type">The result type of the block.</param>
         /// <param name="variables">The variables in the block.</param>
         /// <param name="expressions">The expressions in the block.</param>
         /// <returns>The created <see cref="T:System.Linq.Expressions.BlockExpression" />.</returns>
-        public BlockExpression Block(Type type, IEnumerable<ParameterExpression> variables, Expression[] expressions) => Expression.Block(type, variables, expressions);
+        public virtual BlockExpression Block(Type type, IEnumerable<ParameterExpression> variables, Expression[] expressions) => Expression.Block(type, variables, expressions);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.BlockExpression" /> that contains the given variables and expressions.</summary>
         /// <param name="type">The result type of the block.</param>
         /// <param name="variables">The variables in the block.</param>
         /// <param name="expressions">The expressions in the block.</param>
         /// <returns>The created <see cref="T:System.Linq.Expressions.BlockExpression" />.</returns>
-        public BlockExpression Block(Type type, IEnumerable<ParameterExpression> variables, IEnumerable<Expression> expressions) => Expression.Block(type, variables, expressions);
+        public virtual BlockExpression Block(Type type, IEnumerable<ParameterExpression> variables, IEnumerable<Expression> expressions) => Expression.Block(type, variables, expressions);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.BlockExpression" /> that contains four expressions and has no variables.</summary>
         /// <param name="arg0">The first expression in the block.</param>
@@ -321,7 +324,7 @@ namespace System.Linq.Expressions
         /// <param name="arg2">The third expression in the block.</param>
         /// <param name="arg3">The fourth expression in the block.</param>
         /// <returns>The created <see cref="T:System.Linq.Expressions.BlockExpression" />.</returns>
-        public BlockExpression Block(Expression arg0, Expression arg1, Expression arg2, Expression arg3) => Expression.Block(arg0, arg1, arg2, arg3);
+        public virtual BlockExpression Block(Expression arg0, Expression arg1, Expression arg2, Expression arg3) => Expression.Block(arg0, arg1, arg2, arg3);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.BlockExpression" /> that contains five expressions and has no variables.</summary>
         /// <param name="arg0">The first expression in the block.</param>
@@ -330,31 +333,31 @@ namespace System.Linq.Expressions
         /// <param name="arg3">The fourth expression in the block.</param>
         /// <param name="arg4">The fifth expression in the block.</param>
         /// <returns>The created <see cref="T:System.Linq.Expressions.BlockExpression" />.</returns>
-        public BlockExpression Block(Expression arg0, Expression arg1, Expression arg2, Expression arg3, Expression arg4) => Expression.Block(arg0, arg1, arg2, arg3, arg4);
+        public virtual BlockExpression Block(Expression arg0, Expression arg1, Expression arg2, Expression arg3, Expression arg4) => Expression.Block(arg0, arg1, arg2, arg3, arg4);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.GotoExpression" /> representing a break statement.</summary>
         /// <param name="target">The <see cref="T:System.Linq.Expressions.LabelTarget" /> that the <see cref="T:System.Linq.Expressions.GotoExpression" /> will jump to.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.GotoExpression" /> with <see cref="P:System.Linq.Expressions.GotoExpression.Kind" /> equal to Break, the <see cref="P:System.Linq.Expressions.GotoExpression.Target" /> property set to <paramref name="target" />, and a null value to be passed to the target label upon jumping.</returns>
-        public GotoExpression Break(LabelTarget target) => Expression.Break(target);
+        public virtual GotoExpression Break(LabelTarget target) => Expression.Break(target);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.GotoExpression" /> representing a break statement. The value passed to the label upon jumping can be specified.</summary>
         /// <param name="target">The <see cref="T:System.Linq.Expressions.LabelTarget" /> that the <see cref="T:System.Linq.Expressions.GotoExpression" /> will jump to.</param>
         /// <param name="value">The value that will be passed to the associated label upon jumping.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.GotoExpression" /> with <see cref="P:System.Linq.Expressions.GotoExpression.Kind" /> equal to Break, the <see cref="P:System.Linq.Expressions.GotoExpression.Target" /> property set to <paramref name="target" />, and <paramref name="value" /> to be passed to the target label upon jumping.</returns>
-        public GotoExpression Break(LabelTarget target, Expression value) => Expression.Break(target, value);
+        public virtual GotoExpression Break(LabelTarget target, Expression value) => Expression.Break(target, value);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.GotoExpression" /> representing a break statement with the specified type.</summary>
         /// <param name="target">The <see cref="T:System.Linq.Expressions.LabelTarget" /> that the <see cref="T:System.Linq.Expressions.GotoExpression" /> will jump to.</param>
         /// <param name="type">An <see cref="T:System.Type" /> to set the <see cref="P:System.Linq.Expressions.Expression.Type" /> property equal to.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.GotoExpression" /> with <see cref="P:System.Linq.Expressions.GotoExpression.Kind" /> equal to Break, the <see cref="P:System.Linq.Expressions.GotoExpression.Target" /> property set to <paramref name="target" />, and the <see cref="P:System.Linq.Expressions.Expression.Type" /> property set to <paramref name="type" />.</returns>
-        public GotoExpression Break(LabelTarget target, Type type) => Expression.Break(target, type);
+        public virtual GotoExpression Break(LabelTarget target, Type type) => Expression.Break(target, type);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.GotoExpression" /> representing a break statement with the specified type. The value passed to the label upon jumping can be specified.</summary>
         /// <param name="target">The <see cref="T:System.Linq.Expressions.LabelTarget" /> that the <see cref="T:System.Linq.Expressions.GotoExpression" /> will jump to.</param>
         /// <param name="value">The value that will be passed to the associated label upon jumping.</param>
         /// <param name="type">An <see cref="T:System.Type" /> to set the <see cref="P:System.Linq.Expressions.Expression.Type" /> property equal to.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.GotoExpression" /> with <see cref="P:System.Linq.Expressions.GotoExpression.Kind" /> equal to Break, the <see cref="P:System.Linq.Expressions.GotoExpression.Target" /> property set to <paramref name="target" />, the <see cref="P:System.Linq.Expressions.Expression.Type" /> property set to <paramref name="type" />, and <paramref name="value" /> to be passed to the target label upon jumping.</returns>
-        public GotoExpression Break(LabelTarget target, Expression value, Type type) => Expression.Break(target, value, type);
+        public virtual GotoExpression Break(LabelTarget target, Expression value, Type type) => Expression.Break(target, value, type);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.MethodCallExpression" /> that represents a call to a <see langword="static" /> (<see langword="Shared" /> in Visual Basic) method that takes one argument.</summary>
         /// <param name="method">A <see cref="T:System.Reflection.MethodInfo" /> to set the <see cref="P:System.Linq.Expressions.MethodCallExpression.Method" /> property equal to.</param>
@@ -362,7 +365,7 @@ namespace System.Linq.Expressions
         /// <returns>A <see cref="T:System.Linq.Expressions.MethodCallExpression" /> that has the <see cref="P:System.Linq.Expressions.Expression.NodeType" /> property equal to <see cref="F:System.Linq.Expressions.ExpressionType.Call" /> and the <see cref="P:System.Linq.Expressions.MethodCallExpression.Object" /> and <see cref="P:System.Linq.Expressions.MethodCallExpression.Method" /> properties set to the specified values.</returns>
         /// <exception cref="T:System.ArgumentNullException">
         ///   <paramref name="method" /> is null.</exception>
-        public MethodCallExpression Call(MethodInfo method, Expression arg0) => Expression.Call(method, arg0);
+        public virtual MethodCallExpression Call(MethodInfo method, Expression arg0) => Expression.Call(method, arg0);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.MethodCallExpression" /> that represents a call to a <see langword="static" /> (<see langword="Shared" /> in Visual Basic) method that has arguments.</summary>
         /// <param name="method">A <see cref="T:System.Reflection.MethodInfo" /> that represents a <see langword="static" /> (<see langword="Shared" /> in Visual Basic) method to set the <see cref="P:System.Linq.Expressions.MethodCallExpression.Method" /> property equal to.</param>
@@ -371,13 +374,13 @@ namespace System.Linq.Expressions
         /// <exception cref="T:System.ArgumentNullException">
         ///   <paramref name="method" /> is <see langword="null" />.</exception>
         /// <exception cref="T:System.ArgumentException">The number of elements in <paramref name="arguments" /> does not equal the number of parameters for the method represented by <paramref name="method" />.-or-One or more of the elements of <paramref name="arguments" /> is not assignable to the corresponding parameter for the method represented by <paramref name="method" />.</exception>
-        public MethodCallExpression Call(MethodInfo method, Expression[] arguments) => Expression.Call(method, arguments);
+        public virtual MethodCallExpression Call(MethodInfo method, Expression[] arguments) => Expression.Call(method, arguments);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.MethodCallExpression" /> that represents a call to a static (Shared in Visual Basic) method.</summary>
         /// <param name="method">The <see cref="T:System.Reflection.MethodInfo" /> that represents the target method.</param>
         /// <param name="arguments">A collection of <see cref="T:System.Linq.Expressions.Expression" /> that represents the call arguments.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.MethodCallExpression" /> that has the <see cref="P:System.Linq.Expressions.Expression.NodeType" /> property equal to <see cref="F:System.Linq.Expressions.ExpressionType.Call" /> and the <see cref="P:System.Linq.Expressions.MethodCallExpression.Object" /> and <see cref="P:System.Linq.Expressions.MethodCallExpression.Method" /> properties set to the specified values.</returns>
-        public MethodCallExpression Call(MethodInfo method, IEnumerable<Expression> arguments) => Expression.Call(method, arguments);
+        public virtual MethodCallExpression Call(MethodInfo method, IEnumerable<Expression> arguments) => Expression.Call(method, arguments);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.MethodCallExpression" /> that represents a call to a method that takes no arguments.</summary>
         /// <param name="instance">An <see cref="T:System.Linq.Expressions.Expression" /> that specifies the instance for an instance method call (pass <see langword="null" /> for a <see langword="static" /> (<see langword="Shared" /> in Visual Basic) method).</param>
@@ -388,7 +391,7 @@ namespace System.Linq.Expressions
         ///               <paramref name="instance" /> is <see langword="null" /> and <paramref name="method" /> represents an instance method.</exception>
         /// <exception cref="T:System.ArgumentException">
         ///   <paramref name="instance" />.Type is not assignable to the declaring type of the method represented by <paramref name="method" />.</exception>
-        public MethodCallExpression Call(Expression instance, MethodInfo method) => Expression.Call(instance, method);
+        public virtual MethodCallExpression Call(Expression instance, MethodInfo method) => Expression.Call(instance, method);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.MethodCallExpression" /> that represents a call to a static method that takes two arguments.</summary>
         /// <param name="method">A <see cref="T:System.Reflection.MethodInfo" /> to set the <see cref="P:System.Linq.Expressions.MethodCallExpression.Method" /> property equal to.</param>
@@ -397,7 +400,7 @@ namespace System.Linq.Expressions
         /// <returns>A <see cref="T:System.Linq.Expressions.MethodCallExpression" /> that has the <see cref="P:System.Linq.Expressions.Expression.NodeType" /> property equal to <see cref="F:System.Linq.Expressions.ExpressionType.Call" /> and the <see cref="P:System.Linq.Expressions.MethodCallExpression.Object" /> and <see cref="P:System.Linq.Expressions.MethodCallExpression.Method" /> properties set to the specified values.</returns>
         /// <exception cref="T:System.ArgumentNullException">
         ///   <paramref name="method" /> is null.</exception>
-        public MethodCallExpression Call(MethodInfo method, Expression arg0, Expression arg1) => Expression.Call(method, arg0, arg1);
+        public virtual MethodCallExpression Call(MethodInfo method, Expression arg0, Expression arg1) => Expression.Call(method, arg0, arg1);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.MethodCallExpression" /> that represents a call to a method that takes arguments.</summary>
         /// <param name="instance">An <see cref="T:System.Linq.Expressions.Expression" /> that specifies the instance for an instance method call (pass <see langword="null" /> for a <see langword="static" /> (<see langword="Shared" /> in Visual Basic) method).</param>
@@ -410,7 +413,7 @@ namespace System.Linq.Expressions
         ///               <paramref name="arguments" /> is not <see langword="null" /> and one or more of its elements is <see langword="null" />.</exception>
         /// <exception cref="T:System.ArgumentException">
         ///   <paramref name="instance" />.Type is not assignable to the declaring type of the method represented by <paramref name="method" />.-or-The number of elements in <paramref name="arguments" /> does not equal the number of parameters for the method represented by <paramref name="method" />.-or-One or more of the elements of <paramref name="arguments" /> is not assignable to the corresponding parameter for the method represented by <paramref name="method" />.</exception>
-        public MethodCallExpression Call(Expression instance, MethodInfo method, Expression[] arguments) => Expression.Call(instance, method, arguments);
+        public virtual MethodCallExpression Call(Expression instance, MethodInfo method, Expression[] arguments) => Expression.Call(instance, method, arguments);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.MethodCallExpression" /> that represents a call to a method that takes arguments.</summary>
         /// <param name="instance">An <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.MethodCallExpression.Object" /> property equal to (pass <see langword="null" /> for a <see langword="static" /> (<see langword="Shared" /> in Visual Basic) method).</param>
@@ -422,7 +425,7 @@ namespace System.Linq.Expressions
         ///               <paramref name="instance" /> is <see langword="null" /> and <paramref name="method" /> represents an instance method.</exception>
         /// <exception cref="T:System.ArgumentException">
         ///   <paramref name="instance" />.Type is not assignable to the declaring type of the method represented by <paramref name="method" />.-or-The number of elements in <paramref name="arguments" /> does not equal the number of parameters for the method represented by <paramref name="method" />.-or-One or more of the elements of <paramref name="arguments" /> is not assignable to the corresponding parameter for the method represented by <paramref name="method" />.</exception>
-        public MethodCallExpression Call(Expression instance, MethodInfo method, IEnumerable<Expression> arguments) => Expression.Call(instance, method, arguments);
+        public virtual MethodCallExpression Call(Expression instance, MethodInfo method, IEnumerable<Expression> arguments) => Expression.Call(instance, method, arguments);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.MethodCallExpression" /> that represents a call to a static method that takes three arguments.</summary>
         /// <param name="method">A <see cref="T:System.Reflection.MethodInfo" /> to set the <see cref="P:System.Linq.Expressions.MethodCallExpression.Method" /> property equal to.</param>
@@ -432,7 +435,7 @@ namespace System.Linq.Expressions
         /// <returns>A <see cref="T:System.Linq.Expressions.MethodCallExpression" /> that has the <see cref="P:System.Linq.Expressions.Expression.NodeType" /> property equal to <see cref="F:System.Linq.Expressions.ExpressionType.Call" /> and the <see cref="P:System.Linq.Expressions.MethodCallExpression.Object" /> and <see cref="P:System.Linq.Expressions.MethodCallExpression.Method" /> properties set to the specified values.</returns>
         /// <exception cref="T:System.ArgumentNullException">
         ///   <paramref name="method" /> is null.</exception>
-        public MethodCallExpression Call(MethodInfo method, Expression arg0, Expression arg1, Expression arg2) => Expression.Call(method, arg0, arg1, arg2);
+        public virtual MethodCallExpression Call(MethodInfo method, Expression arg0, Expression arg1, Expression arg2) => Expression.Call(method, arg0, arg1, arg2);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.MethodCallExpression" /> that represents a call to a method that takes two arguments.</summary>
         /// <param name="instance">An <see cref="T:System.Linq.Expressions.Expression" /> that specifies the instance for an instance call. (pass null for a static (Shared in Visual Basic) method).</param>
@@ -440,7 +443,7 @@ namespace System.Linq.Expressions
         /// <param name="arg0">The <see cref="T:System.Linq.Expressions.Expression" /> that represents the first argument.</param>
         /// <param name="arg1">The <see cref="T:System.Linq.Expressions.Expression" /> that represents the second argument.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.MethodCallExpression" /> that has the <see cref="P:System.Linq.Expressions.Expression.NodeType" /> property equal to <see cref="F:System.Linq.Expressions.ExpressionType.Call" /> and the <see cref="P:System.Linq.Expressions.MethodCallExpression.Object" /> and <see cref="P:System.Linq.Expressions.MethodCallExpression.Method" /> properties set to the specified values.</returns>
-        public MethodCallExpression Call(Expression instance, MethodInfo method, Expression arg0, Expression arg1) => Expression.Call(instance, method, arg0, arg1);
+        public virtual MethodCallExpression Call(Expression instance, MethodInfo method, Expression arg0, Expression arg1) => Expression.Call(instance, method, arg0, arg1);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.MethodCallExpression" /> that represents a call to a method by calling the appropriate factory method.</summary>
         /// <param name="instance">An <see cref="T:System.Linq.Expressions.Expression" /> whose <see cref="P:System.Linq.Expressions.Expression.Type" /> property value will be searched for a specific method.</param>
@@ -451,7 +454,7 @@ namespace System.Linq.Expressions
         /// <exception cref="T:System.ArgumentNullException">
         ///   <paramref name="instance" /> or <paramref name="methodName" /> is <see langword="null" />.</exception>
         /// <exception cref="T:System.InvalidOperationException">No method whose name is <paramref name="methodName" />, whose type parameters match <paramref name="typeArguments" />, and whose parameter types match <paramref name="arguments" /> is found in <paramref name="instance" />.Type or its base types.-or-More than one method whose name is <paramref name="methodName" />, whose type parameters match <paramref name="typeArguments" />, and whose parameter types match <paramref name="arguments" /> is found in <paramref name="instance" />.Type or its base types.</exception>
-        public MethodCallExpression Call(Expression instance, String methodName, Type[] typeArguments, Expression[] arguments) => Expression.Call(instance, methodName, typeArguments, arguments);
+        public virtual MethodCallExpression Call(Expression instance, String methodName, Type[] typeArguments, Expression[] arguments) => Expression.Call(instance, methodName, typeArguments, arguments);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.MethodCallExpression" /> that represents a call to a <see langword="static" /> (<see langword="Shared" /> in Visual Basic) method by calling the appropriate factory method.</summary>
         /// <param name="type">The <see cref="T:System.Type" /> that specifies the type that contains the specified <see langword="static" /> (<see langword="Shared" /> in Visual Basic) method.</param>
@@ -462,7 +465,7 @@ namespace System.Linq.Expressions
         /// <exception cref="T:System.ArgumentNullException">
         ///   <paramref name="type" /> or <paramref name="methodName" /> is <see langword="null" />.</exception>
         /// <exception cref="T:System.InvalidOperationException">No method whose name is <paramref name="methodName" />, whose type parameters match <paramref name="typeArguments" />, and whose parameter types match <paramref name="arguments" /> is found in <paramref name="type" /> or its base types.-or-More than one method whose name is <paramref name="methodName" />, whose type parameters match <paramref name="typeArguments" />, and whose parameter types match <paramref name="arguments" /> is found in <paramref name="type" /> or its base types.</exception>
-        public MethodCallExpression Call(Type type, String methodName, Type[] typeArguments, Expression[] arguments) => Expression.Call(type, methodName, typeArguments, arguments);
+        public virtual MethodCallExpression Call(Type type, String methodName, Type[] typeArguments, Expression[] arguments) => Expression.Call(type, methodName, typeArguments, arguments);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.MethodCallExpression" /> that represents a call to a static method that takes four arguments.</summary>
         /// <param name="method">A <see cref="T:System.Reflection.MethodInfo" /> to set the <see cref="P:System.Linq.Expressions.MethodCallExpression.Method" /> property equal to.</param>
@@ -473,7 +476,7 @@ namespace System.Linq.Expressions
         /// <returns>A <see cref="T:System.Linq.Expressions.MethodCallExpression" /> that has the <see cref="P:System.Linq.Expressions.Expression.NodeType" /> property equal to <see cref="F:System.Linq.Expressions.ExpressionType.Call" /> and the <see cref="P:System.Linq.Expressions.MethodCallExpression.Object" /> and <see cref="P:System.Linq.Expressions.MethodCallExpression.Method" /> properties set to the specified values.</returns>
         /// <exception cref="T:System.ArgumentNullException">
         ///   <paramref name="method" /> is null.</exception>
-        public MethodCallExpression Call(MethodInfo method, Expression arg0, Expression arg1, Expression arg2, Expression arg3) => Expression.Call(method, arg0, arg1, arg2, arg3);
+        public virtual MethodCallExpression Call(MethodInfo method, Expression arg0, Expression arg1, Expression arg2, Expression arg3) => Expression.Call(method, arg0, arg1, arg2, arg3);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.MethodCallExpression" /> that represents a call to a method that takes three arguments.</summary>
         /// <param name="instance">An <see cref="T:System.Linq.Expressions.Expression" /> that specifies the instance for an instance call. (pass null for a static (Shared in Visual Basic) method).</param>
@@ -482,7 +485,7 @@ namespace System.Linq.Expressions
         /// <param name="arg1">The <see cref="T:System.Linq.Expressions.Expression" /> that represents the second argument.</param>
         /// <param name="arg2">The <see cref="T:System.Linq.Expressions.Expression" /> that represents the third argument.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.MethodCallExpression" /> that has the <see cref="P:System.Linq.Expressions.Expression.NodeType" /> property equal to <see cref="F:System.Linq.Expressions.ExpressionType.Call" /> and the <see cref="P:System.Linq.Expressions.MethodCallExpression.Object" /> and <see cref="P:System.Linq.Expressions.MethodCallExpression.Method" /> properties set to the specified values.</returns>
-        public MethodCallExpression Call(Expression instance, MethodInfo method, Expression arg0, Expression arg1, Expression arg2) => Expression.Call(instance, method, arg0, arg1, arg2);
+        public virtual MethodCallExpression Call(Expression instance, MethodInfo method, Expression arg0, Expression arg1, Expression arg2) => Expression.Call(instance, method, arg0, arg1, arg2);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.MethodCallExpression" /> that represents a call to a static method that takes five arguments.</summary>
         /// <param name="method">A <see cref="T:System.Reflection.MethodInfo" /> to set the <see cref="P:System.Linq.Expressions.MethodCallExpression.Method" /> property equal to.</param>
@@ -494,38 +497,38 @@ namespace System.Linq.Expressions
         /// <returns>A <see cref="T:System.Linq.Expressions.MethodCallExpression" /> that has the <see cref="P:System.Linq.Expressions.Expression.NodeType" /> property equal to <see cref="F:System.Linq.Expressions.ExpressionType.Call" /> and the <see cref="P:System.Linq.Expressions.MethodCallExpression.Object" /> and <see cref="P:System.Linq.Expressions.MethodCallExpression.Method" /> properties set to the specified values.</returns>
         /// <exception cref="T:System.ArgumentNullException">
         ///   <paramref name="method" /> is null.</exception>
-        public MethodCallExpression Call(MethodInfo method, Expression arg0, Expression arg1, Expression arg2, Expression arg3, Expression arg4) => Expression.Call(method, arg0, arg1, arg2, arg3, arg4);
+        public virtual MethodCallExpression Call(MethodInfo method, Expression arg0, Expression arg1, Expression arg2, Expression arg3, Expression arg4) => Expression.Call(method, arg0, arg1, arg2, arg3, arg4);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.CatchBlock" /> representing a catch statement.</summary>
         /// <param name="type">The <see cref="P:System.Linq.Expressions.Expression.Type" /> of <see cref="T:System.Exception" /> this <see cref="T:System.Linq.Expressions.CatchBlock" /> will handle.</param>
         /// <param name="body">The body of the catch statement.</param>
         /// <returns>The created <see cref="T:System.Linq.Expressions.CatchBlock" />.</returns>
-        public CatchBlock Catch(Type type, Expression body) => Expression.Catch(type, body);
+        public virtual CatchBlock Catch(Type type, Expression body) => Expression.Catch(type, body);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.CatchBlock" /> representing a catch statement with a reference to the caught <see cref="T:System.Exception" /> object for use in the handler body.</summary>
         /// <param name="variable">A <see cref="T:System.Linq.Expressions.ParameterExpression" /> representing a reference to the <see cref="T:System.Exception" /> object caught by this handler.</param>
         /// <param name="body">The body of the catch statement.</param>
         /// <returns>The created <see cref="T:System.Linq.Expressions.CatchBlock" />.</returns>
-        public CatchBlock Catch(ParameterExpression variable, Expression body) => Expression.Catch(variable, body);
+        public virtual CatchBlock Catch(ParameterExpression variable, Expression body) => Expression.Catch(variable, body);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.CatchBlock" /> representing a catch statement with an <see cref="T:System.Exception" /> filter but no reference to the caught <see cref="T:System.Exception" /> object.</summary>
         /// <param name="type">The <see cref="P:System.Linq.Expressions.Expression.Type" /> of <see cref="T:System.Exception" /> this <see cref="T:System.Linq.Expressions.CatchBlock" /> will handle.</param>
         /// <param name="body">The body of the catch statement.</param>
         /// <param name="filter">The body of the <see cref="T:System.Exception" /> filter.</param>
         /// <returns>The created <see cref="T:System.Linq.Expressions.CatchBlock" />.</returns>
-        public CatchBlock Catch(Type type, Expression body, Expression filter) => Expression.Catch(type, body, filter);
+        public virtual CatchBlock Catch(Type type, Expression body, Expression filter) => Expression.Catch(type, body, filter);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.CatchBlock" /> representing a catch statement with an <see cref="T:System.Exception" /> filter and a reference to the caught <see cref="T:System.Exception" /> object.</summary>
         /// <param name="variable">A <see cref="T:System.Linq.Expressions.ParameterExpression" /> representing a reference to the <see cref="T:System.Exception" /> object caught by this handler.</param>
         /// <param name="body">The body of the catch statement.</param>
         /// <param name="filter">The body of the <see cref="T:System.Exception" /> filter.</param>
         /// <returns>The created <see cref="T:System.Linq.Expressions.CatchBlock" />.</returns>
-        public CatchBlock Catch(ParameterExpression variable, Expression body, Expression filter) => Expression.Catch(variable, body, filter);
+        public virtual CatchBlock Catch(ParameterExpression variable, Expression body, Expression filter) => Expression.Catch(variable, body, filter);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.DebugInfoExpression" /> for clearing a sequence point.</summary>
         /// <param name="document">The <see cref="T:System.Linq.Expressions.SymbolDocumentInfo" /> that represents the source file.</param>
         /// <returns>An instance of <see cref="T:System.Linq.Expressions.DebugInfoExpression" /> for clearning a sequence point.</returns>
-        public DebugInfoExpression ClearDebugInfo(SymbolDocumentInfo document) => Expression.ClearDebugInfo(document);
+        public virtual DebugInfoExpression ClearDebugInfo(SymbolDocumentInfo document) => Expression.ClearDebugInfo(document);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.BinaryExpression" /> that represents a coalescing operation.</summary>
         /// <param name="left">An <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Left" /> property equal to.</param>
@@ -536,7 +539,7 @@ namespace System.Linq.Expressions
         /// <exception cref="T:System.InvalidOperationException">The <see cref="P:System.Linq.Expressions.Expression.Type" /> property of <paramref name="left" /> does not represent a reference type or a nullable value type.</exception>
         /// <exception cref="T:System.ArgumentException">
         ///   <paramref name="left" />.Type and <paramref name="right" />.Type are not convertible to each other.</exception>
-        public BinaryExpression Coalesce(Expression left, Expression right) => Expression.Coalesce(left, right);
+        public virtual BinaryExpression Coalesce(Expression left, Expression right) => Expression.Coalesce(left, right);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.BinaryExpression" /> that represents a coalescing operation, given a conversion function.</summary>
         /// <param name="left">An <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Left" /> property equal to.</param>
@@ -549,7 +552,7 @@ namespace System.Linq.Expressions
         ///   <paramref name="left" />.Type and <paramref name="right" />.Type are not convertible to each other.-or-
         ///               <paramref name="conversion" /> is not <see langword="null" /> and <paramref name="conversion" />.Type is a delegate type that does not take exactly one argument.</exception>
         /// <exception cref="T:System.InvalidOperationException">The <see cref="P:System.Linq.Expressions.Expression.Type" /> property of <paramref name="left" /> does not represent a reference type or a nullable value type.-or-The <see cref="P:System.Linq.Expressions.Expression.Type" /> property of <paramref name="left" /> represents a type that is not assignable to the parameter type of the delegate type <paramref name="conversion" />.Type.-or-The <see cref="P:System.Linq.Expressions.Expression.Type" /> property of <paramref name="right" /> is not equal to the return type of the delegate type <paramref name="conversion" />.Type.</exception>
-        public BinaryExpression Coalesce(Expression left, Expression right, LambdaExpression conversion) => Expression.Coalesce(left, right, conversion);
+        public virtual BinaryExpression Coalesce(Expression left, Expression right, LambdaExpression conversion) => Expression.Coalesce(left, right, conversion);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.ConditionalExpression" /> that represents a conditional statement.</summary>
         /// <param name="test">An <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.ConditionalExpression.Test" /> property equal to.</param>
@@ -561,7 +564,7 @@ namespace System.Linq.Expressions
         /// <exception cref="T:System.ArgumentException">
         ///   <paramref name="test" />.Type is not <see cref="T:System.Boolean" />.-or-
         ///               <paramref name="ifTrue" />.Type is not equal to <paramref name="ifFalse" />.Type.</exception>
-        public ConditionalExpression Condition(Expression test, Expression ifTrue, Expression ifFalse) => Expression.Condition(test, ifTrue, ifFalse);
+        public virtual ConditionalExpression Condition(Expression test, Expression ifTrue, Expression ifFalse) => Expression.Condition(test, ifTrue, ifFalse);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.ConditionalExpression" /> that represents a conditional statement.</summary>
         /// <param name="test">An <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.ConditionalExpression.Test" /> property equal to.</param>
@@ -569,12 +572,12 @@ namespace System.Linq.Expressions
         /// <param name="ifFalse">An <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.ConditionalExpression.IfFalse" /> property equal to.</param>
         /// <param name="type">A <see cref="P:System.Linq.Expressions.Expression.Type" /> to set the <see cref="P:System.Linq.Expressions.Expression.Type" /> property equal to.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.ConditionalExpression" /> that has the <see cref="P:System.Linq.Expressions.Expression.NodeType" /> property equal to <see cref="F:System.Linq.Expressions.ExpressionType.Conditional" /> and the <see cref="P:System.Linq.Expressions.ConditionalExpression.Test" />, <see cref="P:System.Linq.Expressions.ConditionalExpression.IfTrue" />, and <see cref="P:System.Linq.Expressions.ConditionalExpression.IfFalse" /> properties set to the specified values.</returns>
-        public ConditionalExpression Condition(Expression test, Expression ifTrue, Expression ifFalse, Type type) => Expression.Condition(test, ifTrue, ifFalse, type);
+        public virtual ConditionalExpression Condition(Expression test, Expression ifTrue, Expression ifFalse, Type type) => Expression.Condition(test, ifTrue, ifFalse, type);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.ConstantExpression" /> that has the <see cref="P:System.Linq.Expressions.ConstantExpression.Value" /> property set to the specified value.</summary>
         /// <param name="value">An <see cref="T:System.Object" /> to set the <see cref="P:System.Linq.Expressions.ConstantExpression.Value" /> property equal to.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.ConstantExpression" /> that has the <see cref="P:System.Linq.Expressions.Expression.NodeType" /> property equal to <see cref="F:System.Linq.Expressions.ExpressionType.Constant" /> and the <see cref="P:System.Linq.Expressions.ConstantExpression.Value" /> property set to the specified value.</returns>
-        public ConstantExpression Constant(Object value) => Expression.Constant(value);
+        public virtual ConstantExpression Constant(Object value) => Expression.Constant(value);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.ConstantExpression" /> that has the <see cref="P:System.Linq.Expressions.ConstantExpression.Value" /> and <see cref="P:System.Linq.Expressions.Expression.Type" /> properties set to the specified values.</summary>
         /// <param name="value">An <see cref="T:System.Object" /> to set the <see cref="P:System.Linq.Expressions.ConstantExpression.Value" /> property equal to.</param>
@@ -584,18 +587,18 @@ namespace System.Linq.Expressions
         ///   <paramref name="type" /> is <see langword="null" />.</exception>
         /// <exception cref="T:System.ArgumentException">
         ///   <paramref name="value" /> is not <see langword="null" /> and <paramref name="type" /> is not assignable from the dynamic type of <paramref name="value" />.</exception>
-        public ConstantExpression Constant(Object value, Type type) => Expression.Constant(value, type);
+        public virtual ConstantExpression Constant(Object value, Type type) => Expression.Constant(value, type);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.GotoExpression" /> representing a continue statement.</summary>
         /// <param name="target">The <see cref="T:System.Linq.Expressions.LabelTarget" /> that the <see cref="T:System.Linq.Expressions.GotoExpression" /> will jump to.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.GotoExpression" /> with <see cref="P:System.Linq.Expressions.GotoExpression.Kind" /> equal to Continue, the <see cref="P:System.Linq.Expressions.GotoExpression.Target" /> property set to <paramref name="target" />, and a null value to be passed to the target label upon jumping.</returns>
-        public GotoExpression Continue(LabelTarget target) => Expression.Continue(target);
+        public virtual GotoExpression Continue(LabelTarget target) => Expression.Continue(target);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.GotoExpression" /> representing a continue statement with the specified type.</summary>
         /// <param name="target">The <see cref="T:System.Linq.Expressions.LabelTarget" /> that the <see cref="T:System.Linq.Expressions.GotoExpression" /> will jump to.</param>
         /// <param name="type">An <see cref="T:System.Type" /> to set the <see cref="P:System.Linq.Expressions.Expression.Type" /> property equal to.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.GotoExpression" /> with <see cref="P:System.Linq.Expressions.GotoExpression.Kind" /> equal to Continue, the <see cref="P:System.Linq.Expressions.GotoExpression.Target" /> property set to <paramref name="target" />, the <see cref="P:System.Linq.Expressions.Expression.Type" /> property set to <paramref name="type" />, and a null value to be passed to the target label upon jumping.</returns>
-        public GotoExpression Continue(LabelTarget target, Type type) => Expression.Continue(target, type);
+        public virtual GotoExpression Continue(LabelTarget target, Type type) => Expression.Continue(target, type);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.UnaryExpression" /> that represents a type conversion operation.</summary>
         /// <param name="expression">An <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.UnaryExpression.Operand" /> property equal to.</param>
@@ -604,7 +607,7 @@ namespace System.Linq.Expressions
         /// <exception cref="T:System.ArgumentNullException">
         ///   <paramref name="expression" /> or <paramref name="type" /> is <see langword="null" />.</exception>
         /// <exception cref="T:System.InvalidOperationException">No conversion operator is defined between <paramref name="expression" />.Type and <paramref name="type" />.</exception>
-        public UnaryExpression Convert(Expression expression, Type type) => Expression.Convert(expression, type);
+        public virtual UnaryExpression Convert(Expression expression, Type type) => Expression.Convert(expression, type);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.UnaryExpression" /> that represents a conversion operation for which the implementing method is specified.</summary>
         /// <param name="expression">An <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.UnaryExpression.Operand" /> property equal to.</param>
@@ -619,7 +622,7 @@ namespace System.Linq.Expressions
         ///               <paramref name="expression" />.Type is not assignable to the argument type of the method represented by <paramref name="method" />.-or-The return type of the method represented by <paramref name="method" /> is not assignable to <paramref name="type" />.-or-
         ///               <paramref name="expression" />.Type or <paramref name="type" /> is a nullable value type and the corresponding non-nullable value type does not equal the argument type or the return type, respectively, of the method represented by <paramref name="method" />.</exception>
         /// <exception cref="T:System.Reflection.AmbiguousMatchException">More than one method that matches the <paramref name="method" /> description was found.</exception>
-        public UnaryExpression Convert(Expression expression, Type type, MethodInfo method) => Expression.Convert(expression, type, method);
+        public virtual UnaryExpression Convert(Expression expression, Type type, MethodInfo method) => Expression.Convert(expression, type, method);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.UnaryExpression" /> that represents a conversion operation that throws an exception if the target type is overflowed.</summary>
         /// <param name="expression">An <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.UnaryExpression.Operand" /> property equal to.</param>
@@ -628,7 +631,7 @@ namespace System.Linq.Expressions
         /// <exception cref="T:System.ArgumentNullException">
         ///   <paramref name="expression" /> or <paramref name="type" /> is <see langword="null" />.</exception>
         /// <exception cref="T:System.InvalidOperationException">No conversion operator is defined between <paramref name="expression" />.Type and <paramref name="type" />.</exception>
-        public UnaryExpression ConvertChecked(Expression expression, Type type) => Expression.ConvertChecked(expression, type);
+        public virtual UnaryExpression ConvertChecked(Expression expression, Type type) => Expression.ConvertChecked(expression, type);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.UnaryExpression" /> that represents a conversion operation that throws an exception if the target type is overflowed and for which the implementing method is specified.</summary>
         /// <param name="expression">An <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.UnaryExpression.Operand" /> property equal to.</param>
@@ -643,7 +646,7 @@ namespace System.Linq.Expressions
         ///               <paramref name="expression" />.Type is not assignable to the argument type of the method represented by <paramref name="method" />.-or-The return type of the method represented by <paramref name="method" /> is not assignable to <paramref name="type" />.-or-
         ///               <paramref name="expression" />.Type or <paramref name="type" /> is a nullable value type and the corresponding non-nullable value type does not equal the argument type or the return type, respectively, of the method represented by <paramref name="method" />.</exception>
         /// <exception cref="T:System.Reflection.AmbiguousMatchException">More than one method that matches the <paramref name="method" /> description was found.</exception>
-        public UnaryExpression ConvertChecked(Expression expression, Type type, MethodInfo method) => Expression.ConvertChecked(expression, type, method);
+        public virtual UnaryExpression ConvertChecked(Expression expression, Type type, MethodInfo method) => Expression.ConvertChecked(expression, type, method);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.DebugInfoExpression" /> with the specified span.</summary>
         /// <param name="document">The <see cref="T:System.Linq.Expressions.SymbolDocumentInfo" /> that represents the source file.</param>
@@ -652,23 +655,23 @@ namespace System.Linq.Expressions
         /// <param name="endLine">The end line of this <see cref="T:System.Linq.Expressions.DebugInfoExpression" />. Must be greater or equal than the start line.</param>
         /// <param name="endColumn">The end column of this <see cref="T:System.Linq.Expressions.DebugInfoExpression" />. If the end line is the same as the start line, it must be greater or equal than the start column. In any case, must be greater than 0.</param>
         /// <returns>An instance of <see cref="T:System.Linq.Expressions.DebugInfoExpression" />.</returns>
-        public DebugInfoExpression DebugInfo(SymbolDocumentInfo document, Int32 startLine, Int32 startColumn, Int32 endLine, Int32 endColumn) => Expression.DebugInfo(document, startLine, startColumn, endLine, endColumn);
+        public virtual DebugInfoExpression DebugInfo(SymbolDocumentInfo document, Int32 startLine, Int32 startColumn, Int32 endLine, Int32 endColumn) => Expression.DebugInfo(document, startLine, startColumn, endLine, endColumn);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.UnaryExpression" /> that represents the decrementing of the expression by 1.</summary>
         /// <param name="expression">An <see cref="T:System.Linq.Expressions.Expression" /> to decrement.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.UnaryExpression" /> that represents the decremented expression.</returns>
-        public UnaryExpression Decrement(Expression expression) => Expression.Decrement(expression);
+        public virtual UnaryExpression Decrement(Expression expression) => Expression.Decrement(expression);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.UnaryExpression" /> that represents the decrementing of the expression by 1.</summary>
         /// <param name="expression">An <see cref="T:System.Linq.Expressions.Expression" /> to decrement.</param>
         /// <param name="method">A <see cref="T:System.Reflection.MethodInfo" /> that represents the implementing method.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.UnaryExpression" /> that represents the decremented expression.</returns>
-        public UnaryExpression Decrement(Expression expression, MethodInfo method) => Expression.Decrement(expression, method);
+        public virtual UnaryExpression Decrement(Expression expression, MethodInfo method) => Expression.Decrement(expression, method);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.DefaultExpression" /> that has the <see cref="P:System.Linq.Expressions.Expression.Type" /> property set to the specified type.</summary>
         /// <param name="type">A <see cref="T:System.Type" /> to set the <see cref="P:System.Linq.Expressions.Expression.Type" /> property equal to.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.DefaultExpression" /> that has the <see cref="P:System.Linq.Expressions.Expression.NodeType" /> property equal to <see cref="F:System.Linq.Expressions.ExpressionType.Default" /> and the <see cref="P:System.Linq.Expressions.Expression.Type" /> property set to the specified type.</returns>
-        public DefaultExpression Default(Type type) => Expression.Default(type);
+        public virtual DefaultExpression Default(Type type) => Expression.Default(type);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.BinaryExpression" /> that represents an arithmetic division operation.</summary>
         /// <param name="left">An <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Left" /> property to.</param>
@@ -677,7 +680,7 @@ namespace System.Linq.Expressions
         /// <exception cref="T:System.ArgumentNullException">
         ///   <paramref name="left" /> or <paramref name="right" /> is <see langword="null" />.</exception>
         /// <exception cref="T:System.InvalidOperationException">The division operator is not defined for <paramref name="left" />.Type and <paramref name="right" />.Type.</exception>
-        public BinaryExpression Divide(Expression left, Expression right) => Expression.Divide(left, right);
+        public virtual BinaryExpression Divide(Expression left, Expression right) => Expression.Divide(left, right);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.BinaryExpression" /> that represents an arithmetic division operation. The implementing method can be specified.</summary>
         /// <param name="left">An <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Left" /> property equal to.</param>
@@ -690,20 +693,20 @@ namespace System.Linq.Expressions
         ///   <paramref name="method" /> is not <see langword="null" /> and the method it represents returns <see langword="void" />, is not <see langword="static" /> (<see langword="Shared" /> in Visual Basic), or does not take exactly two arguments.</exception>
         /// <exception cref="T:System.InvalidOperationException">
         ///   <paramref name="method" /> is <see langword="null" /> and the division operator is not defined for <paramref name="left" />.Type and <paramref name="right" />.Type.</exception>
-        public BinaryExpression Divide(Expression left, Expression right, MethodInfo method) => Expression.Divide(left, right, method);
+        public virtual BinaryExpression Divide(Expression left, Expression right, MethodInfo method) => Expression.Divide(left, right, method);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.BinaryExpression" /> that represents a division assignment operation that does not have overflow checking.</summary>
         /// <param name="left">An <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Left" /> property equal to.</param>
         /// <param name="right">An <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Right" /> property equal to.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.BinaryExpression" /> that has the <see cref="P:System.Linq.Expressions.Expression.NodeType" /> property equal to <see cref="F:System.Linq.Expressions.ExpressionType.DivideAssign" /> and the <see cref="P:System.Linq.Expressions.BinaryExpression.Left" /> and <see cref="P:System.Linq.Expressions.BinaryExpression.Right" /> properties set to the specified values.</returns>
-        public BinaryExpression DivideAssign(Expression left, Expression right) => Expression.DivideAssign(left, right);
+        public virtual BinaryExpression DivideAssign(Expression left, Expression right) => Expression.DivideAssign(left, right);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.BinaryExpression" /> that represents a division assignment operation that does not have overflow checking.</summary>
         /// <param name="left">An <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Left" /> property equal to.</param>
         /// <param name="right">An <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Right" /> property equal to.</param>
         /// <param name="method">A <see cref="T:System.Reflection.MethodInfo" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Method" /> property equal to.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.BinaryExpression" /> that has the <see cref="P:System.Linq.Expressions.Expression.NodeType" /> property equal to <see cref="F:System.Linq.Expressions.ExpressionType.DivideAssign" /> and the <see cref="P:System.Linq.Expressions.BinaryExpression.Left" />, <see cref="P:System.Linq.Expressions.BinaryExpression.Right" />, and <see cref="P:System.Linq.Expressions.BinaryExpression.Method" /> properties set to the specified values.</returns>
-        public BinaryExpression DivideAssign(Expression left, Expression right, MethodInfo method) => Expression.DivideAssign(left, right, method);
+        public virtual BinaryExpression DivideAssign(Expression left, Expression right, MethodInfo method) => Expression.DivideAssign(left, right, method);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.BinaryExpression" /> that represents a division assignment operation that does not have overflow checking.</summary>
         /// <param name="left">An <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Left" /> property equal to.</param>
@@ -711,28 +714,28 @@ namespace System.Linq.Expressions
         /// <param name="method">A <see cref="T:System.Reflection.MethodInfo" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Method" /> property equal to.</param>
         /// <param name="conversion">A <see cref="T:System.Linq.Expressions.LambdaExpression" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Conversion" /> property equal to.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.BinaryExpression" /> that has the <see cref="P:System.Linq.Expressions.Expression.NodeType" /> property equal to <see cref="F:System.Linq.Expressions.ExpressionType.DivideAssign" /> and the <see cref="P:System.Linq.Expressions.BinaryExpression.Left" />, <see cref="P:System.Linq.Expressions.BinaryExpression.Right" />, <see cref="P:System.Linq.Expressions.BinaryExpression.Method" />, and <see cref="P:System.Linq.Expressions.BinaryExpression.Conversion" /> properties set to the specified values.</returns>
-        public BinaryExpression DivideAssign(Expression left, Expression right, MethodInfo method, LambdaExpression conversion) => Expression.DivideAssign(left, right, method, conversion);
+        public virtual BinaryExpression DivideAssign(Expression left, Expression right, MethodInfo method, LambdaExpression conversion) => Expression.DivideAssign(left, right, method, conversion);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.DynamicExpression" /> that represents a dynamic operation bound by the provided <see cref="T:System.Runtime.CompilerServices.CallSiteBinder" />.</summary>
         /// <param name="binder">The runtime binder for the dynamic operation.</param>
         /// <param name="returnType">The result type of the dynamic expression.</param>
         /// <param name="arguments">The arguments to the dynamic operation.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.DynamicExpression" /> that has <see cref="P:System.Linq.Expressions.Expression.NodeType" /> equal to <see cref="F:System.Linq.Expressions.ExpressionType.Dynamic" /> and has the <see cref="P:System.Linq.Expressions.DynamicExpression.Binder" /> and <see cref="P:System.Linq.Expressions.DynamicExpression.Arguments" /> set to the specified values.</returns>
-        public DynamicExpression Dynamic(CallSiteBinder binder, Type returnType, Expression[] arguments) => Expression.Dynamic(binder, returnType, arguments);
+        public virtual DynamicExpression Dynamic(CallSiteBinder binder, Type returnType, Expression[] arguments) => Expression.Dynamic(binder, returnType, arguments);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.DynamicExpression" /> that represents a dynamic operation bound by the provided <see cref="T:System.Runtime.CompilerServices.CallSiteBinder" />.</summary>
         /// <param name="binder">The runtime binder for the dynamic operation.</param>
         /// <param name="returnType">The result type of the dynamic expression.</param>
         /// <param name="arg0">The first argument to the dynamic operation.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.DynamicExpression" /> that has <see cref="P:System.Linq.Expressions.Expression.NodeType" /> equal to <see cref="F:System.Linq.Expressions.ExpressionType.Dynamic" /> and has the <see cref="P:System.Linq.Expressions.DynamicExpression.Binder" /> and <see cref="P:System.Linq.Expressions.DynamicExpression.Arguments" /> set to the specified values.</returns>
-        public DynamicExpression Dynamic(CallSiteBinder binder, Type returnType, Expression arg0) => Expression.Dynamic(binder, returnType, arg0);
+        public virtual DynamicExpression Dynamic(CallSiteBinder binder, Type returnType, Expression arg0) => Expression.Dynamic(binder, returnType, arg0);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.DynamicExpression" /> that represents a dynamic operation bound by the provided <see cref="T:System.Runtime.CompilerServices.CallSiteBinder" />.</summary>
         /// <param name="binder">The runtime binder for the dynamic operation.</param>
         /// <param name="returnType">The result type of the dynamic expression.</param>
         /// <param name="arguments">The arguments to the dynamic operation.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.DynamicExpression" /> that has <see cref="P:System.Linq.Expressions.Expression.NodeType" /> equal to <see cref="F:System.Linq.Expressions.ExpressionType.Dynamic" /> and has the <see cref="P:System.Linq.Expressions.DynamicExpression.Binder" /> and <see cref="P:System.Linq.Expressions.DynamicExpression.Arguments" /> set to the specified values.</returns>
-        public DynamicExpression Dynamic(CallSiteBinder binder, Type returnType, IEnumerable<Expression> arguments) => Expression.Dynamic(binder, returnType, arguments);
+        public virtual DynamicExpression Dynamic(CallSiteBinder binder, Type returnType, IEnumerable<Expression> arguments) => Expression.Dynamic(binder, returnType, arguments);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.DynamicExpression" /> that represents a dynamic operation bound by the provided <see cref="T:System.Runtime.CompilerServices.CallSiteBinder" />.</summary>
         /// <param name="binder">The runtime binder for the dynamic operation.</param>
@@ -740,7 +743,7 @@ namespace System.Linq.Expressions
         /// <param name="arg0">The first argument to the dynamic operation.</param>
         /// <param name="arg1">The second argument to the dynamic operation.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.DynamicExpression" /> that has <see cref="P:System.Linq.Expressions.Expression.NodeType" /> equal to <see cref="F:System.Linq.Expressions.ExpressionType.Dynamic" /> and has the <see cref="P:System.Linq.Expressions.DynamicExpression.Binder" /> and <see cref="P:System.Linq.Expressions.DynamicExpression.Arguments" /> set to the specified values.</returns>
-        public DynamicExpression Dynamic(CallSiteBinder binder, Type returnType, Expression arg0, Expression arg1) => Expression.Dynamic(binder, returnType, arg0, arg1);
+        public virtual DynamicExpression Dynamic(CallSiteBinder binder, Type returnType, Expression arg0, Expression arg1) => Expression.Dynamic(binder, returnType, arg0, arg1);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.DynamicExpression" /> that represents a dynamic operation bound by the provided <see cref="T:System.Runtime.CompilerServices.CallSiteBinder" />.</summary>
         /// <param name="binder">The runtime binder for the dynamic operation.</param>
@@ -749,7 +752,7 @@ namespace System.Linq.Expressions
         /// <param name="arg1">The second argument to the dynamic operation.</param>
         /// <param name="arg2">The third argument to the dynamic operation.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.DynamicExpression" /> that has <see cref="P:System.Linq.Expressions.Expression.NodeType" /> equal to <see cref="F:System.Linq.Expressions.ExpressionType.Dynamic" /> and has the <see cref="P:System.Linq.Expressions.DynamicExpression.Binder" /> and <see cref="P:System.Linq.Expressions.DynamicExpression.Arguments" /> set to the specified values.</returns>
-        public DynamicExpression Dynamic(CallSiteBinder binder, Type returnType, Expression arg0, Expression arg1, Expression arg2) => Expression.Dynamic(binder, returnType, arg0, arg1, arg2);
+        public virtual DynamicExpression Dynamic(CallSiteBinder binder, Type returnType, Expression arg0, Expression arg1, Expression arg2) => Expression.Dynamic(binder, returnType, arg0, arg1, arg2);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.DynamicExpression" /> that represents a dynamic operation bound by the provided <see cref="T:System.Runtime.CompilerServices.CallSiteBinder" />.</summary>
         /// <param name="binder">The runtime binder for the dynamic operation.</param>
@@ -759,7 +762,7 @@ namespace System.Linq.Expressions
         /// <param name="arg2">The third argument to the dynamic operation.</param>
         /// <param name="arg3">The fourth argument to the dynamic operation.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.DynamicExpression" /> that has <see cref="P:System.Linq.Expressions.Expression.NodeType" /> equal to <see cref="F:System.Linq.Expressions.ExpressionType.Dynamic" /> and has the <see cref="P:System.Linq.Expressions.DynamicExpression.Binder" /> and <see cref="P:System.Linq.Expressions.DynamicExpression.Arguments" /> set to the specified values.</returns>
-        public DynamicExpression Dynamic(CallSiteBinder binder, Type returnType, Expression arg0, Expression arg1, Expression arg2, Expression arg3) => Expression.Dynamic(binder, returnType, arg0, arg1, arg2, arg3);
+        public virtual DynamicExpression Dynamic(CallSiteBinder binder, Type returnType, Expression arg0, Expression arg1, Expression arg2, Expression arg3) => Expression.Dynamic(binder, returnType, arg0, arg1, arg2, arg3);
 
         /// <summary>Creates an <see cref="T:System.Linq.Expressions.ElementInit" />, given an array of values as the second argument.</summary>
         /// <param name="addMethod">A <see cref="T:System.Reflection.MethodInfo" /> to set the <see cref="P:System.Linq.Expressions.ElementInit.AddMethod" /> property equal to.</param>
@@ -768,7 +771,7 @@ namespace System.Linq.Expressions
         /// <exception cref="T:System.ArgumentNullException">
         ///   <paramref name="addMethod" /> or <paramref name="arguments" /> is <see langword="null" />.</exception>
         /// <exception cref="T:System.ArgumentException">The method that addMethod represents is not named "Add" (case insensitive).-or-The method that addMethod represents is not an instance method.-or-arguments does not contain the same number of elements as the number of parameters for the method that addMethod represents.-or-The <see cref="P:System.Linq.Expressions.Expression.Type" /> property of one or more elements of <paramref name="arguments" /> is not assignable to the type of the corresponding parameter of the method that <paramref name="addMethod" /> represents.</exception>
-        public ElementInit ElementInit(MethodInfo addMethod, Expression[] arguments) => Expression.ElementInit(addMethod, arguments);
+        public virtual ElementInit ElementInit(MethodInfo addMethod, Expression[] arguments) => Expression.ElementInit(addMethod, arguments);
 
         /// <summary>Creates an <see cref="T:System.Linq.Expressions.ElementInit" />, given an <see cref="T:System.Collections.Generic.IEnumerable`1" /> as the second argument.</summary>
         /// <param name="addMethod">A <see cref="T:System.Reflection.MethodInfo" /> to set the <see cref="P:System.Linq.Expressions.ElementInit.AddMethod" /> property equal to.</param>
@@ -778,11 +781,11 @@ namespace System.Linq.Expressions
         ///   <paramref name="addMethod" /> or <paramref name="arguments" /> is <see langword="null" />.</exception>
         /// <exception cref="T:System.ArgumentException">The method that <paramref name="addMethod" /> represents is not named "Add" (case insensitive).-or-The method that <paramref name="addMethod" /> represents is not an instance method.-or-
         ///               <paramref name="arguments" /> does not contain the same number of elements as the number of parameters for the method that <paramref name="addMethod" /> represents.-or-The <see cref="P:System.Linq.Expressions.Expression.Type" /> property of one or more elements of <paramref name="arguments" /> is not assignable to the type of the corresponding parameter of the method that <paramref name="addMethod" /> represents.</exception>
-        public ElementInit ElementInit(MethodInfo addMethod, IEnumerable<Expression> arguments) => Expression.ElementInit(addMethod, arguments);
+        public virtual ElementInit ElementInit(MethodInfo addMethod, IEnumerable<Expression> arguments) => Expression.ElementInit(addMethod, arguments);
 
         /// <summary>Creates an empty expression that has <see cref="T:System.Void" /> type.</summary>
         /// <returns>A <see cref="T:System.Linq.Expressions.DefaultExpression" /> that has the <see cref="P:System.Linq.Expressions.Expression.NodeType" /> property equal to <see cref="F:System.Linq.Expressions.ExpressionType.Default" /> and the <see cref="P:System.Linq.Expressions.Expression.Type" /> property set to <see cref="T:System.Void" />.</returns>
-        public DefaultExpression Empty() => Expression.Empty();
+        public virtual DefaultExpression Empty() => Expression.Empty();
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.BinaryExpression" /> that represents an equality comparison.</summary>
         /// <param name="left">An <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Left" /> property equal to.</param>
@@ -791,7 +794,7 @@ namespace System.Linq.Expressions
         /// <exception cref="T:System.ArgumentNullException">
         ///   <paramref name="left" /> or <paramref name="right" /> is <see langword="null" />.</exception>
         /// <exception cref="T:System.InvalidOperationException">The equality operator is not defined for <paramref name="left" />.Type and <paramref name="right" />.Type.</exception>
-        public BinaryExpression Equal(Expression left, Expression right) => Expression.Equal(left, right);
+        public virtual BinaryExpression Equal(Expression left, Expression right) => Expression.Equal(left, right);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.BinaryExpression" /> that represents an equality comparison. The implementing method can be specified.</summary>
         /// <param name="left">An <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Left" /> property equal to.</param>
@@ -806,7 +809,7 @@ namespace System.Linq.Expressions
         ///   <paramref name="method" /> is not <see langword="null" /> and the method it represents returns <see langword="void" />, is not <see langword="static" /> (<see langword="Shared" /> in Visual Basic), or does not take exactly two arguments.</exception>
         /// <exception cref="T:System.InvalidOperationException">
         ///   <paramref name="method" /> is <see langword="null" /> and the equality operator is not defined for <paramref name="left" />.Type and <paramref name="right" />.Type.</exception>
-        public BinaryExpression Equal(Expression left, Expression right, Boolean liftToNull, MethodInfo method) => Expression.Equal(left, right, liftToNull, method);
+        public virtual BinaryExpression Equal(Expression left, Expression right, Boolean liftToNull, MethodInfo method) => Expression.Equal(left, right, liftToNull, method);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.BinaryExpression" /> that represents a bitwise <see langword="XOR" /> operation, using op_ExclusiveOr for user-defined types.</summary>
         /// <param name="left">An <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Left" /> property equal to.</param>
@@ -815,7 +818,7 @@ namespace System.Linq.Expressions
         /// <exception cref="T:System.ArgumentNullException">
         ///   <paramref name="left" /> or <paramref name="right" /> is <see langword="null" />.</exception>
         /// <exception cref="T:System.InvalidOperationException">The <see langword="XOR" /> operator is not defined for <paramref name="left" />.Type and <paramref name="right" />.Type.</exception>
-        public BinaryExpression ExclusiveOr(Expression left, Expression right) => Expression.ExclusiveOr(left, right);
+        public virtual BinaryExpression ExclusiveOr(Expression left, Expression right) => Expression.ExclusiveOr(left, right);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.BinaryExpression" /> that represents a bitwise <see langword="XOR" /> operation, using op_ExclusiveOr for user-defined types. The implementing method can be specified.</summary>
         /// <param name="left">An <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Left" /> property equal to.</param>
@@ -828,20 +831,20 @@ namespace System.Linq.Expressions
         ///   <paramref name="method" /> is not <see langword="null" /> and the method it represents returns <see langword="void" />, is not <see langword="static" /> (<see langword="Shared" /> in Visual Basic), or does not take exactly two arguments.</exception>
         /// <exception cref="T:System.InvalidOperationException">
         ///   <paramref name="method" /> is <see langword="null" /> and the <see langword="XOR" /> operator is not defined for <paramref name="left" />.Type and <paramref name="right" />.Type.</exception>
-        public BinaryExpression ExclusiveOr(Expression left, Expression right, MethodInfo method) => Expression.ExclusiveOr(left, right, method);
+        public virtual BinaryExpression ExclusiveOr(Expression left, Expression right, MethodInfo method) => Expression.ExclusiveOr(left, right, method);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.BinaryExpression" /> that represents a bitwise XOR assignment operation, using op_ExclusiveOr for user-defined types.</summary>
         /// <param name="left">An <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Left" /> property equal to.</param>
         /// <param name="right">An <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Right" /> property equal to.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.BinaryExpression" /> that has the <see cref="P:System.Linq.Expressions.Expression.NodeType" /> property equal to <see cref="F:System.Linq.Expressions.ExpressionType.ExclusiveOrAssign" /> and the <see cref="P:System.Linq.Expressions.BinaryExpression.Left" /> and <see cref="P:System.Linq.Expressions.BinaryExpression.Right" /> properties set to the specified values.</returns>
-        public BinaryExpression ExclusiveOrAssign(Expression left, Expression right) => Expression.ExclusiveOrAssign(left, right);
+        public virtual BinaryExpression ExclusiveOrAssign(Expression left, Expression right) => Expression.ExclusiveOrAssign(left, right);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.BinaryExpression" /> that represents a bitwise XOR assignment operation, using op_ExclusiveOr for user-defined types.</summary>
         /// <param name="left">An <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Left" /> property equal to.</param>
         /// <param name="right">An <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Right" /> property equal to.</param>
         /// <param name="method">A <see cref="T:System.Reflection.MethodInfo" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Method" /> property equal to.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.BinaryExpression" /> that has the <see cref="P:System.Linq.Expressions.Expression.NodeType" /> property equal to <see cref="F:System.Linq.Expressions.ExpressionType.ExclusiveOrAssign" /> and the <see cref="P:System.Linq.Expressions.BinaryExpression.Left" />, <see cref="P:System.Linq.Expressions.BinaryExpression.Right" />, and <see cref="P:System.Linq.Expressions.BinaryExpression.Method" /> properties set to the specified values.</returns>
-        public BinaryExpression ExclusiveOrAssign(Expression left, Expression right, MethodInfo method) => Expression.ExclusiveOrAssign(left, right, method);
+        public virtual BinaryExpression ExclusiveOrAssign(Expression left, Expression right, MethodInfo method) => Expression.ExclusiveOrAssign(left, right, method);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.BinaryExpression" /> that represents a bitwise XOR assignment operation, using op_ExclusiveOr for user-defined types.</summary>
         /// <param name="left">An <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Left" /> property equal to.</param>
@@ -849,7 +852,7 @@ namespace System.Linq.Expressions
         /// <param name="method">A <see cref="T:System.Reflection.MethodInfo" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Method" /> property equal to.</param>
         /// <param name="conversion">A <see cref="T:System.Linq.Expressions.LambdaExpression" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Conversion" /> property equal to.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.BinaryExpression" /> that has the <see cref="P:System.Linq.Expressions.Expression.NodeType" /> property equal to <see cref="F:System.Linq.Expressions.ExpressionType.ExclusiveOrAssign" /> and the <see cref="P:System.Linq.Expressions.BinaryExpression.Left" />, <see cref="P:System.Linq.Expressions.BinaryExpression.Right" />, <see cref="P:System.Linq.Expressions.BinaryExpression.Method" />, and <see cref="P:System.Linq.Expressions.BinaryExpression.Conversion" /> properties set to the specified values.</returns>
-        public BinaryExpression ExclusiveOrAssign(Expression left, Expression right, MethodInfo method, LambdaExpression conversion) => Expression.ExclusiveOrAssign(left, right, method, conversion);
+        public virtual BinaryExpression ExclusiveOrAssign(Expression left, Expression right, MethodInfo method, LambdaExpression conversion) => Expression.ExclusiveOrAssign(left, right, method, conversion);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.MemberExpression" /> that represents accessing a field.</summary>
         /// <param name="expression">An <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.MemberExpression.Expression" /> property equal to. For <see langword="static" /> (<see langword="Shared" /> in Visual Basic), <paramref name="expression" /> must be <see langword="null" />.</param>
@@ -859,7 +862,7 @@ namespace System.Linq.Expressions
         ///   <paramref name="field" /> is <see langword="null" />.-or-The field represented by <paramref name="field" /> is not <see langword="static" /> (<see langword="Shared" /> in Visual Basic) and <paramref name="expression" /> is <see langword="null" />.</exception>
         /// <exception cref="T:System.ArgumentException">
         ///   <paramref name="expression" />.Type is not assignable to the declaring type of the field represented by <paramref name="field" />.</exception>
-        public MemberExpression Field(Expression expression, FieldInfo field) => Expression.Field(expression, field);
+        public virtual MemberExpression Field(Expression expression, FieldInfo field) => Expression.Field(expression, field);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.MemberExpression" /> that represents accessing a field given the name of the field.</summary>
         /// <param name="expression">An <see cref="T:System.Linq.Expressions.Expression" /> whose <see cref="P:System.Linq.Expressions.Expression.Type" /> contains a field named <paramref name="fieldName" />. This can be null for static fields.</param>
@@ -868,38 +871,38 @@ namespace System.Linq.Expressions
         /// <exception cref="T:System.ArgumentNullException">
         ///   <paramref name="expression" /> or <paramref name="fieldName" /> is <see langword="null" />.</exception>
         /// <exception cref="T:System.ArgumentException">No field named <paramref name="fieldName" /> is defined in <paramref name="expression" />.Type or its base types.</exception>
-        public MemberExpression Field(Expression expression, String fieldName) => Expression.Field(expression, fieldName);
+        public virtual MemberExpression Field(Expression expression, String fieldName) => Expression.Field(expression, fieldName);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.MemberExpression" /> that represents accessing a field.</summary>
         /// <param name="expression">The containing object of the field. This can be null for static fields.</param>
         /// <param name="type">The <see cref="P:System.Linq.Expressions.Expression.Type" /> that contains the field.</param>
         /// <param name="fieldName">The field to be accessed.</param>
         /// <returns>The created <see cref="T:System.Linq.Expressions.MemberExpression" />.</returns>
-        public MemberExpression Field(Expression expression, Type type, String fieldName) => Expression.Field(expression, type, fieldName);
+        public virtual MemberExpression Field(Expression expression, Type type, String fieldName) => Expression.Field(expression, type, fieldName);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.GotoExpression" /> representing a "go to" statement.</summary>
         /// <param name="target">The <see cref="T:System.Linq.Expressions.LabelTarget" /> that the <see cref="T:System.Linq.Expressions.GotoExpression" /> will jump to.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.GotoExpression" /> with <see cref="P:System.Linq.Expressions.GotoExpression.Kind" /> equal to Goto, the <see cref="P:System.Linq.Expressions.GotoExpression.Target" /> property set to the specified value, and a null value to be passed to the target label upon jumping.</returns>
-        public GotoExpression Goto(LabelTarget target) => Expression.Goto(target);
+        public virtual GotoExpression Goto(LabelTarget target) => Expression.Goto(target);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.GotoExpression" /> representing a "go to" statement with the specified type.</summary>
         /// <param name="target">The <see cref="T:System.Linq.Expressions.LabelTarget" /> that the <see cref="T:System.Linq.Expressions.GotoExpression" /> will jump to.</param>
         /// <param name="type">An <see cref="T:System.Type" /> to set the <see cref="P:System.Linq.Expressions.Expression.Type" /> property equal to.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.GotoExpression" /> with <see cref="P:System.Linq.Expressions.GotoExpression.Kind" /> equal to Goto, the <see cref="P:System.Linq.Expressions.GotoExpression.Target" /> property set to the specified value, the <see cref="P:System.Linq.Expressions.Expression.Type" /> property set to <paramref name="type" />, and a null value to be passed to the target label upon jumping.</returns>
-        public GotoExpression Goto(LabelTarget target, Type type) => Expression.Goto(target, type);
+        public virtual GotoExpression Goto(LabelTarget target, Type type) => Expression.Goto(target, type);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.GotoExpression" /> representing a "go to" statement. The value passed to the label upon jumping can be specified.</summary>
         /// <param name="target">The <see cref="T:System.Linq.Expressions.LabelTarget" /> that the <see cref="T:System.Linq.Expressions.GotoExpression" /> will jump to.</param>
         /// <param name="value">The value that will be passed to the associated label upon jumping.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.GotoExpression" /> with <see cref="P:System.Linq.Expressions.GotoExpression.Kind" /> equal to Goto, the <see cref="P:System.Linq.Expressions.GotoExpression.Target" /> property set to <paramref name="target" />, and <paramref name="value" /> to be passed to the target label upon jumping.</returns>
-        public GotoExpression Goto(LabelTarget target, Expression value) => Expression.Goto(target, value);
+        public virtual GotoExpression Goto(LabelTarget target, Expression value) => Expression.Goto(target, value);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.GotoExpression" /> representing a "go to" statement with the specified type. The value passed to the label upon jumping can be specified.</summary>
         /// <param name="target">The <see cref="T:System.Linq.Expressions.LabelTarget" /> that the <see cref="T:System.Linq.Expressions.GotoExpression" /> will jump to.</param>
         /// <param name="value">The value that will be passed to the associated label upon jumping.</param>
         /// <param name="type">An <see cref="T:System.Type" /> to set the <see cref="P:System.Linq.Expressions.Expression.Type" /> property equal to.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.GotoExpression" /> with <see cref="P:System.Linq.Expressions.GotoExpression.Kind" /> equal to Goto, the <see cref="P:System.Linq.Expressions.GotoExpression.Target" /> property set to <paramref name="target" />, the <see cref="P:System.Linq.Expressions.Expression.Type" /> property set to <paramref name="type" />, and <paramref name="value" /> to be passed to the target label upon jumping.</returns>
-        public GotoExpression Goto(LabelTarget target, Expression value, Type type) => Expression.Goto(target, value, type);
+        public virtual GotoExpression Goto(LabelTarget target, Expression value, Type type) => Expression.Goto(target, value, type);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.BinaryExpression" /> that represents a "greater than" numeric comparison.</summary>
         /// <param name="left">An <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Left" /> property equal to.</param>
@@ -908,7 +911,7 @@ namespace System.Linq.Expressions
         /// <exception cref="T:System.ArgumentNullException">
         ///   <paramref name="left" /> or <paramref name="right" /> is <see langword="null" />.</exception>
         /// <exception cref="T:System.InvalidOperationException">The "greater than" operator is not defined for <paramref name="left" />.Type and <paramref name="right" />.Type.</exception>
-        public BinaryExpression GreaterThan(Expression left, Expression right) => Expression.GreaterThan(left, right);
+        public virtual BinaryExpression GreaterThan(Expression left, Expression right) => Expression.GreaterThan(left, right);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.BinaryExpression" /> that represents a "greater than" numeric comparison. The implementing method can be specified.</summary>
         /// <param name="left">An <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Left" /> property equal to.</param>
@@ -923,7 +926,7 @@ namespace System.Linq.Expressions
         ///   <paramref name="method" /> is not <see langword="null" /> and the method it represents returns <see langword="void" />, is not <see langword="static" /> (<see langword="Shared" /> in Visual Basic), or does not take exactly two arguments.</exception>
         /// <exception cref="T:System.InvalidOperationException">
         ///   <paramref name="method" /> is <see langword="null" /> and the "greater than" operator is not defined for <paramref name="left" />.Type and <paramref name="right" />.Type.</exception>
-        public BinaryExpression GreaterThan(Expression left, Expression right, Boolean liftToNull, MethodInfo method) => Expression.GreaterThan(left, right, liftToNull, method);
+        public virtual BinaryExpression GreaterThan(Expression left, Expression right, Boolean liftToNull, MethodInfo method) => Expression.GreaterThan(left, right, liftToNull, method);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.BinaryExpression" /> that represents a "greater than or equal" numeric comparison.</summary>
         /// <param name="left">An <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Left" /> property equal to.</param>
@@ -932,7 +935,7 @@ namespace System.Linq.Expressions
         /// <exception cref="T:System.ArgumentNullException">
         ///   <paramref name="left" /> or <paramref name="right" /> is <see langword="null" />.</exception>
         /// <exception cref="T:System.InvalidOperationException">The "greater than or equal" operator is not defined for <paramref name="left" />.Type and <paramref name="right" />.Type.</exception>
-        public BinaryExpression GreaterThanOrEqual(Expression left, Expression right) => Expression.GreaterThanOrEqual(left, right);
+        public virtual BinaryExpression GreaterThanOrEqual(Expression left, Expression right) => Expression.GreaterThanOrEqual(left, right);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.BinaryExpression" /> that represents a "greater than or equal" numeric comparison.</summary>
         /// <param name="left">An <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Left" /> property equal to.</param>
@@ -947,31 +950,31 @@ namespace System.Linq.Expressions
         ///   <paramref name="method" /> is not <see langword="null" /> and the method it represents returns <see langword="void" />, is not <see langword="static" /> (<see langword="Shared" /> in Visual Basic), or does not take exactly two arguments.</exception>
         /// <exception cref="T:System.InvalidOperationException">
         ///   <paramref name="method" /> is <see langword="null" /> and the "greater than or equal" operator is not defined for <paramref name="left" />.Type and <paramref name="right" />.Type.</exception>
-        public BinaryExpression GreaterThanOrEqual(Expression left, Expression right, Boolean liftToNull, MethodInfo method) => Expression.GreaterThanOrEqual(left, right, liftToNull, method);
+        public virtual BinaryExpression GreaterThanOrEqual(Expression left, Expression right, Boolean liftToNull, MethodInfo method) => Expression.GreaterThanOrEqual(left, right, liftToNull, method);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.ConditionalExpression" /> that represents a conditional block with an <see langword="if" /> statement.</summary>
         /// <param name="test">An <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.ConditionalExpression.Test" /> property equal to.</param>
         /// <param name="ifTrue">An <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.ConditionalExpression.IfTrue" /> property equal to.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.ConditionalExpression" /> that has the <see cref="P:System.Linq.Expressions.Expression.NodeType" /> property equal to <see cref="F:System.Linq.Expressions.ExpressionType.Conditional" /> and the <see cref="P:System.Linq.Expressions.ConditionalExpression.Test" />, <see cref="P:System.Linq.Expressions.ConditionalExpression.IfTrue" />, properties set to the specified values. The <see cref="P:System.Linq.Expressions.ConditionalExpression.IfFalse" /> property is set to default expression and the type of the resulting <see cref="T:System.Linq.Expressions.ConditionalExpression" /> returned by this method is <see cref="T:System.Void" />.</returns>
-        public ConditionalExpression IfThen(Expression test, Expression ifTrue) => Expression.IfThen(test, ifTrue);
+        public virtual ConditionalExpression IfThen(Expression test, Expression ifTrue) => Expression.IfThen(test, ifTrue);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.ConditionalExpression" /> that represents a conditional block with <see langword="if" /> and <see langword="else" /> statements.</summary>
         /// <param name="test">An <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.ConditionalExpression.Test" /> property equal to.</param>
         /// <param name="ifTrue">An <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.ConditionalExpression.IfTrue" /> property equal to.</param>
         /// <param name="ifFalse">An <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.ConditionalExpression.IfFalse" /> property equal to.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.ConditionalExpression" /> that has the <see cref="P:System.Linq.Expressions.Expression.NodeType" /> property equal to <see cref="F:System.Linq.Expressions.ExpressionType.Conditional" /> and the <see cref="P:System.Linq.Expressions.ConditionalExpression.Test" />, <see cref="P:System.Linq.Expressions.ConditionalExpression.IfTrue" />, and <see cref="P:System.Linq.Expressions.ConditionalExpression.IfFalse" /> properties set to the specified values. The type of the resulting <see cref="T:System.Linq.Expressions.ConditionalExpression" /> returned by this method is <see cref="T:System.Void" />.</returns>
-        public ConditionalExpression IfThenElse(Expression test, Expression ifTrue, Expression ifFalse) => Expression.IfThenElse(test, ifTrue, ifFalse);
+        public virtual ConditionalExpression IfThenElse(Expression test, Expression ifTrue, Expression ifFalse) => Expression.IfThenElse(test, ifTrue, ifFalse);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.UnaryExpression" /> that represents the incrementing of the expression value by 1.</summary>
         /// <param name="expression">An <see cref="T:System.Linq.Expressions.Expression" /> to increment.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.UnaryExpression" /> that represents the incremented expression.</returns>
-        public UnaryExpression Increment(Expression expression) => Expression.Increment(expression);
+        public virtual UnaryExpression Increment(Expression expression) => Expression.Increment(expression);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.UnaryExpression" /> that represents the incrementing of the expression by 1.</summary>
         /// <param name="expression">An <see cref="T:System.Linq.Expressions.Expression" /> to increment.</param>
         /// <param name="method">A <see cref="T:System.Reflection.MethodInfo" /> that represents the implementing method.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.UnaryExpression" /> that represents the incremented expression.</returns>
-        public UnaryExpression Increment(Expression expression, MethodInfo method) => Expression.Increment(expression, method);
+        public virtual UnaryExpression Increment(Expression expression, MethodInfo method) => Expression.Increment(expression, method);
 
         /// <summary>Creates an <see cref="T:System.Linq.Expressions.InvocationExpression" /> that applies a delegate or lambda expression to a list of argument expressions.</summary>
         /// <param name="expression">An <see cref="T:System.Linq.Expressions.Expression" /> that represents the delegate or lambda expression to be applied.</param>
@@ -983,7 +986,7 @@ namespace System.Linq.Expressions
         ///   <paramref name="expression" />.Type does not represent a delegate type or an <see cref="T:System.Linq.Expressions.Expression`1" />.-or-The <see cref="P:System.Linq.Expressions.Expression.Type" /> property of an element of <paramref name="arguments" /> is not assignable to the type of the corresponding parameter of the delegate represented by <paramref name="expression" />.</exception>
         /// <exception cref="T:System.InvalidOperationException">
         ///   <paramref name="arguments" /> does not contain the same number of elements as the list of parameters for the delegate represented by <paramref name="expression" />.</exception>
-        public InvocationExpression Invoke(Expression expression, Expression[] arguments) => Expression.Invoke(expression, arguments);
+        public virtual InvocationExpression Invoke(Expression expression, Expression[] arguments) => Expression.Invoke(expression, arguments);
 
         /// <summary>Creates an <see cref="T:System.Linq.Expressions.InvocationExpression" /> that applies a delegate or lambda expression to a list of argument expressions.</summary>
         /// <param name="expression">An <see cref="T:System.Linq.Expressions.Expression" /> that represents the delegate or lambda expression to be applied to.</param>
@@ -995,60 +998,60 @@ namespace System.Linq.Expressions
         ///   <paramref name="expression" />.Type does not represent a delegate type or an <see cref="T:System.Linq.Expressions.Expression`1" />.-or-The <see cref="P:System.Linq.Expressions.Expression.Type" /> property of an element of <paramref name="arguments" /> is not assignable to the type of the corresponding parameter of the delegate represented by <paramref name="expression" />.</exception>
         /// <exception cref="T:System.InvalidOperationException">
         ///   <paramref name="arguments" /> does not contain the same number of elements as the list of parameters for the delegate represented by <paramref name="expression" />.</exception>
-        public InvocationExpression Invoke(Expression expression, IEnumerable<Expression> arguments) => Expression.Invoke(expression, arguments);
+        public virtual InvocationExpression Invoke(Expression expression, IEnumerable<Expression> arguments) => Expression.Invoke(expression, arguments);
 
         /// <summary>Returns whether the expression evaluates to false.</summary>
         /// <param name="expression">An <see cref="T:System.Linq.Expressions.Expression" /> to evaluate.</param>
         /// <returns>An instance of <see cref="T:System.Linq.Expressions.UnaryExpression" />.</returns>
-        public UnaryExpression IsFalse(Expression expression) => Expression.IsFalse(expression);
+        public virtual UnaryExpression IsFalse(Expression expression) => Expression.IsFalse(expression);
 
         /// <summary>Returns whether the expression evaluates to false.</summary>
         /// <param name="expression">An <see cref="T:System.Linq.Expressions.Expression" /> to evaluate.</param>
         /// <param name="method">A <see cref="T:System.Reflection.MethodInfo" /> that represents the implementing method.</param>
         /// <returns>An instance of <see cref="T:System.Linq.Expressions.UnaryExpression" />.</returns>
-        public UnaryExpression IsFalse(Expression expression, MethodInfo method) => Expression.IsFalse(expression, method);
+        public virtual UnaryExpression IsFalse(Expression expression, MethodInfo method) => Expression.IsFalse(expression, method);
 
         /// <summary>Returns whether the expression evaluates to true.</summary>
         /// <param name="expression">An <see cref="T:System.Linq.Expressions.Expression" /> to evaluate.</param>
         /// <returns>An instance of <see cref="T:System.Linq.Expressions.UnaryExpression" />.</returns>
-        public UnaryExpression IsTrue(Expression expression) => Expression.IsTrue(expression);
+        public virtual UnaryExpression IsTrue(Expression expression) => Expression.IsTrue(expression);
 
         /// <summary>Returns whether the expression evaluates to true.</summary>
         /// <param name="expression">An <see cref="T:System.Linq.Expressions.Expression" /> to evaluate.</param>
         /// <param name="method">A <see cref="T:System.Reflection.MethodInfo" /> that represents the implementing method.</param>
         /// <returns>An instance of <see cref="T:System.Linq.Expressions.UnaryExpression" />.</returns>
-        public UnaryExpression IsTrue(Expression expression, MethodInfo method) => Expression.IsTrue(expression, method);
+        public virtual UnaryExpression IsTrue(Expression expression, MethodInfo method) => Expression.IsTrue(expression, method);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.LabelTarget" /> representing a label with void type and no name.</summary>
         /// <returns>The new <see cref="T:System.Linq.Expressions.LabelTarget" />.</returns>
-        public LabelTarget Label() => Expression.Label();
+        public virtual LabelTarget Label() => Expression.Label();
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.LabelExpression" /> representing a label without a default value.</summary>
         /// <param name="target">The <see cref="T:System.Linq.Expressions.LabelTarget" /> which this <see cref="T:System.Linq.Expressions.LabelExpression" /> will be associated with.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.LabelExpression" /> without a default value.</returns>
-        public LabelExpression Label(LabelTarget target) => Expression.Label(target);
+        public virtual LabelExpression Label(LabelTarget target) => Expression.Label(target);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.LabelTarget" /> representing a label with void type and the given name.</summary>
         /// <param name="name">The name of the label.</param>
         /// <returns>The new <see cref="T:System.Linq.Expressions.LabelTarget" />.</returns>
-        public LabelTarget Label(String name) => Expression.Label(name);
+        public virtual LabelTarget Label(String name) => Expression.Label(name);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.LabelTarget" /> representing a label with the given type.</summary>
         /// <param name="type">The type of value that is passed when jumping to the label.</param>
         /// <returns>The new <see cref="T:System.Linq.Expressions.LabelTarget" />.</returns>
-        public LabelTarget Label(Type type) => Expression.Label(type);
+        public virtual LabelTarget Label(Type type) => Expression.Label(type);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.LabelExpression" /> representing a label with the given default value.</summary>
         /// <param name="target">The <see cref="T:System.Linq.Expressions.LabelTarget" /> which this <see cref="T:System.Linq.Expressions.LabelExpression" /> will be associated with.</param>
         /// <param name="defaultValue">The value of this <see cref="T:System.Linq.Expressions.LabelExpression" /> when the label is reached through regular control flow.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.LabelExpression" /> with the given default value.</returns>
-        public LabelExpression Label(LabelTarget target, Expression defaultValue) => Expression.Label(target, defaultValue);
+        public virtual LabelExpression Label(LabelTarget target, Expression defaultValue) => Expression.Label(target, defaultValue);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.LabelTarget" /> representing a label with the given type and name.</summary>
         /// <param name="type">The type of value that is passed when jumping to the label.</param>
         /// <param name="name">The name of the label.</param>
         /// <returns>The new <see cref="T:System.Linq.Expressions.LabelTarget" />.</returns>
-        public LabelTarget Label(Type type, String name) => Expression.Label(type, name);
+        public virtual LabelTarget Label(Type type, String name) => Expression.Label(type, name);
 
         /// <summary>Creates an <see cref="T:System.Linq.Expressions.Expression`1" /> where the delegate type is known at compile time.</summary>
         /// <param name="body">An <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.LambdaExpression.Body" /> property equal to.</param>
@@ -1061,7 +1064,7 @@ namespace System.Linq.Expressions
         ///   <typeparamref name="TDelegate" /> is not a delegate type.-or-
         ///               <paramref name="body" />.Type represents a type that is not assignable to the return type of <typeparamref name="TDelegate" />.-or-
         ///               <paramref name="parameters" /> does not contain the same number of elements as the list of parameters for <typeparamref name="TDelegate" />.-or-The <see cref="P:System.Linq.Expressions.Expression.Type" /> property of an element of <paramref name="parameters" /> is not assignable from the type of the corresponding parameter type of <typeparamref name="TDelegate" />.</exception>
-        public Expression<TDelegate> Lambda<TDelegate>(Expression body, ParameterExpression[] parameters) => Expression.Lambda<TDelegate>(body, parameters);
+        public virtual Expression<TDelegate> Lambda<TDelegate>(Expression body, ParameterExpression[] parameters) => Expression.Lambda<TDelegate>(body, parameters);
 
         /// <summary>Creates an <see cref="T:System.Linq.Expressions.Expression`1" /> where the delegate type is known at compile time.</summary>
         /// <param name="body">An <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.LambdaExpression.Body" /> property equal to.</param>
@@ -1074,7 +1077,7 @@ namespace System.Linq.Expressions
         ///   <typeparamref name="TDelegate" /> is not a delegate type.-or-
         ///               <paramref name="body" />.Type represents a type that is not assignable to the return type of <typeparamref name="TDelegate" />.-or-
         ///               <paramref name="parameters" /> does not contain the same number of elements as the list of parameters for <typeparamref name="TDelegate" />.-or-The <see cref="P:System.Linq.Expressions.Expression.Type" /> property of an element of <paramref name="parameters" /> is not assignable from the type of the corresponding parameter type of <typeparamref name="TDelegate" />.</exception>
-        public Expression<TDelegate> Lambda<TDelegate>(Expression body, IEnumerable<ParameterExpression> parameters) => Expression.Lambda<TDelegate>(body, parameters);
+        public virtual Expression<TDelegate> Lambda<TDelegate>(Expression body, IEnumerable<ParameterExpression> parameters) => Expression.Lambda<TDelegate>(body, parameters);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.LambdaExpression" /> by first constructing a delegate type.</summary>
         /// <param name="body">An <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.LambdaExpression.Body" /> property equal to.</param>
@@ -1084,13 +1087,13 @@ namespace System.Linq.Expressions
         ///   <paramref name="body" /> is <see langword="null" />.-or-One or more elements of <paramref name="parameters" /> are <see langword="null" />.</exception>
         /// <exception cref="T:System.ArgumentException">
         ///   <paramref name="parameters" /> contains more than sixteen elements.</exception>
-        public LambdaExpression Lambda(Expression body, ParameterExpression[] parameters) => Expression.Lambda(body, parameters);
+        public virtual LambdaExpression Lambda(Expression body, ParameterExpression[] parameters) => Expression.Lambda(body, parameters);
 
         /// <summary>Creates a LambdaExpression by first constructing a delegate type.</summary>
         /// <param name="body">An <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.LambdaExpression.Body" /> property equal to.</param>
         /// <param name="parameters">An <see cref="T:System.Collections.Generic.IEnumerable`1" /> that contains <see cref="T:System.Linq.Expressions.ParameterExpression" /> objects to use to populate the <see cref="P:System.Linq.Expressions.LambdaExpression.Parameters" /> collection.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.LambdaExpression" /> that has the <see cref="P:System.Linq.Expressions.LambdaExpression.NodeType" /> property equal to Lambda and the <see cref="P:System.Linq.Expressions.LambdaExpression.Body" /> and <see cref="P:System.Linq.Expressions.LambdaExpression.Parameters" /> properties set to the specified values.</returns>
-        public LambdaExpression Lambda(Expression body, IEnumerable<ParameterExpression> parameters) => Expression.Lambda(body, parameters);
+        public virtual LambdaExpression Lambda(Expression body, IEnumerable<ParameterExpression> parameters) => Expression.Lambda(body, parameters);
 
         /// <summary>Creates an <see cref="T:System.Linq.Expressions.Expression`1" /> where the delegate type is known at compile time.</summary>
         /// <param name="body">An <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.LambdaExpression.Body" /> property equal to.</param>
@@ -1098,7 +1101,7 @@ namespace System.Linq.Expressions
         /// <param name="parameters">An array that contains <see cref="T:System.Linq.Expressions.ParameterExpression" /> objects to use to populate the <see cref="P:System.Linq.Expressions.LambdaExpression.Parameters" /> collection.</param>
         /// <typeparam name="TDelegate">The delegate type. </typeparam>
         /// <returns>An <see cref="T:System.Linq.Expressions.Expression`1" /> that has the <see cref="P:System.Linq.Expressions.Expression.NodeType" /> property equal to <see cref="F:System.Linq.Expressions.ExpressionType.Lambda" /> and the <see cref="P:System.Linq.Expressions.LambdaExpression.Body" /> and <see cref="P:System.Linq.Expressions.LambdaExpression.Parameters" /> properties set to the specified values.</returns>
-        public Expression<TDelegate> Lambda<TDelegate>(Expression body, Boolean tailCall, ParameterExpression[] parameters) => Expression.Lambda<TDelegate>(body, tailCall, parameters);
+        public virtual Expression<TDelegate> Lambda<TDelegate>(Expression body, Boolean tailCall, ParameterExpression[] parameters) => Expression.Lambda<TDelegate>(body, tailCall, parameters);
 
         /// <summary>Creates an <see cref="T:System.Linq.Expressions.Expression`1" /> where the delegate type is known at compile time.</summary>
         /// <param name="body">An <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.LambdaExpression.Body" /> property equal to.</param>
@@ -1106,7 +1109,7 @@ namespace System.Linq.Expressions
         /// <param name="parameters">An <see cref="T:System.Collections.Generic.IEnumerable`1" /> that contains <see cref="T:System.Linq.Expressions.ParameterExpression" /> objects to use to populate the <see cref="P:System.Linq.Expressions.LambdaExpression.Parameters" /> collection.</param>
         /// <typeparam name="TDelegate">The delegate type. </typeparam>
         /// <returns>An <see cref="T:System.Linq.Expressions.Expression`1" /> that has the <see cref="P:System.Linq.Expressions.LambdaExpression.NodeType" /> property equal to <see cref="F:System.Linq.Expressions.ExpressionType.Lambda" /> and the <see cref="P:System.Linq.Expressions.LambdaExpression.Body" /> and <see cref="P:System.Linq.Expressions.LambdaExpression.Parameters" /> properties set to the specified values.</returns>
-        public Expression<TDelegate> Lambda<TDelegate>(Expression body, Boolean tailCall, IEnumerable<ParameterExpression> parameters) => Expression.Lambda<TDelegate>(body, tailCall, parameters);
+        public virtual Expression<TDelegate> Lambda<TDelegate>(Expression body, Boolean tailCall, IEnumerable<ParameterExpression> parameters) => Expression.Lambda<TDelegate>(body, tailCall, parameters);
 
         /// <summary>Creates an <see cref="T:System.Linq.Expressions.Expression`1" /> where the delegate type is known at compile time.</summary>
         /// <param name="body">An <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.LambdaExpression.Body" /> property equal to.</param>
@@ -1114,21 +1117,21 @@ namespace System.Linq.Expressions
         /// <param name="parameters">An <see cref="T:System.Collections.Generic.IEnumerable`1" /> that contains <see cref="T:System.Linq.Expressions.ParameterExpression" /> objects to use to populate the <see cref="P:System.Linq.Expressions.LambdaExpression.Parameters" /> collection.</param>
         /// <typeparam name="TDelegate">The delegate type. </typeparam>
         /// <returns>An <see cref="T:System.Linq.Expressions.Expression`1" /> that has the <see cref="P:System.Linq.Expressions.Expression.NodeType" /> property equal to <see cref="F:System.Linq.Expressions.ExpressionType.Lambda" /> and the <see cref="P:System.Linq.Expressions.LambdaExpression.Body" /> and <see cref="P:System.Linq.Expressions.LambdaExpression.Parameters" /> properties set to the specified values.</returns>
-        public Expression<TDelegate> Lambda<TDelegate>(Expression body, String name, IEnumerable<ParameterExpression> parameters) => Expression.Lambda<TDelegate>(body, name, parameters);
+        public virtual Expression<TDelegate> Lambda<TDelegate>(Expression body, String name, IEnumerable<ParameterExpression> parameters) => Expression.Lambda<TDelegate>(body, name, parameters);
 
         /// <summary>Creates a LambdaExpression by first constructing a delegate type.</summary>
         /// <param name="body">An <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.LambdaExpression.Body" /> property equal to.</param>
         /// <param name="tailCall">A <see cref="T:System.Boolean" /> that indicates if tail call optimization will be applied when compiling the created expression.</param>
         /// <param name="parameters">An array that contains <see cref="T:System.Linq.Expressions.ParameterExpression" /> objects to use to populate the <see cref="P:System.Linq.Expressions.LambdaExpression.Parameters" /> collection.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.LambdaExpression" /> that has the <see cref="P:System.Linq.Expressions.LambdaExpression.NodeType" /> property equal to Lambda and the <see cref="P:System.Linq.Expressions.LambdaExpression.Body" /> and <see cref="P:System.Linq.Expressions.LambdaExpression.Parameters" /> properties set to the specified values.</returns>
-        public LambdaExpression Lambda(Expression body, Boolean tailCall, ParameterExpression[] parameters) => Expression.Lambda(body, tailCall, parameters);
+        public virtual LambdaExpression Lambda(Expression body, Boolean tailCall, ParameterExpression[] parameters) => Expression.Lambda(body, tailCall, parameters);
 
         /// <summary>Creates a LambdaExpression by first constructing a delegate type.</summary>
         /// <param name="body">An <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.LambdaExpression.Body" /> property equal to.</param>
         /// <param name="tailCall">A <see cref="T:System.Boolean" /> that indicates if tail call optimization will be applied when compiling the created expression.</param>
         /// <param name="parameters">An <see cref="T:System.Collections.Generic.IEnumerable`1" /> that contains <see cref="T:System.Linq.Expressions.ParameterExpression" /> objects to use to populate the <see cref="P:System.Linq.Expressions.LambdaExpression.Parameters" /> collection.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.LambdaExpression" /> that has the <see cref="P:System.Linq.Expressions.LambdaExpression.NodeType" /> property equal to Lambda and the <see cref="P:System.Linq.Expressions.LambdaExpression.Body" /> and <see cref="P:System.Linq.Expressions.LambdaExpression.Parameters" /> properties set to the specified values.</returns>
-        public LambdaExpression Lambda(Expression body, Boolean tailCall, IEnumerable<ParameterExpression> parameters) => Expression.Lambda(body, tailCall, parameters);
+        public virtual LambdaExpression Lambda(Expression body, Boolean tailCall, IEnumerable<ParameterExpression> parameters) => Expression.Lambda(body, tailCall, parameters);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.LambdaExpression" /> by first constructing a delegate type. It can be used when the delegate type is not known at compile time.</summary>
         /// <param name="delegateType">A <see cref="T:System.Type" /> that represents a delegate signature for the lambda.</param>
@@ -1141,7 +1144,7 @@ namespace System.Linq.Expressions
         ///   <paramref name="delegateType" /> does not represent a delegate type.-or-
         ///               <paramref name="body" />.Type represents a type that is not assignable to the return type of the delegate type represented by <paramref name="delegateType" />.-or-
         ///               <paramref name="parameters" /> does not contain the same number of elements as the list of parameters for the delegate type represented by <paramref name="delegateType" />.-or-The <see cref="P:System.Linq.Expressions.Expression.Type" /> property of an element of <paramref name="parameters" /> is not assignable from the type of the corresponding parameter type of the delegate type represented by <paramref name="delegateType" />.</exception>
-        public LambdaExpression Lambda(Type delegateType, Expression body, ParameterExpression[] parameters) => Expression.Lambda(delegateType, body, parameters);
+        public virtual LambdaExpression Lambda(Type delegateType, Expression body, ParameterExpression[] parameters) => Expression.Lambda(delegateType, body, parameters);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.LambdaExpression" /> by first constructing a delegate type. It can be used when the delegate type is not known at compile time.</summary>
         /// <param name="delegateType">A <see cref="T:System.Type" /> that represents a delegate signature for the lambda.</param>
@@ -1154,14 +1157,14 @@ namespace System.Linq.Expressions
         ///   <paramref name="delegateType" /> does not represent a delegate type.-or-
         ///               <paramref name="body" />.Type represents a type that is not assignable to the return type of the delegate type represented by <paramref name="delegateType" />.-or-
         ///               <paramref name="parameters" /> does not contain the same number of elements as the list of parameters for the delegate type represented by <paramref name="delegateType" />.-or-The <see cref="P:System.Linq.Expressions.Expression.Type" /> property of an element of <paramref name="parameters" /> is not assignable from the type of the corresponding parameter type of the delegate type represented by <paramref name="delegateType" />.</exception>
-        public LambdaExpression Lambda(Type delegateType, Expression body, IEnumerable<ParameterExpression> parameters) => Expression.Lambda(delegateType, body, parameters);
+        public virtual LambdaExpression Lambda(Type delegateType, Expression body, IEnumerable<ParameterExpression> parameters) => Expression.Lambda(delegateType, body, parameters);
 
         /// <summary>Creates a LambdaExpression by first constructing a delegate type.</summary>
         /// <param name="body">An <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.LambdaExpression.Body" /> property equal to.</param>
         /// <param name="name">The name for the lambda. Used for emitting debug information.</param>
         /// <param name="parameters">An <see cref="T:System.Collections.Generic.IEnumerable`1" /> that contains <see cref="T:System.Linq.Expressions.ParameterExpression" /> objects to use to populate the <see cref="P:System.Linq.Expressions.LambdaExpression.Parameters" /> collection.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.LambdaExpression" /> that has the <see cref="P:System.Linq.Expressions.LambdaExpression.NodeType" /> property equal to Lambda and the <see cref="P:System.Linq.Expressions.LambdaExpression.Body" /> and <see cref="P:System.Linq.Expressions.LambdaExpression.Parameters" /> properties set to the specified values.</returns>
-        public LambdaExpression Lambda(Expression body, String name, IEnumerable<ParameterExpression> parameters) => Expression.Lambda(body, name, parameters);
+        public virtual LambdaExpression Lambda(Expression body, String name, IEnumerable<ParameterExpression> parameters) => Expression.Lambda(body, name, parameters);
 
         /// <summary>Creates an <see cref="T:System.Linq.Expressions.Expression`1" /> where the delegate type is known at compile time.</summary>
         /// <param name="body">An <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.LambdaExpression.Body" /> property equal to.</param>
@@ -1170,7 +1173,7 @@ namespace System.Linq.Expressions
         /// <param name="parameters">An <see cref="T:System.Collections.Generic.IEnumerable`1" /> that contains <see cref="T:System.Linq.Expressions.ParameterExpression" /> objects to use to populate the <see cref="P:System.Linq.Expressions.LambdaExpression.Parameters" /> collection.</param>
         /// <typeparam name="TDelegate">The delegate type. </typeparam>
         /// <returns>An <see cref="T:System.Linq.Expressions.Expression`1" /> that has the <see cref="P:System.Linq.Expressions.LambdaExpression.NodeType" /> property equal to <see cref="F:System.Linq.Expressions.ExpressionType.Lambda" /> and the <see cref="P:System.Linq.Expressions.LambdaExpression.Body" /> and <see cref="P:System.Linq.Expressions.LambdaExpression.Parameters" /> properties set to the specified values.</returns>
-        public Expression<TDelegate> Lambda<TDelegate>(Expression body, String name, Boolean tailCall, IEnumerable<ParameterExpression> parameters) => Expression.Lambda<TDelegate>(body, name, tailCall, parameters);
+        public virtual Expression<TDelegate> Lambda<TDelegate>(Expression body, String name, Boolean tailCall, IEnumerable<ParameterExpression> parameters) => Expression.Lambda<TDelegate>(body, name, tailCall, parameters);
 
         /// <summary>Creates a LambdaExpression by first constructing a delegate type.</summary>
         /// <param name="delegateType">A <see cref="P:System.Linq.Expressions.Expression.Type" /> representing the delegate signature for the lambda.</param>
@@ -1178,7 +1181,7 @@ namespace System.Linq.Expressions
         /// <param name="tailCall">A <see cref="T:System.Boolean" /> that indicates if tail call optimization will be applied when compiling the created expression.</param>
         /// <param name="parameters">An array that contains <see cref="T:System.Linq.Expressions.ParameterExpression" /> objects to use to populate the <see cref="P:System.Linq.Expressions.LambdaExpression.Parameters" /> collection.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.LambdaExpression" /> that has the <see cref="P:System.Linq.Expressions.LambdaExpression.NodeType" /> property equal to Lambda and the <see cref="P:System.Linq.Expressions.LambdaExpression.Body" /> and <see cref="P:System.Linq.Expressions.LambdaExpression.Parameters" /> properties set to the specified values.</returns>
-        public LambdaExpression Lambda(Type delegateType, Expression body, Boolean tailCall, ParameterExpression[] parameters) => Expression.Lambda(delegateType, body, tailCall, parameters);
+        public virtual LambdaExpression Lambda(Type delegateType, Expression body, Boolean tailCall, ParameterExpression[] parameters) => Expression.Lambda(delegateType, body, tailCall, parameters);
 
         /// <summary>Creates a LambdaExpression by first constructing a delegate type.</summary>
         /// <param name="delegateType">A <see cref="P:System.Linq.Expressions.Expression.Type" /> representing the delegate signature for the lambda.</param>
@@ -1186,7 +1189,7 @@ namespace System.Linq.Expressions
         /// <param name="tailCall">A <see cref="T:System.Boolean" /> that indicates if tail call optimization will be applied when compiling the created expression.</param>
         /// <param name="parameters">An <see cref="T:System.Collections.Generic.IEnumerable`1" /> that contains <see cref="T:System.Linq.Expressions.ParameterExpression" /> objects to use to populate the <see cref="P:System.Linq.Expressions.LambdaExpression.Parameters" /> collection.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.LambdaExpression" /> that has the <see cref="P:System.Linq.Expressions.LambdaExpression.NodeType" /> property equal to Lambda and the <see cref="P:System.Linq.Expressions.LambdaExpression.Body" /> and <see cref="P:System.Linq.Expressions.LambdaExpression.Parameters" /> properties set to the specified values.</returns>
-        public LambdaExpression Lambda(Type delegateType, Expression body, Boolean tailCall, IEnumerable<ParameterExpression> parameters) => Expression.Lambda(delegateType, body, tailCall, parameters);
+        public virtual LambdaExpression Lambda(Type delegateType, Expression body, Boolean tailCall, IEnumerable<ParameterExpression> parameters) => Expression.Lambda(delegateType, body, tailCall, parameters);
 
         /// <summary>Creates a LambdaExpression by first constructing a delegate type.</summary>
         /// <param name="body">An <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.LambdaExpression.Body" /> property equal to.</param>
@@ -1194,7 +1197,7 @@ namespace System.Linq.Expressions
         /// <param name="tailCall">A <see cref="T:System.Boolean" /> that indicates if tail call optimization will be applied when compiling the created expression.</param>
         /// <param name="parameters">An <see cref="T:System.Collections.Generic.IEnumerable`1" /> that contains <see cref="T:System.Linq.Expressions.ParameterExpression" /> objects to use to populate the <see cref="P:System.Linq.Expressions.LambdaExpression.Parameters" /> collection.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.LambdaExpression" /> that has the <see cref="P:System.Linq.Expressions.LambdaExpression.NodeType" /> property equal to Lambda and the <see cref="P:System.Linq.Expressions.LambdaExpression.Body" /> and <see cref="P:System.Linq.Expressions.LambdaExpression.Parameters" /> properties set to the specified values.</returns>
-        public LambdaExpression Lambda(Expression body, String name, Boolean tailCall, IEnumerable<ParameterExpression> parameters) => Expression.Lambda(body, name, tailCall, parameters);
+        public virtual LambdaExpression Lambda(Expression body, String name, Boolean tailCall, IEnumerable<ParameterExpression> parameters) => Expression.Lambda(body, name, tailCall, parameters);
 
         /// <summary>Creates a LambdaExpression by first constructing a delegate type.</summary>
         /// <param name="delegateType">A <see cref="P:System.Linq.Expressions.Expression.Type" /> representing the delegate signature for the lambda.</param>
@@ -1202,7 +1205,7 @@ namespace System.Linq.Expressions
         /// <param name="name">The name for the lambda. Used for emitting debug information.</param>
         /// <param name="parameters">An <see cref="T:System.Collections.Generic.IEnumerable`1" /> that contains <see cref="T:System.Linq.Expressions.ParameterExpression" /> objects to use to populate the <see cref="P:System.Linq.Expressions.LambdaExpression.Parameters" /> collection.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.LambdaExpression" /> that has the <see cref="P:System.Linq.Expressions.LambdaExpression.NodeType" /> property equal to Lambda and the <see cref="P:System.Linq.Expressions.LambdaExpression.Body" /> and <see cref="P:System.Linq.Expressions.LambdaExpression.Parameters" /> properties set to the specified values.</returns>
-        public LambdaExpression Lambda(Type delegateType, Expression body, String name, IEnumerable<ParameterExpression> parameters) => Expression.Lambda(delegateType, body, name, parameters);
+        public virtual LambdaExpression Lambda(Type delegateType, Expression body, String name, IEnumerable<ParameterExpression> parameters) => Expression.Lambda(delegateType, body, name, parameters);
 
         /// <summary>Creates a LambdaExpression by first constructing a delegate type.</summary>
         /// <param name="delegateType">A <see cref="P:System.Linq.Expressions.Expression.Type" /> representing the delegate signature for the lambda.</param>
@@ -1211,7 +1214,7 @@ namespace System.Linq.Expressions
         /// <param name="tailCall">A <see cref="T:System.Boolean" /> that indicates if tail call optimization will be applied when compiling the created expression. </param>
         /// <param name="parameters">An <see cref="T:System.Collections.Generic.IEnumerable`1" /> that contains <see cref="T:System.Linq.Expressions.ParameterExpression" /> objects to use to populate the <see cref="P:System.Linq.Expressions.LambdaExpression.Parameters" /> collection. </param>
         /// <returns>A <see cref="T:System.Linq.Expressions.LambdaExpression" /> that has the <see cref="P:System.Linq.Expressions.LambdaExpression.NodeType" /> property equal to Lambda and the <see cref="P:System.Linq.Expressions.LambdaExpression.Body" /> and <see cref="P:System.Linq.Expressions.LambdaExpression.Parameters" /> properties set to the specified values.</returns>
-        public LambdaExpression Lambda(Type delegateType, Expression body, String name, Boolean tailCall, IEnumerable<ParameterExpression> parameters) => Expression.Lambda(delegateType, body, name, tailCall, parameters);
+        public virtual LambdaExpression Lambda(Type delegateType, Expression body, String name, Boolean tailCall, IEnumerable<ParameterExpression> parameters) => Expression.Lambda(delegateType, body, name, tailCall, parameters);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.BinaryExpression" /> that represents a bitwise left-shift operation.</summary>
         /// <param name="left">An <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Left" /> property equal to.</param>
@@ -1220,7 +1223,7 @@ namespace System.Linq.Expressions
         /// <exception cref="T:System.ArgumentNullException">
         ///   <paramref name="left" /> or <paramref name="right" /> is <see langword="null" />.</exception>
         /// <exception cref="T:System.InvalidOperationException">The left-shift operator is not defined for <paramref name="left" />.Type and <paramref name="right" />.Type.</exception>
-        public BinaryExpression LeftShift(Expression left, Expression right) => Expression.LeftShift(left, right);
+        public virtual BinaryExpression LeftShift(Expression left, Expression right) => Expression.LeftShift(left, right);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.BinaryExpression" /> that represents a bitwise left-shift operation.</summary>
         /// <param name="left">An <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Left" /> property equal to.</param>
@@ -1233,20 +1236,20 @@ namespace System.Linq.Expressions
         ///   <paramref name="method" /> is not <see langword="null" /> and the method it represents returns <see langword="void" />, is not <see langword="static" /> (<see langword="Shared" /> in Visual Basic), or does not take exactly two arguments.</exception>
         /// <exception cref="T:System.InvalidOperationException">
         ///   <paramref name="method" /> is <see langword="null" /> and the left-shift operator is not defined for <paramref name="left" />.Type and <paramref name="right" />.Type.</exception>
-        public BinaryExpression LeftShift(Expression left, Expression right, MethodInfo method) => Expression.LeftShift(left, right, method);
+        public virtual BinaryExpression LeftShift(Expression left, Expression right, MethodInfo method) => Expression.LeftShift(left, right, method);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.BinaryExpression" /> that represents a bitwise left-shift assignment operation.</summary>
         /// <param name="left">An <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Left" /> property equal to.</param>
         /// <param name="right">An <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Right" /> property equal to.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.BinaryExpression" /> that has the <see cref="P:System.Linq.Expressions.Expression.NodeType" /> property equal to <see cref="F:System.Linq.Expressions.ExpressionType.LeftShiftAssign" /> and the <see cref="P:System.Linq.Expressions.BinaryExpression.Left" /> and <see cref="P:System.Linq.Expressions.BinaryExpression.Right" /> properties set to the specified values.</returns>
-        public BinaryExpression LeftShiftAssign(Expression left, Expression right) => Expression.LeftShiftAssign(left, right);
+        public virtual BinaryExpression LeftShiftAssign(Expression left, Expression right) => Expression.LeftShiftAssign(left, right);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.BinaryExpression" /> that represents a bitwise left-shift assignment operation.</summary>
         /// <param name="left">An <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Left" /> property equal to.</param>
         /// <param name="right">An <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Right" /> property equal to.</param>
         /// <param name="method">A <see cref="T:System.Reflection.MethodInfo" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Method" /> property equal to.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.BinaryExpression" /> that has the <see cref="P:System.Linq.Expressions.Expression.NodeType" /> property equal to <see cref="F:System.Linq.Expressions.ExpressionType.LeftShiftAssign" /> and the <see cref="P:System.Linq.Expressions.BinaryExpression.Left" />, <see cref="P:System.Linq.Expressions.BinaryExpression.Right" />, and <see cref="P:System.Linq.Expressions.BinaryExpression.Method" /> properties set to the specified values.</returns>
-        public BinaryExpression LeftShiftAssign(Expression left, Expression right, MethodInfo method) => Expression.LeftShiftAssign(left, right, method);
+        public virtual BinaryExpression LeftShiftAssign(Expression left, Expression right, MethodInfo method) => Expression.LeftShiftAssign(left, right, method);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.BinaryExpression" /> that represents a bitwise left-shift assignment operation.</summary>
         /// <param name="left">An <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Left" /> property equal to.</param>
@@ -1254,7 +1257,7 @@ namespace System.Linq.Expressions
         /// <param name="method">A <see cref="T:System.Reflection.MethodInfo" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Method" /> property equal to.</param>
         /// <param name="conversion">A <see cref="T:System.Linq.Expressions.LambdaExpression" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Conversion" /> property equal to.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.BinaryExpression" /> that has the <see cref="P:System.Linq.Expressions.Expression.NodeType" /> property equal to <see cref="F:System.Linq.Expressions.ExpressionType.LeftShiftAssign" /> and the <see cref="P:System.Linq.Expressions.BinaryExpression.Left" />, <see cref="P:System.Linq.Expressions.BinaryExpression.Right" />, <see cref="P:System.Linq.Expressions.BinaryExpression.Method" />, and <see cref="P:System.Linq.Expressions.BinaryExpression.Conversion" /> properties set to the specified values.</returns>
-        public BinaryExpression LeftShiftAssign(Expression left, Expression right, MethodInfo method, LambdaExpression conversion) => Expression.LeftShiftAssign(left, right, method, conversion);
+        public virtual BinaryExpression LeftShiftAssign(Expression left, Expression right, MethodInfo method, LambdaExpression conversion) => Expression.LeftShiftAssign(left, right, method, conversion);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.BinaryExpression" /> that represents a "less than" numeric comparison.</summary>
         /// <param name="left">An <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Left" /> property equal to.</param>
@@ -1263,7 +1266,7 @@ namespace System.Linq.Expressions
         /// <exception cref="T:System.ArgumentNullException">
         ///   <paramref name="left" /> or <paramref name="right" /> is <see langword="null" />.</exception>
         /// <exception cref="T:System.InvalidOperationException">The "less than" operator is not defined for <paramref name="left" />.Type and <paramref name="right" />.Type.</exception>
-        public BinaryExpression LessThan(Expression left, Expression right) => Expression.LessThan(left, right);
+        public virtual BinaryExpression LessThan(Expression left, Expression right) => Expression.LessThan(left, right);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.BinaryExpression" /> that represents a "less than" numeric comparison.</summary>
         /// <param name="left">An <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Left" /> property equal to.</param>
@@ -1278,7 +1281,7 @@ namespace System.Linq.Expressions
         ///   <paramref name="method" /> is not <see langword="null" /> and the method it represents returns <see langword="void" />, is not <see langword="static" /> (<see langword="Shared" /> in Visual Basic), or does not take exactly two arguments.</exception>
         /// <exception cref="T:System.InvalidOperationException">
         ///   <paramref name="method" /> is <see langword="null" /> and the "less than" operator is not defined for <paramref name="left" />.Type and <paramref name="right" />.Type.</exception>
-        public BinaryExpression LessThan(Expression left, Expression right, Boolean liftToNull, MethodInfo method) => Expression.LessThan(left, right, liftToNull, method);
+        public virtual BinaryExpression LessThan(Expression left, Expression right, Boolean liftToNull, MethodInfo method) => Expression.LessThan(left, right, liftToNull, method);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.BinaryExpression" /> that represents a " less than or equal" numeric comparison.</summary>
         /// <param name="left">An <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Left" /> property equal to.</param>
@@ -1287,7 +1290,7 @@ namespace System.Linq.Expressions
         /// <exception cref="T:System.ArgumentNullException">
         ///   <paramref name="left" /> or <paramref name="right" /> is <see langword="null" />.</exception>
         /// <exception cref="T:System.InvalidOperationException">The "less than or equal" operator is not defined for <paramref name="left" />.Type and <paramref name="right" />.Type.</exception>
-        public BinaryExpression LessThanOrEqual(Expression left, Expression right) => Expression.LessThanOrEqual(left, right);
+        public virtual BinaryExpression LessThanOrEqual(Expression left, Expression right) => Expression.LessThanOrEqual(left, right);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.BinaryExpression" /> that represents a "less than or equal" numeric comparison.</summary>
         /// <param name="left">An <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Left" /> property equal to.</param>
@@ -1302,7 +1305,7 @@ namespace System.Linq.Expressions
         ///   <paramref name="method" /> is not <see langword="null" /> and the method it represents returns <see langword="void" />, is not <see langword="static" /> (<see langword="Shared" /> in Visual Basic), or does not take exactly two arguments.</exception>
         /// <exception cref="T:System.InvalidOperationException">
         ///   <paramref name="method" /> is <see langword="null" /> and the "less than or equal" operator is not defined for <paramref name="left" />.Type and <paramref name="right" />.Type.</exception>
-        public BinaryExpression LessThanOrEqual(Expression left, Expression right, Boolean liftToNull, MethodInfo method) => Expression.LessThanOrEqual(left, right, liftToNull, method);
+        public virtual BinaryExpression LessThanOrEqual(Expression left, Expression right, Boolean liftToNull, MethodInfo method) => Expression.LessThanOrEqual(left, right, liftToNull, method);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.MemberListBinding" /> where the member is a field or property.</summary>
         /// <param name="member">A <see cref="T:System.Reflection.MemberInfo" /> that represents a field or property to set the <see cref="P:System.Linq.Expressions.MemberBinding.Member" /> property equal to.</param>
@@ -1312,7 +1315,7 @@ namespace System.Linq.Expressions
         ///   <paramref name="member" /> is <see langword="null" />. -or-One or more elements of <paramref name="initializers" /> are <see langword="null" />.</exception>
         /// <exception cref="T:System.ArgumentException">
         ///   <paramref name="member" /> does not represent a field or property.-or-The <see cref="P:System.Reflection.FieldInfo.FieldType" /> or <see cref="P:System.Reflection.PropertyInfo.PropertyType" /> of the field or property that <paramref name="member" /> represents does not implement <see cref="T:System.Collections.IEnumerable" />.</exception>
-        public MemberListBinding ListBind(MemberInfo member, ElementInit[] initializers) => Expression.ListBind(member, initializers);
+        public virtual MemberListBinding ListBind(MemberInfo member, ElementInit[] initializers) => Expression.ListBind(member, initializers);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.MemberListBinding" /> where the member is a field or property.</summary>
         /// <param name="member">A <see cref="T:System.Reflection.MemberInfo" /> that represents a field or property to set the <see cref="P:System.Linq.Expressions.MemberBinding.Member" /> property equal to.</param>
@@ -1322,7 +1325,7 @@ namespace System.Linq.Expressions
         ///   <paramref name="member" /> is <see langword="null" />. -or-One or more elements of <paramref name="initializers" /> are <see langword="null" />.</exception>
         /// <exception cref="T:System.ArgumentException">
         ///   <paramref name="member" /> does not represent a field or property.-or-The <see cref="P:System.Reflection.FieldInfo.FieldType" /> or <see cref="P:System.Reflection.PropertyInfo.PropertyType" /> of the field or property that <paramref name="member" /> represents does not implement <see cref="T:System.Collections.IEnumerable" />.</exception>
-        public MemberListBinding ListBind(MemberInfo member, IEnumerable<ElementInit> initializers) => Expression.ListBind(member, initializers);
+        public virtual MemberListBinding ListBind(MemberInfo member, IEnumerable<ElementInit> initializers) => Expression.ListBind(member, initializers);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.MemberListBinding" /> object based on a specified property accessor method.</summary>
         /// <param name="propertyAccessor">A <see cref="T:System.Reflection.MethodInfo" /> that represents a property accessor method.</param>
@@ -1332,7 +1335,7 @@ namespace System.Linq.Expressions
         ///   <paramref name="propertyAccessor" /> is <see langword="null" />. -or-One or more elements of <paramref name="initializers" /> are <see langword="null" />.</exception>
         /// <exception cref="T:System.ArgumentException">
         ///   <paramref name="propertyAccessor" /> does not represent a property accessor method.-or-The <see cref="P:System.Reflection.PropertyInfo.PropertyType" /> of the property that the method represented by <paramref name="propertyAccessor" /> accesses does not implement <see cref="T:System.Collections.IEnumerable" />.</exception>
-        public MemberListBinding ListBind(MethodInfo propertyAccessor, ElementInit[] initializers) => Expression.ListBind(propertyAccessor, initializers);
+        public virtual MemberListBinding ListBind(MethodInfo propertyAccessor, ElementInit[] initializers) => Expression.ListBind(propertyAccessor, initializers);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.MemberListBinding" /> based on a specified property accessor method.</summary>
         /// <param name="propertyAccessor">A <see cref="T:System.Reflection.MethodInfo" /> that represents a property accessor method.</param>
@@ -1342,7 +1345,7 @@ namespace System.Linq.Expressions
         ///   <paramref name="propertyAccessor" /> is <see langword="null" />. -or-One or more elements of <paramref name="initializers" /> are <see langword="null" />.</exception>
         /// <exception cref="T:System.ArgumentException">
         ///   <paramref name="propertyAccessor" /> does not represent a property accessor method.-or-The <see cref="P:System.Reflection.PropertyInfo.PropertyType" /> of the property that the method represented by <paramref name="propertyAccessor" /> accesses does not implement <see cref="T:System.Collections.IEnumerable" />.</exception>
-        public MemberListBinding ListBind(MethodInfo propertyAccessor, IEnumerable<ElementInit> initializers) => Expression.ListBind(propertyAccessor, initializers);
+        public virtual MemberListBinding ListBind(MethodInfo propertyAccessor, IEnumerable<ElementInit> initializers) => Expression.ListBind(propertyAccessor, initializers);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.ListInitExpression" /> that uses specified <see cref="T:System.Linq.Expressions.ElementInit" /> objects to initialize a collection.</summary>
         /// <param name="newExpression">A <see cref="T:System.Linq.Expressions.NewExpression" /> to set the <see cref="P:System.Linq.Expressions.ListInitExpression.NewExpression" /> property equal to.</param>
@@ -1352,7 +1355,7 @@ namespace System.Linq.Expressions
         ///   <paramref name="newExpression" /> or <paramref name="initializers" /> is <see langword="null" />.-or-One or more elements of <paramref name="initializers" /> are <see langword="null" />.</exception>
         /// <exception cref="T:System.ArgumentException">
         ///   <paramref name="newExpression" />.Type does not implement <see cref="T:System.Collections.IEnumerable" />.</exception>
-        public ListInitExpression ListInit(NewExpression newExpression, ElementInit[] initializers) => Expression.ListInit(newExpression, initializers);
+        public virtual ListInitExpression ListInit(NewExpression newExpression, ElementInit[] initializers) => Expression.ListInit(newExpression, initializers);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.ListInitExpression" /> that uses specified <see cref="T:System.Linq.Expressions.ElementInit" /> objects to initialize a collection.</summary>
         /// <param name="newExpression">A <see cref="T:System.Linq.Expressions.NewExpression" /> to set the <see cref="P:System.Linq.Expressions.ListInitExpression.NewExpression" /> property equal to.</param>
@@ -1362,7 +1365,7 @@ namespace System.Linq.Expressions
         ///   <paramref name="newExpression" /> or <paramref name="initializers" /> is <see langword="null" />.-or-One or more elements of <paramref name="initializers" /> are <see langword="null" />.</exception>
         /// <exception cref="T:System.ArgumentException">
         ///   <paramref name="newExpression" />.Type does not implement <see cref="T:System.Collections.IEnumerable" />.</exception>
-        public ListInitExpression ListInit(NewExpression newExpression, IEnumerable<ElementInit> initializers) => Expression.ListInit(newExpression, initializers);
+        public virtual ListInitExpression ListInit(NewExpression newExpression, IEnumerable<ElementInit> initializers) => Expression.ListInit(newExpression, initializers);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.ListInitExpression" /> that uses a method named "Add" to add elements to a collection.</summary>
         /// <param name="newExpression">A <see cref="T:System.Linq.Expressions.NewExpression" /> to set the <see cref="P:System.Linq.Expressions.ListInitExpression.NewExpression" /> property equal to.</param>
@@ -1373,7 +1376,7 @@ namespace System.Linq.Expressions
         /// <exception cref="T:System.ArgumentException">
         ///   <paramref name="newExpression" />.Type does not implement <see cref="T:System.Collections.IEnumerable" />.</exception>
         /// <exception cref="T:System.InvalidOperationException">There is no instance method named "Add" (case insensitive) declared in <paramref name="newExpression" />.Type or its base type.-or-The add method on <paramref name="newExpression" />.Type or its base type does not take exactly one argument.-or-The type represented by the <see cref="P:System.Linq.Expressions.Expression.Type" /> property of the first element of <paramref name="initializers" /> is not assignable to the argument type of the add method on <paramref name="newExpression" />.Type or its base type.-or-More than one argument-compatible method named "Add" (case-insensitive) exists on <paramref name="newExpression" />.Type and/or its base type.</exception>
-        public ListInitExpression ListInit(NewExpression newExpression, Expression[] initializers) => Expression.ListInit(newExpression, initializers);
+        public virtual ListInitExpression ListInit(NewExpression newExpression, Expression[] initializers) => Expression.ListInit(newExpression, initializers);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.ListInitExpression" /> that uses a method named "Add" to add elements to a collection.</summary>
         /// <param name="newExpression">A <see cref="T:System.Linq.Expressions.NewExpression" /> to set the <see cref="P:System.Linq.Expressions.ListInitExpression.NewExpression" /> property equal to.</param>
@@ -1384,7 +1387,7 @@ namespace System.Linq.Expressions
         /// <exception cref="T:System.ArgumentException">
         ///   <paramref name="newExpression" />.Type does not implement <see cref="T:System.Collections.IEnumerable" />.</exception>
         /// <exception cref="T:System.InvalidOperationException">There is no instance method named "Add" (case insensitive) declared in <paramref name="newExpression" />.Type or its base type.-or-The add method on <paramref name="newExpression" />.Type or its base type does not take exactly one argument.-or-The type represented by the <see cref="P:System.Linq.Expressions.Expression.Type" /> property of the first element of <paramref name="initializers" /> is not assignable to the argument type of the add method on <paramref name="newExpression" />.Type or its base type.-or-More than one argument-compatible method named "Add" (case-insensitive) exists on <paramref name="newExpression" />.Type and/or its base type.</exception>
-        public ListInitExpression ListInit(NewExpression newExpression, IEnumerable<Expression> initializers) => Expression.ListInit(newExpression, initializers);
+        public virtual ListInitExpression ListInit(NewExpression newExpression, IEnumerable<Expression> initializers) => Expression.ListInit(newExpression, initializers);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.ListInitExpression" /> that uses a specified method to add elements to a collection.</summary>
         /// <param name="newExpression">A <see cref="T:System.Linq.Expressions.NewExpression" /> to set the <see cref="P:System.Linq.Expressions.ListInitExpression.NewExpression" /> property equal to.</param>
@@ -1399,7 +1402,7 @@ namespace System.Linq.Expressions
         ///               <paramref name="addMethod" /> is not <see langword="null" /> and the type represented by the <see cref="P:System.Linq.Expressions.Expression.Type" /> property of one or more elements of <paramref name="initializers" /> is not assignable to the argument type of the method that <paramref name="addMethod" /> represents.</exception>
         /// <exception cref="T:System.InvalidOperationException">
         ///   <paramref name="addMethod" /> is <see langword="null" /> and no instance method named "Add" that takes one type-compatible argument exists on <paramref name="newExpression" />.Type or its base type.</exception>
-        public ListInitExpression ListInit(NewExpression newExpression, MethodInfo addMethod, Expression[] initializers) => Expression.ListInit(newExpression, addMethod, initializers);
+        public virtual ListInitExpression ListInit(NewExpression newExpression, MethodInfo addMethod, Expression[] initializers) => Expression.ListInit(newExpression, addMethod, initializers);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.ListInitExpression" /> that uses a specified method to add elements to a collection.</summary>
         /// <param name="newExpression">A <see cref="T:System.Linq.Expressions.NewExpression" /> to set the <see cref="P:System.Linq.Expressions.ListInitExpression.NewExpression" /> property equal to.</param>
@@ -1414,25 +1417,25 @@ namespace System.Linq.Expressions
         ///               <paramref name="addMethod" /> is not <see langword="null" /> and the type represented by the <see cref="P:System.Linq.Expressions.Expression.Type" /> property of one or more elements of <paramref name="initializers" /> is not assignable to the argument type of the method that <paramref name="addMethod" /> represents.</exception>
         /// <exception cref="T:System.InvalidOperationException">
         ///   <paramref name="addMethod" /> is <see langword="null" /> and no instance method named "Add" that takes one type-compatible argument exists on <paramref name="newExpression" />.Type or its base type.</exception>
-        public ListInitExpression ListInit(NewExpression newExpression, MethodInfo addMethod, IEnumerable<Expression> initializers) => Expression.ListInit(newExpression, addMethod, initializers);
+        public virtual ListInitExpression ListInit(NewExpression newExpression, MethodInfo addMethod, IEnumerable<Expression> initializers) => Expression.ListInit(newExpression, addMethod, initializers);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.LoopExpression" /> with the given body.</summary>
         /// <param name="body">The body of the loop.</param>
         /// <returns>The created <see cref="T:System.Linq.Expressions.LoopExpression" />.</returns>
-        public LoopExpression Loop(Expression body) => Expression.Loop(body);
+        public virtual LoopExpression Loop(Expression body) => Expression.Loop(body);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.LoopExpression" /> with the given body and break target.</summary>
         /// <param name="body">The body of the loop.</param>
         /// <param name="break">The break target used by the loop body.</param>
         /// <returns>The created <see cref="T:System.Linq.Expressions.LoopExpression" />.</returns>
-        public LoopExpression Loop(Expression body, LabelTarget @break) => Expression.Loop(body, @break);
+        public virtual LoopExpression Loop(Expression body, LabelTarget @break) => Expression.Loop(body, @break);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.LoopExpression" /> with the given body.</summary>
         /// <param name="body">The body of the loop.</param>
         /// <param name="break">The break target used by the loop body.</param>
         /// <param name="continue">The continue target used by the loop body.</param>
         /// <returns>The created <see cref="T:System.Linq.Expressions.LoopExpression" />.</returns>
-        public LoopExpression Loop(Expression body, LabelTarget @break, LabelTarget @continue) => Expression.Loop(body, @break, @continue);
+        public virtual LoopExpression Loop(Expression body, LabelTarget @break, LabelTarget @continue) => Expression.Loop(body, @break, @continue);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.BinaryExpression" />, given the left and right operands, by calling an appropriate factory method.</summary>
         /// <param name="binaryType">The <see cref="T:System.Linq.Expressions.ExpressionType" /> that specifies the type of binary operation.</param>
@@ -1443,7 +1446,7 @@ namespace System.Linq.Expressions
         ///   <paramref name="binaryType" /> does not correspond to a binary expression node.</exception>
         /// <exception cref="T:System.ArgumentNullException">
         ///   <paramref name="left" /> or <paramref name="right" /> is <see langword="null" />.</exception>
-        public BinaryExpression MakeBinary(ExpressionType binaryType, Expression left, Expression right) => Expression.MakeBinary(binaryType, left, right);
+        public virtual BinaryExpression MakeBinary(ExpressionType binaryType, Expression left, Expression right) => Expression.MakeBinary(binaryType, left, right);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.BinaryExpression" />, given the left operand, right operand and implementing method, by calling the appropriate factory method.</summary>
         /// <param name="binaryType">The <see cref="T:System.Linq.Expressions.ExpressionType" /> that specifies the type of binary operation.</param>
@@ -1457,7 +1460,7 @@ namespace System.Linq.Expressions
         ///   <paramref name="binaryType" /> does not correspond to a binary expression node.</exception>
         /// <exception cref="T:System.ArgumentNullException">
         ///   <paramref name="left" /> or <paramref name="right" /> is <see langword="null" />.</exception>
-        public BinaryExpression MakeBinary(ExpressionType binaryType, Expression left, Expression right, Boolean liftToNull, MethodInfo method) => Expression.MakeBinary(binaryType, left, right, liftToNull, method);
+        public virtual BinaryExpression MakeBinary(ExpressionType binaryType, Expression left, Expression right, Boolean liftToNull, MethodInfo method) => Expression.MakeBinary(binaryType, left, right, liftToNull, method);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.BinaryExpression" />, given the left operand, right operand, implementing method and type conversion function, by calling the appropriate factory method.</summary>
         /// <param name="binaryType">The <see cref="T:System.Linq.Expressions.ExpressionType" /> that specifies the type of binary operation.</param>
@@ -1472,7 +1475,7 @@ namespace System.Linq.Expressions
         ///   <paramref name="binaryType" /> does not correspond to a binary expression node.</exception>
         /// <exception cref="T:System.ArgumentNullException">
         ///   <paramref name="left" /> or <paramref name="right" /> is <see langword="null" />.</exception>
-        public BinaryExpression MakeBinary(ExpressionType binaryType, Expression left, Expression right, Boolean liftToNull, MethodInfo method, LambdaExpression conversion) => Expression.MakeBinary(binaryType, left, right, liftToNull, method, conversion);
+        public virtual BinaryExpression MakeBinary(ExpressionType binaryType, Expression left, Expression right, Boolean liftToNull, MethodInfo method, LambdaExpression conversion) => Expression.MakeBinary(binaryType, left, right, liftToNull, method, conversion);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.CatchBlock" /> representing a catch statement with the specified elements.</summary>
         /// <param name="type">The <see cref="P:System.Linq.Expressions.Expression.Type" /> of <see cref="T:System.Exception" /> this <see cref="T:System.Linq.Expressions.CatchBlock" /> will handle.</param>
@@ -1480,28 +1483,28 @@ namespace System.Linq.Expressions
         /// <param name="body">The body of the catch statement.</param>
         /// <param name="filter">The body of the <see cref="T:System.Exception" /> filter.</param>
         /// <returns>The created <see cref="T:System.Linq.Expressions.CatchBlock" />.</returns>
-        public CatchBlock MakeCatchBlock(Type type, ParameterExpression variable, Expression body, Expression filter) => Expression.MakeCatchBlock(type, variable, body, filter);
+        public virtual CatchBlock MakeCatchBlock(Type type, ParameterExpression variable, Expression body, Expression filter) => Expression.MakeCatchBlock(type, variable, body, filter);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.DynamicExpression" /> that represents a dynamic operation bound by the provided <see cref="T:System.Runtime.CompilerServices.CallSiteBinder" />.</summary>
         /// <param name="delegateType">The type of the delegate used by the <see cref="T:System.Runtime.CompilerServices.CallSite" />.</param>
         /// <param name="binder">The runtime binder for the dynamic operation.</param>
         /// <param name="arguments">The arguments to the dynamic operation.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.DynamicExpression" /> that has <see cref="P:System.Linq.Expressions.Expression.NodeType" /> equal to <see cref="F:System.Linq.Expressions.ExpressionType.Dynamic" /> and has the <see cref="P:System.Linq.Expressions.DynamicExpression.DelegateType" />, <see cref="P:System.Linq.Expressions.DynamicExpression.Binder" />, and <see cref="P:System.Linq.Expressions.DynamicExpression.Arguments" /> set to the specified values.</returns>
-        public DynamicExpression MakeDynamic(Type delegateType, CallSiteBinder binder, Expression[] arguments) => Expression.MakeDynamic(delegateType, binder, arguments);
+        public virtual DynamicExpression MakeDynamic(Type delegateType, CallSiteBinder binder, Expression[] arguments) => Expression.MakeDynamic(delegateType, binder, arguments);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.DynamicExpression" /> that represents a dynamic operation bound by the provided <see cref="T:System.Runtime.CompilerServices.CallSiteBinder" />.</summary>
         /// <param name="delegateType">The type of the delegate used by the <see cref="T:System.Runtime.CompilerServices.CallSite" />.</param>
         /// <param name="binder">The runtime binder for the dynamic operation.</param>
         /// <param name="arguments">The arguments to the dynamic operation.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.DynamicExpression" /> that has <see cref="P:System.Linq.Expressions.Expression.NodeType" /> equal to <see cref="F:System.Linq.Expressions.ExpressionType.Dynamic" /> and has the <see cref="P:System.Linq.Expressions.DynamicExpression.DelegateType" />, <see cref="P:System.Linq.Expressions.DynamicExpression.Binder" />, and <see cref="P:System.Linq.Expressions.DynamicExpression.Arguments" /> set to the specified values.</returns>
-        public DynamicExpression MakeDynamic(Type delegateType, CallSiteBinder binder, IEnumerable<Expression> arguments) => Expression.MakeDynamic(delegateType, binder, arguments);
+        public virtual DynamicExpression MakeDynamic(Type delegateType, CallSiteBinder binder, IEnumerable<Expression> arguments) => Expression.MakeDynamic(delegateType, binder, arguments);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.DynamicExpression" /> that represents a dynamic operation bound by the provided <see cref="T:System.Runtime.CompilerServices.CallSiteBinder" /> and one argument.</summary>
         /// <param name="delegateType">The type of the delegate used by the <see cref="T:System.Runtime.CompilerServices.CallSite" />.</param>
         /// <param name="binder">The runtime binder for the dynamic operation.</param>
         /// <param name="arg0">The argument to the dynamic operation.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.DynamicExpression" /> that has <see cref="P:System.Linq.Expressions.Expression.NodeType" /> equal to <see cref="F:System.Linq.Expressions.ExpressionType.Dynamic" /> and has the <see cref="P:System.Linq.Expressions.DynamicExpression.DelegateType" />, <see cref="P:System.Linq.Expressions.DynamicExpression.Binder" />, and <see cref="P:System.Linq.Expressions.DynamicExpression.Arguments" /> set to the specified values.</returns>
-        public DynamicExpression MakeDynamic(Type delegateType, CallSiteBinder binder, Expression arg0) => Expression.MakeDynamic(delegateType, binder, arg0);
+        public virtual DynamicExpression MakeDynamic(Type delegateType, CallSiteBinder binder, Expression arg0) => Expression.MakeDynamic(delegateType, binder, arg0);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.DynamicExpression" /> that represents a dynamic operation bound by the provided <see cref="T:System.Runtime.CompilerServices.CallSiteBinder" /> and two arguments.</summary>
         /// <param name="delegateType">The type of the delegate used by the <see cref="T:System.Runtime.CompilerServices.CallSite" />.</param>
@@ -1509,7 +1512,7 @@ namespace System.Linq.Expressions
         /// <param name="arg0">The first argument to the dynamic operation.</param>
         /// <param name="arg1">The second argument to the dynamic operation.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.DynamicExpression" /> that has <see cref="P:System.Linq.Expressions.Expression.NodeType" /> equal to <see cref="F:System.Linq.Expressions.ExpressionType.Dynamic" /> and has the <see cref="P:System.Linq.Expressions.DynamicExpression.DelegateType" />, <see cref="P:System.Linq.Expressions.DynamicExpression.Binder" />, and <see cref="P:System.Linq.Expressions.DynamicExpression.Arguments" /> set to the specified values.</returns>
-        public DynamicExpression MakeDynamic(Type delegateType, CallSiteBinder binder, Expression arg0, Expression arg1) => Expression.MakeDynamic(delegateType, binder, arg0, arg1);
+        public virtual DynamicExpression MakeDynamic(Type delegateType, CallSiteBinder binder, Expression arg0, Expression arg1) => Expression.MakeDynamic(delegateType, binder, arg0, arg1);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.DynamicExpression" /> that represents a dynamic operation bound by the provided <see cref="T:System.Runtime.CompilerServices.CallSiteBinder" /> and three arguments.</summary>
         /// <param name="delegateType">The type of the delegate used by the <see cref="T:System.Runtime.CompilerServices.CallSite" />.</param>
@@ -1518,7 +1521,7 @@ namespace System.Linq.Expressions
         /// <param name="arg1">The second argument to the dynamic operation.</param>
         /// <param name="arg2">The third argument to the dynamic operation.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.DynamicExpression" /> that has <see cref="P:System.Linq.Expressions.Expression.NodeType" /> equal to <see cref="F:System.Linq.Expressions.ExpressionType.Dynamic" /> and has the <see cref="P:System.Linq.Expressions.DynamicExpression.DelegateType" />, <see cref="P:System.Linq.Expressions.DynamicExpression.Binder" />, and <see cref="P:System.Linq.Expressions.DynamicExpression.Arguments" /> set to the specified values.</returns>
-        public DynamicExpression MakeDynamic(Type delegateType, CallSiteBinder binder, Expression arg0, Expression arg1, Expression arg2) => Expression.MakeDynamic(delegateType, binder, arg0, arg1, arg2);
+        public virtual DynamicExpression MakeDynamic(Type delegateType, CallSiteBinder binder, Expression arg0, Expression arg1, Expression arg2) => Expression.MakeDynamic(delegateType, binder, arg0, arg1, arg2);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.DynamicExpression" /> that represents a dynamic operation bound by the provided <see cref="T:System.Runtime.CompilerServices.CallSiteBinder" /> and four arguments.</summary>
         /// <param name="delegateType">The type of the delegate used by the <see cref="T:System.Runtime.CompilerServices.CallSite" />.</param>
@@ -1528,7 +1531,7 @@ namespace System.Linq.Expressions
         /// <param name="arg2">The third argument to the dynamic operation.</param>
         /// <param name="arg3">The fourth argument to the dynamic operation.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.DynamicExpression" /> that has <see cref="P:System.Linq.Expressions.Expression.NodeType" /> equal to <see cref="F:System.Linq.Expressions.ExpressionType.Dynamic" /> and has the <see cref="P:System.Linq.Expressions.DynamicExpression.DelegateType" />, <see cref="P:System.Linq.Expressions.DynamicExpression.Binder" />, and <see cref="P:System.Linq.Expressions.DynamicExpression.Arguments" /> set to the specified values.</returns>
-        public DynamicExpression MakeDynamic(Type delegateType, CallSiteBinder binder, Expression arg0, Expression arg1, Expression arg2, Expression arg3) => Expression.MakeDynamic(delegateType, binder, arg0, arg1, arg2, arg3);
+        public virtual DynamicExpression MakeDynamic(Type delegateType, CallSiteBinder binder, Expression arg0, Expression arg1, Expression arg2, Expression arg3) => Expression.MakeDynamic(delegateType, binder, arg0, arg1, arg2, arg3);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.GotoExpression" /> representing a jump of the specified <see cref="T:System.Linq.Expressions.GotoExpressionKind" />. The value passed to the label upon jumping can also be specified.</summary>
         /// <param name="kind">The <see cref="T:System.Linq.Expressions.GotoExpressionKind" /> of the <see cref="T:System.Linq.Expressions.GotoExpression" />.</param>
@@ -1536,14 +1539,14 @@ namespace System.Linq.Expressions
         /// <param name="value">The value that will be passed to the associated label upon jumping.</param>
         /// <param name="type">An <see cref="T:System.Type" /> to set the <see cref="P:System.Linq.Expressions.Expression.Type" /> property equal to.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.GotoExpression" /> with <see cref="P:System.Linq.Expressions.GotoExpression.Kind" /> equal to <paramref name="kind" />, the <see cref="P:System.Linq.Expressions.GotoExpression.Target" /> property set to <paramref name="target" />, the <see cref="P:System.Linq.Expressions.Expression.Type" /> property set to <paramref name="type" />, and <paramref name="value" /> to be passed to the target label upon jumping.</returns>
-        public GotoExpression MakeGoto(GotoExpressionKind kind, LabelTarget target, Expression value, Type type) => Expression.MakeGoto(kind, target, value, type);
+        public virtual GotoExpression MakeGoto(GotoExpressionKind kind, LabelTarget target, Expression value, Type type) => Expression.MakeGoto(kind, target, value, type);
 
         /// <summary>Creates an <see cref="T:System.Linq.Expressions.IndexExpression" /> that represents accessing an indexed property in an object.</summary>
         /// <param name="instance">The object to which the property belongs. It should be null if the property is <see langword="static" /> (<see langword="shared" /> in Visual Basic).</param>
         /// <param name="indexer">An <see cref="T:System.Linq.Expressions.Expression" /> representing the property to index.</param>
         /// <param name="arguments">An IEnumerable&lt;Expression&gt; (IEnumerable (Of Expression) in Visual Basic) that contains the arguments that will be used to index the property.</param>
         /// <returns>The created <see cref="T:System.Linq.Expressions.IndexExpression" />.</returns>
-        public IndexExpression MakeIndex(Expression instance, PropertyInfo indexer, IEnumerable<Expression> arguments) => Expression.MakeIndex(instance, indexer, arguments);
+        public virtual IndexExpression MakeIndex(Expression instance, PropertyInfo indexer, IEnumerable<Expression> arguments) => Expression.MakeIndex(instance, indexer, arguments);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.MemberExpression" /> that represents accessing either a field or a property.</summary>
         /// <param name="expression">An <see cref="T:System.Linq.Expressions.Expression" /> that represents the object that the member belongs to. This can be null for static members.</param>
@@ -1553,7 +1556,7 @@ namespace System.Linq.Expressions
         ///   <paramref name="member" /> is <see langword="null" />.</exception>
         /// <exception cref="T:System.ArgumentException">
         ///   <paramref name="member" /> does not represent a field or property.</exception>
-        public MemberExpression MakeMemberAccess(Expression expression, MemberInfo member) => Expression.MakeMemberAccess(expression, member);
+        public virtual MemberExpression MakeMemberAccess(Expression expression, MemberInfo member) => Expression.MakeMemberAccess(expression, member);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.TryExpression" /> representing a try block with the specified elements.</summary>
         /// <param name="type">The result type of the try expression. If null, bodh and all handlers must have identical type.</param>
@@ -1562,7 +1565,7 @@ namespace System.Linq.Expressions
         /// <param name="fault">The body of the fault block. Pass null if the try block has no fault block associated with it.</param>
         /// <param name="handlers">A collection of <see cref="T:System.Linq.Expressions.CatchBlock" />s representing the catch statements to be associated with the try block.</param>
         /// <returns>The created <see cref="T:System.Linq.Expressions.TryExpression" />.</returns>
-        public TryExpression MakeTry(Type type, Expression body, Expression @finally, Expression fault, IEnumerable<CatchBlock> handlers) => Expression.MakeTry(type, body, @finally, fault, handlers);
+        public virtual TryExpression MakeTry(Type type, Expression body, Expression @finally, Expression fault, IEnumerable<CatchBlock> handlers) => Expression.MakeTry(type, body, @finally, fault, handlers);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.UnaryExpression" />, given an operand, by calling the appropriate factory method.</summary>
         /// <param name="unaryType">The <see cref="T:System.Linq.Expressions.ExpressionType" /> that specifies the type of unary operation.</param>
@@ -1573,7 +1576,7 @@ namespace System.Linq.Expressions
         ///   <paramref name="operand" /> is <see langword="null" />.</exception>
         /// <exception cref="T:System.ArgumentException">
         ///   <paramref name="unaryType" /> does not correspond to a unary expression node.</exception>
-        public UnaryExpression MakeUnary(ExpressionType unaryType, Expression operand, Type type) => Expression.MakeUnary(unaryType, operand, type);
+        public virtual UnaryExpression MakeUnary(ExpressionType unaryType, Expression operand, Type type) => Expression.MakeUnary(unaryType, operand, type);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.UnaryExpression" />, given an operand and implementing method, by calling the appropriate factory method.</summary>
         /// <param name="unaryType">The <see cref="T:System.Linq.Expressions.ExpressionType" /> that specifies the type of unary operation.</param>
@@ -1585,7 +1588,7 @@ namespace System.Linq.Expressions
         ///   <paramref name="operand" /> is <see langword="null" />.</exception>
         /// <exception cref="T:System.ArgumentException">
         ///   <paramref name="unaryType" /> does not correspond to a unary expression node.</exception>
-        public UnaryExpression MakeUnary(ExpressionType unaryType, Expression operand, Type type, MethodInfo method) => Expression.MakeUnary(unaryType, operand, type, method);
+        public virtual UnaryExpression MakeUnary(ExpressionType unaryType, Expression operand, Type type, MethodInfo method) => Expression.MakeUnary(unaryType, operand, type, method);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.MemberMemberBinding" /> that represents the recursive initialization of members of a field or property.</summary>
         /// <param name="member">The <see cref="T:System.Reflection.MemberInfo" /> to set the <see cref="P:System.Linq.Expressions.MemberBinding.Member" /> property equal to.</param>
@@ -1595,7 +1598,7 @@ namespace System.Linq.Expressions
         ///   <paramref name="member" /> or <paramref name="bindings" /> is <see langword="null" />.</exception>
         /// <exception cref="T:System.ArgumentException">
         ///   <paramref name="member" /> does not represent a field or property.-or-The <see cref="P:System.Linq.Expressions.MemberBinding.Member" /> property of an element of <paramref name="bindings" /> does not represent a member of the type of the field or property that <paramref name="member" /> represents.</exception>
-        public MemberMemberBinding MemberBind(MemberInfo member, MemberBinding[] bindings) => Expression.MemberBind(member, bindings);
+        public virtual MemberMemberBinding MemberBind(MemberInfo member, MemberBinding[] bindings) => Expression.MemberBind(member, bindings);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.MemberMemberBinding" /> that represents the recursive initialization of members of a field or property.</summary>
         /// <param name="member">The <see cref="T:System.Reflection.MemberInfo" /> to set the <see cref="P:System.Linq.Expressions.MemberBinding.Member" /> property equal to.</param>
@@ -1605,7 +1608,7 @@ namespace System.Linq.Expressions
         ///   <paramref name="member" /> or <paramref name="bindings" /> is <see langword="null" />.</exception>
         /// <exception cref="T:System.ArgumentException">
         ///   <paramref name="member" /> does not represent a field or property.-or-The <see cref="P:System.Linq.Expressions.MemberBinding.Member" /> property of an element of <paramref name="bindings" /> does not represent a member of the type of the field or property that <paramref name="member" /> represents.</exception>
-        public MemberMemberBinding MemberBind(MemberInfo member, IEnumerable<MemberBinding> bindings) => Expression.MemberBind(member, bindings);
+        public virtual MemberMemberBinding MemberBind(MemberInfo member, IEnumerable<MemberBinding> bindings) => Expression.MemberBind(member, bindings);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.MemberMemberBinding" /> that represents the recursive initialization of members of a member that is accessed by using a property accessor method.</summary>
         /// <param name="propertyAccessor">The <see cref="T:System.Reflection.MethodInfo" /> that represents a property accessor method.</param>
@@ -1615,7 +1618,7 @@ namespace System.Linq.Expressions
         ///   <paramref name="propertyAccessor" /> or <paramref name="bindings" /> is <see langword="null" />.</exception>
         /// <exception cref="T:System.ArgumentException">
         ///   <paramref name="propertyAccessor" /> does not represent a property accessor method.-or-The <see cref="P:System.Linq.Expressions.MemberBinding.Member" /> property of an element of <paramref name="bindings" /> does not represent a member of the type of the property accessed by the method that <paramref name="propertyAccessor" /> represents.</exception>
-        public MemberMemberBinding MemberBind(MethodInfo propertyAccessor, MemberBinding[] bindings) => Expression.MemberBind(propertyAccessor, bindings);
+        public virtual MemberMemberBinding MemberBind(MethodInfo propertyAccessor, MemberBinding[] bindings) => Expression.MemberBind(propertyAccessor, bindings);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.MemberMemberBinding" /> that represents the recursive initialization of members of a member that is accessed by using a property accessor method.</summary>
         /// <param name="propertyAccessor">The <see cref="T:System.Reflection.MethodInfo" /> that represents a property accessor method.</param>
@@ -1625,7 +1628,7 @@ namespace System.Linq.Expressions
         ///   <paramref name="propertyAccessor" /> or <paramref name="bindings" /> is <see langword="null" />.</exception>
         /// <exception cref="T:System.ArgumentException">
         ///   <paramref name="propertyAccessor" /> does not represent a property accessor method.-or-The <see cref="P:System.Linq.Expressions.MemberBinding.Member" /> property of an element of <paramref name="bindings" /> does not represent a member of the type of the property accessed by the method that <paramref name="propertyAccessor" /> represents.</exception>
-        public MemberMemberBinding MemberBind(MethodInfo propertyAccessor, IEnumerable<MemberBinding> bindings) => Expression.MemberBind(propertyAccessor, bindings);
+        public virtual MemberMemberBinding MemberBind(MethodInfo propertyAccessor, IEnumerable<MemberBinding> bindings) => Expression.MemberBind(propertyAccessor, bindings);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.MemberInitExpression" />.</summary>
         /// <param name="newExpression">A <see cref="T:System.Linq.Expressions.NewExpression" /> to set the <see cref="P:System.Linq.Expressions.MemberInitExpression.NewExpression" /> property equal to.</param>
@@ -1634,7 +1637,7 @@ namespace System.Linq.Expressions
         /// <exception cref="T:System.ArgumentNullException">
         ///   <paramref name="newExpression" /> or <paramref name="bindings" /> is <see langword="null" />.</exception>
         /// <exception cref="T:System.ArgumentException">The <see cref="P:System.Linq.Expressions.MemberBinding.Member" /> property of an element of <paramref name="bindings" /> does not represent a member of the type that <paramref name="newExpression" />.Type represents.</exception>
-        public MemberInitExpression MemberInit(NewExpression newExpression, MemberBinding[] bindings) => Expression.MemberInit(newExpression, bindings);
+        public virtual MemberInitExpression MemberInit(NewExpression newExpression, MemberBinding[] bindings) => Expression.MemberInit(newExpression, bindings);
 
         /// <summary>Represents an expression that creates a new object and initializes a property of the object.</summary>
         /// <param name="newExpression">A <see cref="T:System.Linq.Expressions.NewExpression" /> to set the <see cref="P:System.Linq.Expressions.MemberInitExpression.NewExpression" /> property equal to.</param>
@@ -1643,7 +1646,7 @@ namespace System.Linq.Expressions
         /// <exception cref="T:System.ArgumentNullException">
         ///   <paramref name="newExpression" /> or <paramref name="bindings" /> is <see langword="null" />.</exception>
         /// <exception cref="T:System.ArgumentException">The <see cref="P:System.Linq.Expressions.MemberBinding.Member" /> property of an element of <paramref name="bindings" /> does not represent a member of the type that <paramref name="newExpression" />.Type represents.</exception>
-        public MemberInitExpression MemberInit(NewExpression newExpression, IEnumerable<MemberBinding> bindings) => Expression.MemberInit(newExpression, bindings);
+        public virtual MemberInitExpression MemberInit(NewExpression newExpression, IEnumerable<MemberBinding> bindings) => Expression.MemberInit(newExpression, bindings);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.BinaryExpression" /> that represents an arithmetic remainder operation.</summary>
         /// <param name="left">An <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Left" /> property equal to.</param>
@@ -1652,7 +1655,7 @@ namespace System.Linq.Expressions
         /// <exception cref="T:System.ArgumentNullException">
         ///   <paramref name="left" /> or <paramref name="right" /> is <see langword="null" />.</exception>
         /// <exception cref="T:System.InvalidOperationException">The modulus operator is not defined for <paramref name="left" />.Type and <paramref name="right" />.Type.</exception>
-        public BinaryExpression Modulo(Expression left, Expression right) => Expression.Modulo(left, right);
+        public virtual BinaryExpression Modulo(Expression left, Expression right) => Expression.Modulo(left, right);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.BinaryExpression" /> that represents an arithmetic remainder operation.</summary>
         /// <param name="left">An <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Left" /> property equal to.</param>
@@ -1665,20 +1668,20 @@ namespace System.Linq.Expressions
         ///   <paramref name="method" /> is not <see langword="null" /> and the method it represents returns <see langword="void" />, is not <see langword="static" /> (<see langword="Shared" /> in Visual Basic), or does not take exactly two arguments.</exception>
         /// <exception cref="T:System.InvalidOperationException">
         ///   <paramref name="method" /> is <see langword="null" /> and the modulus operator is not defined for <paramref name="left" />.Type and <paramref name="right" />.Type.</exception>
-        public BinaryExpression Modulo(Expression left, Expression right, MethodInfo method) => Expression.Modulo(left, right, method);
+        public virtual BinaryExpression Modulo(Expression left, Expression right, MethodInfo method) => Expression.Modulo(left, right, method);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.BinaryExpression" /> that represents a remainder assignment operation.</summary>
         /// <param name="left">An <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Left" /> property equal to.</param>
         /// <param name="right">An <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Right" /> property equal to.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.BinaryExpression" /> that has the <see cref="P:System.Linq.Expressions.Expression.NodeType" /> property equal to <see cref="F:System.Linq.Expressions.ExpressionType.ModuloAssign" /> and the <see cref="P:System.Linq.Expressions.BinaryExpression.Left" /> and <see cref="P:System.Linq.Expressions.BinaryExpression.Right" /> properties set to the specified values.</returns>
-        public BinaryExpression ModuloAssign(Expression left, Expression right) => Expression.ModuloAssign(left, right);
+        public virtual BinaryExpression ModuloAssign(Expression left, Expression right) => Expression.ModuloAssign(left, right);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.BinaryExpression" /> that represents a remainder assignment operation.</summary>
         /// <param name="left">An <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Left" /> property equal to.</param>
         /// <param name="right">An <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Right" /> property equal to.</param>
         /// <param name="method">A <see cref="T:System.Reflection.MethodInfo" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Method" /> property equal to.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.BinaryExpression" /> that has the <see cref="P:System.Linq.Expressions.Expression.NodeType" /> property equal to <see cref="F:System.Linq.Expressions.ExpressionType.ModuloAssign" /> and the <see cref="P:System.Linq.Expressions.BinaryExpression.Left" />, <see cref="P:System.Linq.Expressions.BinaryExpression.Right" />, and <see cref="P:System.Linq.Expressions.BinaryExpression.Method" /> properties set to the specified values.</returns>
-        public BinaryExpression ModuloAssign(Expression left, Expression right, MethodInfo method) => Expression.ModuloAssign(left, right, method);
+        public virtual BinaryExpression ModuloAssign(Expression left, Expression right, MethodInfo method) => Expression.ModuloAssign(left, right, method);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.BinaryExpression" /> that represents a remainder assignment operation.</summary>
         /// <param name="left">An <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Left" /> property equal to.</param>
@@ -1686,7 +1689,7 @@ namespace System.Linq.Expressions
         /// <param name="method">A <see cref="T:System.Reflection.MethodInfo" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Method" /> property equal to.</param>
         /// <param name="conversion">A <see cref="T:System.Linq.Expressions.LambdaExpression" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Conversion" /> property equal to.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.BinaryExpression" /> that has the <see cref="P:System.Linq.Expressions.Expression.NodeType" /> property equal to <see cref="F:System.Linq.Expressions.ExpressionType.ModuloAssign" /> and the <see cref="P:System.Linq.Expressions.BinaryExpression.Left" />, <see cref="P:System.Linq.Expressions.BinaryExpression.Right" />, <see cref="P:System.Linq.Expressions.BinaryExpression.Method" />, and <see cref="P:System.Linq.Expressions.BinaryExpression.Conversion" /> properties set to the specified values.</returns>
-        public BinaryExpression ModuloAssign(Expression left, Expression right, MethodInfo method, LambdaExpression conversion) => Expression.ModuloAssign(left, right, method, conversion);
+        public virtual BinaryExpression ModuloAssign(Expression left, Expression right, MethodInfo method, LambdaExpression conversion) => Expression.ModuloAssign(left, right, method, conversion);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.BinaryExpression" /> that represents an arithmetic multiplication operation that does not have overflow checking.</summary>
         /// <param name="left">An <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Left" /> property equal to.</param>
@@ -1695,7 +1698,7 @@ namespace System.Linq.Expressions
         /// <exception cref="T:System.ArgumentNullException">
         ///   <paramref name="left" /> or <paramref name="right" /> is <see langword="null" />.</exception>
         /// <exception cref="T:System.InvalidOperationException">The multiplication operator is not defined for <paramref name="left" />.Type and <paramref name="right" />.Type.</exception>
-        public BinaryExpression Multiply(Expression left, Expression right) => Expression.Multiply(left, right);
+        public virtual BinaryExpression Multiply(Expression left, Expression right) => Expression.Multiply(left, right);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.BinaryExpression" /> that represents an arithmetic multiplication operation that does not have overflow checking.</summary>
         /// <param name="left">An <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Left" /> property equal to.</param>
@@ -1708,20 +1711,20 @@ namespace System.Linq.Expressions
         ///   <paramref name="method" /> is not <see langword="null" /> and the method it represents returns <see langword="void" />, is not <see langword="static" /> (<see langword="Shared" /> in Visual Basic), or does not take exactly two arguments.</exception>
         /// <exception cref="T:System.InvalidOperationException">
         ///   <paramref name="method" /> is <see langword="null" /> and the multiplication operator is not defined for <paramref name="left" />.Type and <paramref name="right" />.Type.</exception>
-        public BinaryExpression Multiply(Expression left, Expression right, MethodInfo method) => Expression.Multiply(left, right, method);
+        public virtual BinaryExpression Multiply(Expression left, Expression right, MethodInfo method) => Expression.Multiply(left, right, method);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.BinaryExpression" /> that represents a multiplication assignment operation that does not have overflow checking.</summary>
         /// <param name="left">An <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Left" /> property equal to.</param>
         /// <param name="right">An <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Right" /> property equal to.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.BinaryExpression" /> that has the <see cref="P:System.Linq.Expressions.Expression.NodeType" /> property equal to <see cref="F:System.Linq.Expressions.ExpressionType.MultiplyAssign" /> and the <see cref="P:System.Linq.Expressions.BinaryExpression.Left" /> and <see cref="P:System.Linq.Expressions.BinaryExpression.Right" /> properties set to the specified values.</returns>
-        public BinaryExpression MultiplyAssign(Expression left, Expression right) => Expression.MultiplyAssign(left, right);
+        public virtual BinaryExpression MultiplyAssign(Expression left, Expression right) => Expression.MultiplyAssign(left, right);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.BinaryExpression" /> that represents a multiplication assignment operation that does not have overflow checking.</summary>
         /// <param name="left">An <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Left" /> property equal to.</param>
         /// <param name="right">An <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Right" /> property equal to.</param>
         /// <param name="method">A <see cref="T:System.Reflection.MethodInfo" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Method" /> property equal to.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.BinaryExpression" /> that has the <see cref="P:System.Linq.Expressions.Expression.NodeType" /> property equal to <see cref="F:System.Linq.Expressions.ExpressionType.MultiplyAssign" /> and the <see cref="P:System.Linq.Expressions.BinaryExpression.Left" />, <see cref="P:System.Linq.Expressions.BinaryExpression.Right" />, and <see cref="P:System.Linq.Expressions.BinaryExpression.Method" /> properties set to the specified values.</returns>
-        public BinaryExpression MultiplyAssign(Expression left, Expression right, MethodInfo method) => Expression.MultiplyAssign(left, right, method);
+        public virtual BinaryExpression MultiplyAssign(Expression left, Expression right, MethodInfo method) => Expression.MultiplyAssign(left, right, method);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.BinaryExpression" /> that represents a multiplication assignment operation that does not have overflow checking.</summary>
         /// <param name="left">An <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Left" /> property equal to.</param>
@@ -1729,20 +1732,20 @@ namespace System.Linq.Expressions
         /// <param name="method">A <see cref="T:System.Reflection.MethodInfo" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Method" /> property equal to.</param>
         /// <param name="conversion">A <see cref="T:System.Linq.Expressions.LambdaExpression" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Conversion" /> property equal to.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.BinaryExpression" /> that has the <see cref="P:System.Linq.Expressions.Expression.NodeType" /> property equal to <see cref="F:System.Linq.Expressions.ExpressionType.MultiplyAssign" /> and the <see cref="P:System.Linq.Expressions.BinaryExpression.Left" />, <see cref="P:System.Linq.Expressions.BinaryExpression.Right" />, <see cref="P:System.Linq.Expressions.BinaryExpression.Method" />, and <see cref="P:System.Linq.Expressions.BinaryExpression.Conversion" /> properties set to the specified values.</returns>
-        public BinaryExpression MultiplyAssign(Expression left, Expression right, MethodInfo method, LambdaExpression conversion) => Expression.MultiplyAssign(left, right, method, conversion);
+        public virtual BinaryExpression MultiplyAssign(Expression left, Expression right, MethodInfo method, LambdaExpression conversion) => Expression.MultiplyAssign(left, right, method, conversion);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.BinaryExpression" /> that represents a multiplication assignment operation that has overflow checking.</summary>
         /// <param name="left">An <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Left" /> property equal to.</param>
         /// <param name="right">An <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Right" /> property equal to.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.BinaryExpression" /> that has the <see cref="P:System.Linq.Expressions.Expression.NodeType" /> property equal to <see cref="F:System.Linq.Expressions.ExpressionType.MultiplyAssignChecked" /> and the <see cref="P:System.Linq.Expressions.BinaryExpression.Left" /> and <see cref="P:System.Linq.Expressions.BinaryExpression.Right" /> properties set to the specified values.</returns>
-        public BinaryExpression MultiplyAssignChecked(Expression left, Expression right) => Expression.MultiplyAssignChecked(left, right);
+        public virtual BinaryExpression MultiplyAssignChecked(Expression left, Expression right) => Expression.MultiplyAssignChecked(left, right);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.BinaryExpression" /> that represents a multiplication assignment operation that has overflow checking.</summary>
         /// <param name="left">An <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Left" /> property equal to.</param>
         /// <param name="right">An <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Right" /> property equal to.</param>
         /// <param name="method">A <see cref="T:System.Reflection.MethodInfo" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Method" /> property equal to.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.BinaryExpression" /> that has the <see cref="P:System.Linq.Expressions.Expression.NodeType" /> property equal to <see cref="F:System.Linq.Expressions.ExpressionType.MultiplyAssignChecked" /> and the <see cref="P:System.Linq.Expressions.BinaryExpression.Left" />, <see cref="P:System.Linq.Expressions.BinaryExpression.Right" />, and <see cref="P:System.Linq.Expressions.BinaryExpression.Method" /> properties set to the specified values.</returns>
-        public BinaryExpression MultiplyAssignChecked(Expression left, Expression right, MethodInfo method) => Expression.MultiplyAssignChecked(left, right, method);
+        public virtual BinaryExpression MultiplyAssignChecked(Expression left, Expression right, MethodInfo method) => Expression.MultiplyAssignChecked(left, right, method);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.BinaryExpression" /> that represents a multiplication assignment operation that has overflow checking.</summary>
         /// <param name="left">An <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Left" /> property equal to.</param>
@@ -1750,7 +1753,7 @@ namespace System.Linq.Expressions
         /// <param name="method">A <see cref="T:System.Reflection.MethodInfo" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Method" /> property equal to.</param>
         /// <param name="conversion">A <see cref="T:System.Linq.Expressions.LambdaExpression" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Conversion" /> property equal to.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.BinaryExpression" /> that has the <see cref="P:System.Linq.Expressions.Expression.NodeType" /> property equal to <see cref="F:System.Linq.Expressions.ExpressionType.MultiplyAssignChecked" /> and the <see cref="P:System.Linq.Expressions.BinaryExpression.Left" />, <see cref="P:System.Linq.Expressions.BinaryExpression.Right" />, <see cref="P:System.Linq.Expressions.BinaryExpression.Method" />, and <see cref="P:System.Linq.Expressions.BinaryExpression.Conversion" /> properties set to the specified values.</returns>
-        public BinaryExpression MultiplyAssignChecked(Expression left, Expression right, MethodInfo method, LambdaExpression conversion) => Expression.MultiplyAssignChecked(left, right, method, conversion);
+        public virtual BinaryExpression MultiplyAssignChecked(Expression left, Expression right, MethodInfo method, LambdaExpression conversion) => Expression.MultiplyAssignChecked(left, right, method, conversion);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.BinaryExpression" /> that represents an arithmetic multiplication operation that has overflow checking.</summary>
         /// <param name="left">An <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Left" /> property equal to.</param>
@@ -1759,7 +1762,7 @@ namespace System.Linq.Expressions
         /// <exception cref="T:System.ArgumentNullException">
         ///   <paramref name="left" /> or <paramref name="right" /> is <see langword="null" />.</exception>
         /// <exception cref="T:System.InvalidOperationException">The multiplication operator is not defined for <paramref name="left" />.Type and <paramref name="right" />.Type.</exception>
-        public BinaryExpression MultiplyChecked(Expression left, Expression right) => Expression.MultiplyChecked(left, right);
+        public virtual BinaryExpression MultiplyChecked(Expression left, Expression right) => Expression.MultiplyChecked(left, right);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.BinaryExpression" /> that represents an arithmetic multiplication operation that has overflow checking.</summary>
         /// <param name="left">An <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Left" /> property equal to.</param>
@@ -1772,7 +1775,7 @@ namespace System.Linq.Expressions
         ///   <paramref name="method" /> is not <see langword="null" /> and the method it represents returns <see langword="void" />, is not <see langword="static" /> (<see langword="Shared" /> in Visual Basic), or does not take exactly two arguments.</exception>
         /// <exception cref="T:System.InvalidOperationException">
         ///   <paramref name="method" /> is <see langword="null" /> and the multiplication operator is not defined for <paramref name="left" />.Type and <paramref name="right" />.Type.</exception>
-        public BinaryExpression MultiplyChecked(Expression left, Expression right, MethodInfo method) => Expression.MultiplyChecked(left, right, method);
+        public virtual BinaryExpression MultiplyChecked(Expression left, Expression right, MethodInfo method) => Expression.MultiplyChecked(left, right, method);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.UnaryExpression" /> that represents an arithmetic negation operation.</summary>
         /// <param name="expression">An <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.UnaryExpression.Operand" /> property equal to.</param>
@@ -1780,7 +1783,7 @@ namespace System.Linq.Expressions
         /// <exception cref="T:System.ArgumentNullException">
         ///   <paramref name="expression" /> is <see langword="null" />.</exception>
         /// <exception cref="T:System.InvalidOperationException">The unary minus operator is not defined for <paramref name="expression" />.Type.</exception>
-        public UnaryExpression Negate(Expression expression) => Expression.Negate(expression);
+        public virtual UnaryExpression Negate(Expression expression) => Expression.Negate(expression);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.UnaryExpression" /> that represents an arithmetic negation operation.</summary>
         /// <param name="expression">An <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.UnaryExpression.Operand" /> property equal to.</param>
@@ -1793,7 +1796,7 @@ namespace System.Linq.Expressions
         /// <exception cref="T:System.InvalidOperationException">
         ///   <paramref name="method" /> is <see langword="null" /> and the unary minus operator is not defined for <paramref name="expression" />.Type.-or-
         ///               <paramref name="expression" />.Type (or its corresponding non-nullable type if it is a nullable value type) is not assignable to the argument type of the method represented by <paramref name="method" />.</exception>
-        public UnaryExpression Negate(Expression expression, MethodInfo method) => Expression.Negate(expression, method);
+        public virtual UnaryExpression Negate(Expression expression, MethodInfo method) => Expression.Negate(expression, method);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.UnaryExpression" /> that represents an arithmetic negation operation that has overflow checking.</summary>
         /// <param name="expression">An <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.UnaryExpression.Operand" /> property equal to.</param>
@@ -1801,7 +1804,7 @@ namespace System.Linq.Expressions
         /// <exception cref="T:System.ArgumentNullException">
         ///   <paramref name="expression" /> is <see langword="null" />.</exception>
         /// <exception cref="T:System.InvalidOperationException">The unary minus operator is not defined for <paramref name="expression" />.Type.</exception>
-        public UnaryExpression NegateChecked(Expression expression) => Expression.NegateChecked(expression);
+        public virtual UnaryExpression NegateChecked(Expression expression) => Expression.NegateChecked(expression);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.UnaryExpression" /> that represents an arithmetic negation operation that has overflow checking. The implementing method can be specified.</summary>
         /// <param name="expression">An <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.UnaryExpression.Operand" /> property equal to.</param>
@@ -1814,7 +1817,7 @@ namespace System.Linq.Expressions
         /// <exception cref="T:System.InvalidOperationException">
         ///   <paramref name="method" /> is <see langword="null" /> and the unary minus operator is not defined for <paramref name="expression" />.Type.-or-
         ///               <paramref name="expression" />.Type (or its corresponding non-nullable type if it is a nullable value type) is not assignable to the argument type of the method represented by <paramref name="method" />.</exception>
-        public UnaryExpression NegateChecked(Expression expression, MethodInfo method) => Expression.NegateChecked(expression, method);
+        public virtual UnaryExpression NegateChecked(Expression expression, MethodInfo method) => Expression.NegateChecked(expression, method);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.NewExpression" /> that represents calling the specified constructor that takes no arguments.</summary>
         /// <param name="constructor">The <see cref="T:System.Reflection.ConstructorInfo" /> to set the <see cref="P:System.Linq.Expressions.NewExpression.Constructor" /> property equal to.</param>
@@ -1822,7 +1825,7 @@ namespace System.Linq.Expressions
         /// <exception cref="T:System.ArgumentNullException">
         ///   <paramref name="constructor" /> is <see langword="null" />.</exception>
         /// <exception cref="T:System.ArgumentException">The constructor that <paramref name="constructor" /> represents has at least one parameter.</exception>
-        public NewExpression New(ConstructorInfo constructor) => Expression.New(constructor);
+        public virtual NewExpression New(ConstructorInfo constructor) => Expression.New(constructor);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.NewExpression" /> that represents calling the parameterless constructor of the specified type.</summary>
         /// <param name="type">A <see cref="T:System.Type" /> that has a constructor that takes no arguments.</param>
@@ -1830,7 +1833,7 @@ namespace System.Linq.Expressions
         /// <exception cref="T:System.ArgumentNullException">
         ///   <paramref name="type" /> is <see langword="null" />.</exception>
         /// <exception cref="T:System.ArgumentException">The type that <paramref name="type" /> represents does not have a constructor without parameters.</exception>
-        public NewExpression New(Type type) => Expression.New(type);
+        public virtual NewExpression New(Type type) => Expression.New(type);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.NewExpression" /> that represents calling the specified constructor with the specified arguments.</summary>
         /// <param name="constructor">The <see cref="T:System.Reflection.ConstructorInfo" /> to set the <see cref="P:System.Linq.Expressions.NewExpression.Constructor" /> property equal to.</param>
@@ -1839,7 +1842,7 @@ namespace System.Linq.Expressions
         /// <exception cref="T:System.ArgumentNullException">
         ///   <paramref name="constructor" /> is <see langword="null" />.-or-An element of <paramref name="arguments" /> is <see langword="null" />.</exception>
         /// <exception cref="T:System.ArgumentException">The length of <paramref name="arguments" /> does match the number of parameters for the constructor that <paramref name="constructor" /> represents.-or-The <see cref="P:System.Linq.Expressions.Expression.Type" /> property of an element of <paramref name="arguments" /> is not assignable to the type of the corresponding parameter of the constructor that <paramref name="constructor" /> represents.</exception>
-        public NewExpression New(ConstructorInfo constructor, Expression[] arguments) => Expression.New(constructor, arguments);
+        public virtual NewExpression New(ConstructorInfo constructor, Expression[] arguments) => Expression.New(constructor, arguments);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.NewExpression" /> that represents calling the specified constructor with the specified arguments.</summary>
         /// <param name="constructor">The <see cref="T:System.Reflection.ConstructorInfo" /> to set the <see cref="P:System.Linq.Expressions.NewExpression.Constructor" /> property equal to.</param>
@@ -1848,7 +1851,7 @@ namespace System.Linq.Expressions
         /// <exception cref="T:System.ArgumentNullException">
         ///   <paramref name="constructor" /> is <see langword="null" />.-or-An element of <paramref name="arguments" /> is <see langword="null" />.</exception>
         /// <exception cref="T:System.ArgumentException">The <paramref name="arguments" /> parameter does not contain the same number of elements as the number of parameters for the constructor that <paramref name="constructor" /> represents.-or-The <see cref="P:System.Linq.Expressions.Expression.Type" /> property of an element of <paramref name="arguments" /> is not assignable to the type of the corresponding parameter of the constructor that <paramref name="constructor" /> represents.</exception>
-        public NewExpression New(ConstructorInfo constructor, IEnumerable<Expression> arguments) => Expression.New(constructor, arguments);
+        public virtual NewExpression New(ConstructorInfo constructor, IEnumerable<Expression> arguments) => Expression.New(constructor, arguments);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.NewExpression" /> that represents calling the specified constructor with the specified arguments. The members that access the constructor initialized fields are specified.</summary>
         /// <param name="constructor">The <see cref="T:System.Reflection.ConstructorInfo" /> to set the <see cref="P:System.Linq.Expressions.NewExpression.Constructor" /> property equal to.</param>
@@ -1858,7 +1861,7 @@ namespace System.Linq.Expressions
         /// <exception cref="T:System.ArgumentNullException">
         ///   <paramref name="constructor" /> is <see langword="null" />.-or-An element of <paramref name="arguments" /> is <see langword="null" />.-or-An element of <paramref name="members" /> is <see langword="null" />.</exception>
         /// <exception cref="T:System.ArgumentException">The <paramref name="arguments" /> parameter does not contain the same number of elements as the number of parameters for the constructor that <paramref name="constructor" /> represents.-or-The <see cref="P:System.Linq.Expressions.Expression.Type" /> property of an element of <paramref name="arguments" /> is not assignable to the type of the corresponding parameter of the constructor that <paramref name="constructor" /> represents.-or-The <paramref name="members" /> parameter does not have the same number of elements as <paramref name="arguments" />.-or-An element of <paramref name="arguments" /> has a <see cref="P:System.Linq.Expressions.Expression.Type" /> property that represents a type that is not assignable to the type of the member that is represented by the corresponding element of <paramref name="members" />.</exception>
-        public NewExpression New(ConstructorInfo constructor, IEnumerable<Expression> arguments, IEnumerable<MemberInfo> members) => Expression.New(constructor, arguments, members);
+        public virtual NewExpression New(ConstructorInfo constructor, IEnumerable<Expression> arguments, IEnumerable<MemberInfo> members) => Expression.New(constructor, arguments, members);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.NewExpression" /> that represents calling the specified constructor with the specified arguments. The members that access the constructor initialized fields are specified as an array.</summary>
         /// <param name="constructor">The <see cref="T:System.Reflection.ConstructorInfo" /> to set the <see cref="P:System.Linq.Expressions.NewExpression.Constructor" /> property equal to.</param>
@@ -1868,7 +1871,7 @@ namespace System.Linq.Expressions
         /// <exception cref="T:System.ArgumentNullException">
         ///   <paramref name="constructor" /> is <see langword="null" />.-or-An element of <paramref name="arguments" /> is <see langword="null" />.-or-An element of <paramref name="members" /> is <see langword="null" />.</exception>
         /// <exception cref="T:System.ArgumentException">The <paramref name="arguments" /> parameter does not contain the same number of elements as the number of parameters for the constructor that <paramref name="constructor" /> represents.-or-The <see cref="P:System.Linq.Expressions.Expression.Type" /> property of an element of <paramref name="arguments" /> is not assignable to the type of the corresponding parameter of the constructor that <paramref name="constructor" /> represents.-or-The <paramref name="members" /> parameter does not have the same number of elements as <paramref name="arguments" />.-or-An element of <paramref name="arguments" /> has a <see cref="P:System.Linq.Expressions.Expression.Type" /> property that represents a type that is not assignable to the type of the member that is represented by the corresponding element of <paramref name="members" />.</exception>
-        public NewExpression New(ConstructorInfo constructor, IEnumerable<Expression> arguments, MemberInfo[] members) => Expression.New(constructor, arguments, members);
+        public virtual NewExpression New(ConstructorInfo constructor, IEnumerable<Expression> arguments, MemberInfo[] members) => Expression.New(constructor, arguments, members);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.NewArrayExpression" /> that represents creating an array that has a specified rank.</summary>
         /// <param name="type">A <see cref="T:System.Type" /> that represents the element type of the array.</param>
@@ -1877,7 +1880,7 @@ namespace System.Linq.Expressions
         /// <exception cref="T:System.ArgumentNullException">
         ///   <paramref name="type" /> or <paramref name="bounds" /> is <see langword="null" />.-or-An element of <paramref name="bounds" /> is <see langword="null" />.</exception>
         /// <exception cref="T:System.ArgumentException">The <see cref="P:System.Linq.Expressions.Expression.Type" /> property of an element of <paramref name="bounds" /> does not represent an integral type.</exception>
-        public NewArrayExpression NewArrayBounds(Type type, Expression[] bounds) => Expression.NewArrayBounds(type, bounds);
+        public virtual NewArrayExpression NewArrayBounds(Type type, Expression[] bounds) => Expression.NewArrayBounds(type, bounds);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.NewArrayExpression" /> that represents creating an array that has a specified rank.</summary>
         /// <param name="type">A <see cref="T:System.Type" /> that represents the element type of the array.</param>
@@ -1886,7 +1889,7 @@ namespace System.Linq.Expressions
         /// <exception cref="T:System.ArgumentNullException">
         ///   <paramref name="type" /> or <paramref name="bounds" /> is <see langword="null" />.-or-An element of <paramref name="bounds" /> is <see langword="null" />.</exception>
         /// <exception cref="T:System.ArgumentException">The <see cref="P:System.Linq.Expressions.Expression.Type" /> property of an element of <paramref name="bounds" /> does not represent an integral type.</exception>
-        public NewArrayExpression NewArrayBounds(Type type, IEnumerable<Expression> bounds) => Expression.NewArrayBounds(type, bounds);
+        public virtual NewArrayExpression NewArrayBounds(Type type, IEnumerable<Expression> bounds) => Expression.NewArrayBounds(type, bounds);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.NewArrayExpression" /> that represents creating a one-dimensional array and initializing it from a list of elements.</summary>
         /// <param name="type">A <see cref="T:System.Type" /> that represents the element type of the array.</param>
@@ -1895,7 +1898,7 @@ namespace System.Linq.Expressions
         /// <exception cref="T:System.ArgumentNullException">
         ///   <paramref name="type" /> or <paramref name="initializers" /> is <see langword="null" />.-or-An element of <paramref name="initializers" /> is <see langword="null" />.</exception>
         /// <exception cref="T:System.InvalidOperationException">The <see cref="P:System.Linq.Expressions.Expression.Type" /> property of an element of <paramref name="initializers" /> represents a type that is not assignable to the type <paramref name="type" />.</exception>
-        public NewArrayExpression NewArrayInit(Type type, Expression[] initializers) => Expression.NewArrayInit(type, initializers);
+        public virtual NewArrayExpression NewArrayInit(Type type, Expression[] initializers) => Expression.NewArrayInit(type, initializers);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.NewArrayExpression" /> that represents creating a one-dimensional array and initializing it from a list of elements.</summary>
         /// <param name="type">A <see cref="T:System.Type" /> that represents the element type of the array.</param>
@@ -1904,7 +1907,7 @@ namespace System.Linq.Expressions
         /// <exception cref="T:System.ArgumentNullException">
         ///   <paramref name="type" /> or <paramref name="initializers" /> is <see langword="null" />.-or-An element of <paramref name="initializers" /> is <see langword="null" />.</exception>
         /// <exception cref="T:System.InvalidOperationException">The <see cref="P:System.Linq.Expressions.Expression.Type" /> property of an element of <paramref name="initializers" /> represents a type that is not assignable to the type that <paramref name="type" /> represents.</exception>
-        public NewArrayExpression NewArrayInit(Type type, IEnumerable<Expression> initializers) => Expression.NewArrayInit(type, initializers);
+        public virtual NewArrayExpression NewArrayInit(Type type, IEnumerable<Expression> initializers) => Expression.NewArrayInit(type, initializers);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.UnaryExpression" /> that represents a bitwise complement operation.</summary>
         /// <param name="expression">An <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.UnaryExpression.Operand" /> property equal to.</param>
@@ -1912,7 +1915,7 @@ namespace System.Linq.Expressions
         /// <exception cref="T:System.ArgumentNullException">
         ///   <paramref name="expression" /> is <see langword="null" />.</exception>
         /// <exception cref="T:System.InvalidOperationException">The unary not operator is not defined for <paramref name="expression" />.Type.</exception>
-        public UnaryExpression Not(Expression expression) => Expression.Not(expression);
+        public virtual UnaryExpression Not(Expression expression) => Expression.Not(expression);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.UnaryExpression" /> that represents a bitwise complement operation. The implementing method can be specified.</summary>
         /// <param name="expression">An <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.UnaryExpression.Operand" /> property equal to.</param>
@@ -1925,7 +1928,7 @@ namespace System.Linq.Expressions
         /// <exception cref="T:System.InvalidOperationException">
         ///   <paramref name="method" /> is <see langword="null" /> and the unary not operator is not defined for <paramref name="expression" />.Type.-or-
         ///               <paramref name="expression" />.Type (or its corresponding non-nullable type if it is a nullable value type) is not assignable to the argument type of the method represented by <paramref name="method" />.</exception>
-        public UnaryExpression Not(Expression expression, MethodInfo method) => Expression.Not(expression, method);
+        public virtual UnaryExpression Not(Expression expression, MethodInfo method) => Expression.Not(expression, method);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.BinaryExpression" /> that represents an inequality comparison.</summary>
         /// <param name="left">An <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Left" /> property equal to.</param>
@@ -1934,7 +1937,7 @@ namespace System.Linq.Expressions
         /// <exception cref="T:System.ArgumentNullException">
         ///   <paramref name="left" /> or <paramref name="right" /> is <see langword="null" />.</exception>
         /// <exception cref="T:System.InvalidOperationException">The inequality operator is not defined for <paramref name="left" />.Type and <paramref name="right" />.Type.</exception>
-        public BinaryExpression NotEqual(Expression left, Expression right) => Expression.NotEqual(left, right);
+        public virtual BinaryExpression NotEqual(Expression left, Expression right) => Expression.NotEqual(left, right);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.BinaryExpression" /> that represents an inequality comparison.</summary>
         /// <param name="left">An <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Left" /> property equal to.</param>
@@ -1949,18 +1952,18 @@ namespace System.Linq.Expressions
         ///   <paramref name="method" /> is not <see langword="null" /> and the method it represents returns <see langword="void" />, is not <see langword="static" /> (<see langword="Shared" /> in Visual Basic), or does not take exactly two arguments.</exception>
         /// <exception cref="T:System.InvalidOperationException">
         ///   <paramref name="method" /> is <see langword="null" /> and the inequality operator is not defined for <paramref name="left" />.Type and <paramref name="right" />.Type.</exception>
-        public BinaryExpression NotEqual(Expression left, Expression right, Boolean liftToNull, MethodInfo method) => Expression.NotEqual(left, right, liftToNull, method);
+        public virtual BinaryExpression NotEqual(Expression left, Expression right, Boolean liftToNull, MethodInfo method) => Expression.NotEqual(left, right, liftToNull, method);
 
         /// <summary>Returns the expression representing the ones complement.</summary>
         /// <param name="expression">An <see cref="T:System.Linq.Expressions.Expression" />.</param>
         /// <returns>An instance of <see cref="T:System.Linq.Expressions.UnaryExpression" />.</returns>
-        public UnaryExpression OnesComplement(Expression expression) => Expression.OnesComplement(expression);
+        public virtual UnaryExpression OnesComplement(Expression expression) => Expression.OnesComplement(expression);
 
         /// <summary>Returns the expression representing the ones complement.</summary>
         /// <param name="expression">An <see cref="T:System.Linq.Expressions.Expression" />.</param>
         /// <param name="method">A <see cref="T:System.Reflection.MethodInfo" /> that represents the implementing method.</param>
         /// <returns>An instance of <see cref="T:System.Linq.Expressions.UnaryExpression" />.</returns>
-        public UnaryExpression OnesComplement(Expression expression, MethodInfo method) => Expression.OnesComplement(expression, method);
+        public virtual UnaryExpression OnesComplement(Expression expression, MethodInfo method) => Expression.OnesComplement(expression, method);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.BinaryExpression" /> that represents a bitwise <see langword="OR" /> operation.</summary>
         /// <param name="left">An <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Left" /> property equal to.</param>
@@ -1969,7 +1972,7 @@ namespace System.Linq.Expressions
         /// <exception cref="T:System.ArgumentNullException">
         ///   <paramref name="left" /> or <paramref name="right" /> is <see langword="null" />.</exception>
         /// <exception cref="T:System.InvalidOperationException">The bitwise <see langword="OR" /> operator is not defined for <paramref name="left" />.Type and <paramref name="right" />.Type.</exception>
-        public BinaryExpression Or(Expression left, Expression right) => Expression.Or(left, right);
+        public virtual BinaryExpression Or(Expression left, Expression right) => Expression.Or(left, right);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.BinaryExpression" /> that represents a bitwise <see langword="OR" /> operation.</summary>
         /// <param name="left">An <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Left" /> property equal to.</param>
@@ -1982,20 +1985,20 @@ namespace System.Linq.Expressions
         ///   <paramref name="method" /> is not <see langword="null" /> and the method it represents returns <see langword="void" />, is not <see langword="static" /> (<see langword="Shared" /> in Visual Basic), or does not take exactly two arguments.</exception>
         /// <exception cref="T:System.InvalidOperationException">
         ///   <paramref name="method" /> is <see langword="null" /> and the bitwise <see langword="OR" /> operator is not defined for <paramref name="left" />.Type and <paramref name="right" />.Type.</exception>
-        public BinaryExpression Or(Expression left, Expression right, MethodInfo method) => Expression.Or(left, right, method);
+        public virtual BinaryExpression Or(Expression left, Expression right, MethodInfo method) => Expression.Or(left, right, method);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.BinaryExpression" /> that represents a bitwise OR assignment operation.</summary>
         /// <param name="left">An <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Left" /> property equal to.</param>
         /// <param name="right">An <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Right" /> property equal to.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.BinaryExpression" /> that has the <see cref="P:System.Linq.Expressions.Expression.NodeType" /> property equal to <see cref="F:System.Linq.Expressions.ExpressionType.OrAssign" /> and the <see cref="P:System.Linq.Expressions.BinaryExpression.Left" /> and <see cref="P:System.Linq.Expressions.BinaryExpression.Right" /> properties set to the specified values.</returns>
-        public BinaryExpression OrAssign(Expression left, Expression right) => Expression.OrAssign(left, right);
+        public virtual BinaryExpression OrAssign(Expression left, Expression right) => Expression.OrAssign(left, right);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.BinaryExpression" /> that represents a bitwise OR assignment operation.</summary>
         /// <param name="left">An <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Left" /> property equal to.</param>
         /// <param name="right">An <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Right" /> property equal to.</param>
         /// <param name="method">A <see cref="T:System.Reflection.MethodInfo" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Method" /> property equal to.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.BinaryExpression" /> that has the <see cref="P:System.Linq.Expressions.Expression.NodeType" /> property equal to <see cref="F:System.Linq.Expressions.ExpressionType.OrAssign" /> and the <see cref="P:System.Linq.Expressions.BinaryExpression.Left" />, <see cref="P:System.Linq.Expressions.BinaryExpression.Right" />, and <see cref="P:System.Linq.Expressions.BinaryExpression.Method" /> properties set to the specified values.</returns>
-        public BinaryExpression OrAssign(Expression left, Expression right, MethodInfo method) => Expression.OrAssign(left, right, method);
+        public virtual BinaryExpression OrAssign(Expression left, Expression right, MethodInfo method) => Expression.OrAssign(left, right, method);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.BinaryExpression" /> that represents a bitwise OR assignment operation.</summary>
         /// <param name="left">An <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Left" /> property equal to.</param>
@@ -2003,7 +2006,7 @@ namespace System.Linq.Expressions
         /// <param name="method">A <see cref="T:System.Reflection.MethodInfo" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Method" /> property equal to.</param>
         /// <param name="conversion">A <see cref="T:System.Linq.Expressions.LambdaExpression" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Conversion" /> property equal to.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.BinaryExpression" /> that has the <see cref="P:System.Linq.Expressions.Expression.NodeType" /> property equal to <see cref="F:System.Linq.Expressions.ExpressionType.OrAssign" /> and the <see cref="P:System.Linq.Expressions.BinaryExpression.Left" />, <see cref="P:System.Linq.Expressions.BinaryExpression.Right" />, <see cref="P:System.Linq.Expressions.BinaryExpression.Method" />, and <see cref="P:System.Linq.Expressions.BinaryExpression.Conversion" /> properties set to the specified values.</returns>
-        public BinaryExpression OrAssign(Expression left, Expression right, MethodInfo method, LambdaExpression conversion) => Expression.OrAssign(left, right, method, conversion);
+        public virtual BinaryExpression OrAssign(Expression left, Expression right, MethodInfo method, LambdaExpression conversion) => Expression.OrAssign(left, right, method, conversion);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.BinaryExpression" /> that represents a conditional <see langword="OR" /> operation that evaluates the second operand only if the first operand evaluates to <see langword="false" />.</summary>
         /// <param name="left">An <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Left" /> property equal to.</param>
@@ -2013,7 +2016,7 @@ namespace System.Linq.Expressions
         ///   <paramref name="left" /> or <paramref name="right" /> is <see langword="null" />.</exception>
         /// <exception cref="T:System.InvalidOperationException">The bitwise <see langword="OR" /> operator is not defined for <paramref name="left" />.Type and <paramref name="right" />.Type.-or-
         ///               <paramref name="left" />.Type and <paramref name="right" />.Type are not the same Boolean type.</exception>
-        public BinaryExpression OrElse(Expression left, Expression right) => Expression.OrElse(left, right);
+        public virtual BinaryExpression OrElse(Expression left, Expression right) => Expression.OrElse(left, right);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.BinaryExpression" /> that represents a conditional <see langword="OR" /> operation that evaluates the second operand only if the first operand evaluates to <see langword="false" />.</summary>
         /// <param name="left">An <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Left" /> property equal to.</param>
@@ -2027,12 +2030,12 @@ namespace System.Linq.Expressions
         /// <exception cref="T:System.InvalidOperationException">
         ///   <paramref name="method" /> is <see langword="null" /> and the bitwise <see langword="OR" /> operator is not defined for <paramref name="left" />.Type and <paramref name="right" />.Type.-or-
         ///               <paramref name="method" /> is <see langword="null" /> and <paramref name="left" />.Type and <paramref name="right" />.Type are not the same Boolean type.</exception>
-        public BinaryExpression OrElse(Expression left, Expression right, MethodInfo method) => Expression.OrElse(left, right, method);
+        public virtual BinaryExpression OrElse(Expression left, Expression right, MethodInfo method) => Expression.OrElse(left, right, method);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.ParameterExpression" /> node that can be used to identify a parameter or a variable in an expression tree.</summary>
         /// <param name="type">The type of the parameter or variable.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.ParameterExpression" /> node with the specified name and type.</returns>
-        public ParameterExpression Parameter(Type type) => Expression.Parameter(type);
+        public virtual ParameterExpression Parameter(Type type) => Expression.Parameter(type);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.ParameterExpression" /> node that can be used to identify a parameter or a variable in an expression tree.</summary>
         /// <param name="type">The type of the parameter or variable.</param>
@@ -2040,29 +2043,29 @@ namespace System.Linq.Expressions
         /// <returns>A <see cref="T:System.Linq.Expressions.ParameterExpression" /> that has the <see cref="P:System.Linq.Expressions.Expression.NodeType" /> property equal to <see cref="F:System.Linq.Expressions.ExpressionType.Parameter" /> and the <see cref="P:System.Linq.Expressions.Expression.Type" /> and <see cref="P:System.Linq.Expressions.ParameterExpression.Name" /> properties set to the specified values.</returns>
         /// <exception cref="T:System.ArgumentNullException">
         ///   <paramref name="type" /> is <see langword="null" />.</exception>
-        public ParameterExpression Parameter(Type type, String name) => Expression.Parameter(type, name);
+        public virtual ParameterExpression Parameter(Type type, String name) => Expression.Parameter(type, name);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.UnaryExpression" /> that represents the assignment of the expression followed by a subsequent decrement by 1 of the original expression.</summary>
         /// <param name="expression">An <see cref="T:System.Linq.Expressions.Expression" /> to apply the operations on.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.UnaryExpression" /> that represents the resultant expression.</returns>
-        public UnaryExpression PostDecrementAssign(Expression expression) => Expression.PostDecrementAssign(expression);
+        public virtual UnaryExpression PostDecrementAssign(Expression expression) => Expression.PostDecrementAssign(expression);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.UnaryExpression" /> that represents the assignment of the expression followed by a subsequent decrement by 1 of the original expression.</summary>
         /// <param name="expression">An <see cref="T:System.Linq.Expressions.Expression" /> to apply the operations on.</param>
         /// <param name="method">A <see cref="T:System.Reflection.MethodInfo" /> that represents the implementing method.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.UnaryExpression" /> that represents the resultant expression.</returns>
-        public UnaryExpression PostDecrementAssign(Expression expression, MethodInfo method) => Expression.PostDecrementAssign(expression, method);
+        public virtual UnaryExpression PostDecrementAssign(Expression expression, MethodInfo method) => Expression.PostDecrementAssign(expression, method);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.UnaryExpression" /> that represents the assignment of the expression followed by a subsequent increment by 1 of the original expression.</summary>
         /// <param name="expression">An <see cref="T:System.Linq.Expressions.Expression" /> to apply the operations on.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.UnaryExpression" /> that represents the resultant expression.</returns>
-        public UnaryExpression PostIncrementAssign(Expression expression) => Expression.PostIncrementAssign(expression);
+        public virtual UnaryExpression PostIncrementAssign(Expression expression) => Expression.PostIncrementAssign(expression);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.UnaryExpression" /> that represents the assignment of the expression followed by a subsequent increment by 1 of the original expression.</summary>
         /// <param name="expression">An <see cref="T:System.Linq.Expressions.Expression" /> to apply the operations on.</param>
         /// <param name="method">A <see cref="T:System.Reflection.MethodInfo" /> that represents the implementing method.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.UnaryExpression" /> that represents the resultant expression.</returns>
-        public UnaryExpression PostIncrementAssign(Expression expression, MethodInfo method) => Expression.PostIncrementAssign(expression, method);
+        public virtual UnaryExpression PostIncrementAssign(Expression expression, MethodInfo method) => Expression.PostIncrementAssign(expression, method);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.BinaryExpression" /> that represents raising a number to a power.</summary>
         /// <param name="left">An <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Left" /> property equal to.</param>
@@ -2072,7 +2075,7 @@ namespace System.Linq.Expressions
         ///   <paramref name="left" /> or <paramref name="right" /> is <see langword="null" />.</exception>
         /// <exception cref="T:System.InvalidOperationException">The exponentiation operator is not defined for <paramref name="left" />.Type and <paramref name="right" />.Type.-or-
         ///               <paramref name="left" />.Type and/or <paramref name="right" />.Type are not <see cref="T:System.Double" />.</exception>
-        public BinaryExpression Power(Expression left, Expression right) => Expression.Power(left, right);
+        public virtual BinaryExpression Power(Expression left, Expression right) => Expression.Power(left, right);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.BinaryExpression" /> that represents raising a number to a power.</summary>
         /// <param name="left">An <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Left" /> property equal to.</param>
@@ -2086,20 +2089,20 @@ namespace System.Linq.Expressions
         /// <exception cref="T:System.InvalidOperationException">
         ///   <paramref name="method" /> is <see langword="null" /> and the exponentiation operator is not defined for <paramref name="left" />.Type and <paramref name="right" />.Type.-or-
         ///               <paramref name="method" /> is <see langword="null" /> and <paramref name="left" />.Type and/or <paramref name="right" />.Type are not <see cref="T:System.Double" />.</exception>
-        public BinaryExpression Power(Expression left, Expression right, MethodInfo method) => Expression.Power(left, right, method);
+        public virtual BinaryExpression Power(Expression left, Expression right, MethodInfo method) => Expression.Power(left, right, method);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.BinaryExpression" /> that represents raising an expression to a power and assigning the result back to the expression.</summary>
         /// <param name="left">An <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Left" /> property equal to.</param>
         /// <param name="right">An <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Right" /> property equal to.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.BinaryExpression" /> that has the <see cref="P:System.Linq.Expressions.Expression.NodeType" /> property equal to <see cref="F:System.Linq.Expressions.ExpressionType.PowerAssign" /> and the <see cref="P:System.Linq.Expressions.BinaryExpression.Left" /> and <see cref="P:System.Linq.Expressions.BinaryExpression.Right" /> properties set to the specified values.</returns>
-        public BinaryExpression PowerAssign(Expression left, Expression right) => Expression.PowerAssign(left, right);
+        public virtual BinaryExpression PowerAssign(Expression left, Expression right) => Expression.PowerAssign(left, right);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.BinaryExpression" /> that represents raising an expression to a power and assigning the result back to the expression.</summary>
         /// <param name="left">An <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Left" /> property equal to.</param>
         /// <param name="right">An <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Right" /> property equal to.</param>
         /// <param name="method">A <see cref="T:System.Reflection.MethodInfo" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Method" /> property equal to.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.BinaryExpression" /> that has the <see cref="P:System.Linq.Expressions.Expression.NodeType" /> property equal to <see cref="F:System.Linq.Expressions.ExpressionType.PowerAssign" /> and the <see cref="P:System.Linq.Expressions.BinaryExpression.Left" />, <see cref="P:System.Linq.Expressions.BinaryExpression.Right" />, and <see cref="P:System.Linq.Expressions.BinaryExpression.Method" /> properties set to the specified values.</returns>
-        public BinaryExpression PowerAssign(Expression left, Expression right, MethodInfo method) => Expression.PowerAssign(left, right, method);
+        public virtual BinaryExpression PowerAssign(Expression left, Expression right, MethodInfo method) => Expression.PowerAssign(left, right, method);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.BinaryExpression" /> that represents raising an expression to a power and assigning the result back to the expression.</summary>
         /// <param name="left">An <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Left" /> property equal to.</param>
@@ -2107,29 +2110,29 @@ namespace System.Linq.Expressions
         /// <param name="method">A <see cref="T:System.Reflection.MethodInfo" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Method" /> property equal to.</param>
         /// <param name="conversion">A <see cref="T:System.Linq.Expressions.LambdaExpression" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Conversion" /> property equal to.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.BinaryExpression" /> that has the <see cref="P:System.Linq.Expressions.Expression.NodeType" /> property equal to <see cref="F:System.Linq.Expressions.ExpressionType.PowerAssign" /> and the <see cref="P:System.Linq.Expressions.BinaryExpression.Left" />, <see cref="P:System.Linq.Expressions.BinaryExpression.Right" />, <see cref="P:System.Linq.Expressions.BinaryExpression.Method" />, and <see cref="P:System.Linq.Expressions.BinaryExpression.Conversion" /> properties set to the specified values.</returns>
-        public BinaryExpression PowerAssign(Expression left, Expression right, MethodInfo method, LambdaExpression conversion) => Expression.PowerAssign(left, right, method, conversion);
+        public virtual BinaryExpression PowerAssign(Expression left, Expression right, MethodInfo method, LambdaExpression conversion) => Expression.PowerAssign(left, right, method, conversion);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.UnaryExpression" /> that decrements the expression by 1 and assigns the result back to the expression.</summary>
         /// <param name="expression">An <see cref="T:System.Linq.Expressions.Expression" /> to apply the operations on.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.UnaryExpression" /> that represents the resultant expression.</returns>
-        public UnaryExpression PreDecrementAssign(Expression expression) => Expression.PreDecrementAssign(expression);
+        public virtual UnaryExpression PreDecrementAssign(Expression expression) => Expression.PreDecrementAssign(expression);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.UnaryExpression" /> that decrements the expression by 1 and assigns the result back to the expression.</summary>
         /// <param name="expression">An <see cref="T:System.Linq.Expressions.Expression" /> to apply the operations on.</param>
         /// <param name="method">A <see cref="T:System.Reflection.MethodInfo" /> that represents the implementing method.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.UnaryExpression" /> that represents the resultant expression.</returns>
-        public UnaryExpression PreDecrementAssign(Expression expression, MethodInfo method) => Expression.PreDecrementAssign(expression, method);
+        public virtual UnaryExpression PreDecrementAssign(Expression expression, MethodInfo method) => Expression.PreDecrementAssign(expression, method);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.UnaryExpression" /> that increments the expression by 1 and assigns the result back to the expression.</summary>
         /// <param name="expression">An <see cref="T:System.Linq.Expressions.Expression" /> to apply the operations on.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.UnaryExpression" /> that represents the resultant expression.</returns>
-        public UnaryExpression PreIncrementAssign(Expression expression) => Expression.PreIncrementAssign(expression);
+        public virtual UnaryExpression PreIncrementAssign(Expression expression) => Expression.PreIncrementAssign(expression);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.UnaryExpression" /> that increments the expression by 1 and assigns the result back to the expression.</summary>
         /// <param name="expression">An <see cref="T:System.Linq.Expressions.Expression" /> to apply the operations on.</param>
         /// <param name="method">A <see cref="T:System.Reflection.MethodInfo" /> that represents the implementing method.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.UnaryExpression" /> that represents the resultant expression.</returns>
-        public UnaryExpression PreIncrementAssign(Expression expression, MethodInfo method) => Expression.PreIncrementAssign(expression, method);
+        public virtual UnaryExpression PreIncrementAssign(Expression expression, MethodInfo method) => Expression.PreIncrementAssign(expression, method);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.MemberExpression" /> that represents accessing a property.</summary>
         /// <param name="expression">An <see cref="T:System.Linq.Expressions.Expression" /> whose <see cref="P:System.Linq.Expressions.Expression.Type" /> contains a property named <paramref name="propertyName" />. This can be <see langword="null" /> for static properties.</param>
@@ -2138,7 +2141,7 @@ namespace System.Linq.Expressions
         /// <exception cref="T:System.ArgumentNullException">
         ///   <paramref name="expression" /> or <paramref name="propertyName" /> is <see langword="null" />.</exception>
         /// <exception cref="T:System.ArgumentException">No property named <paramref name="propertyName" /> is defined in <paramref name="expression" />.Type or its base types.</exception>
-        public MemberExpression Property(Expression expression, String propertyName) => Expression.Property(expression, propertyName);
+        public virtual MemberExpression Property(Expression expression, String propertyName) => Expression.Property(expression, propertyName);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.MemberExpression" /> that represents accessing a property.</summary>
         /// <param name="expression">An <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.MemberExpression.Expression" /> property equal to. This can be null for static properties.</param>
@@ -2148,7 +2151,7 @@ namespace System.Linq.Expressions
         ///   <paramref name="property" /> is <see langword="null" />.-or-The property that <paramref name="property" /> represents is not <see langword="static" /> (<see langword="Shared" /> in Visual Basic) and <paramref name="expression" /> is <see langword="null" />.</exception>
         /// <exception cref="T:System.ArgumentException">
         ///   <paramref name="expression" />.Type is not assignable to the declaring type of the property that <paramref name="property" /> represents.</exception>
-        public MemberExpression Property(Expression expression, PropertyInfo property) => Expression.Property(expression, property);
+        public virtual MemberExpression Property(Expression expression, PropertyInfo property) => Expression.Property(expression, property);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.MemberExpression" /> that represents accessing a property by using a property accessor method.</summary>
         /// <param name="expression">An <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.MemberExpression.Expression" /> property equal to. This can be null for static properties.</param>
@@ -2158,35 +2161,35 @@ namespace System.Linq.Expressions
         ///   <paramref name="propertyAccessor" /> is <see langword="null" />.-or-The method that <paramref name="propertyAccessor" /> represents is not <see langword="static" /> (<see langword="Shared" /> in Visual Basic) and <paramref name="expression" /> is <see langword="null" />.</exception>
         /// <exception cref="T:System.ArgumentException">
         ///   <paramref name="expression" />.Type is not assignable to the declaring type of the method represented by <paramref name="propertyAccessor" />.-or-The method that <paramref name="propertyAccessor" /> represents is not a property accessor method.</exception>
-        public MemberExpression Property(Expression expression, MethodInfo propertyAccessor) => Expression.Property(expression, propertyAccessor);
+        public virtual MemberExpression Property(Expression expression, MethodInfo propertyAccessor) => Expression.Property(expression, propertyAccessor);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.MemberExpression" /> accessing a property.</summary>
         /// <param name="expression">The containing object of the property. This can be null for static properties.</param>
         /// <param name="type">The <see cref="P:System.Linq.Expressions.Expression.Type" /> that contains the property.</param>
         /// <param name="propertyName">The property to be accessed.</param>
         /// <returns>The created <see cref="T:System.Linq.Expressions.MemberExpression" />.</returns>
-        public MemberExpression Property(Expression expression, Type type, String propertyName) => Expression.Property(expression, type, propertyName);
+        public virtual MemberExpression Property(Expression expression, Type type, String propertyName) => Expression.Property(expression, type, propertyName);
 
         /// <summary>Creates an <see cref="T:System.Linq.Expressions.IndexExpression" /> representing the access to an indexed property.</summary>
         /// <param name="instance">The object to which the property belongs. If the property is static/shared, it must be null.</param>
         /// <param name="propertyName">The name of the indexer.</param>
         /// <param name="arguments">An array of <see cref="T:System.Linq.Expressions.Expression" /> objects that are used to index the property.</param>
         /// <returns>The created <see cref="T:System.Linq.Expressions.IndexExpression" />.</returns>
-        public IndexExpression Property(Expression instance, String propertyName, Expression[] arguments) => Expression.Property(instance, propertyName, arguments);
+        public virtual IndexExpression Property(Expression instance, String propertyName, Expression[] arguments) => Expression.Property(instance, propertyName, arguments);
 
         /// <summary>Creates an <see cref="T:System.Linq.Expressions.IndexExpression" /> representing the access to an indexed property.</summary>
         /// <param name="instance">The object to which the property belongs. If the property is static/shared, it must be null.</param>
         /// <param name="indexer">The <see cref="T:System.Reflection.PropertyInfo" /> that represents the property to index.</param>
         /// <param name="arguments">An array of <see cref="T:System.Linq.Expressions.Expression" /> objects that are used to index the property.</param>
         /// <returns>The created <see cref="T:System.Linq.Expressions.IndexExpression" />.</returns>
-        public IndexExpression Property(Expression instance, PropertyInfo indexer, Expression[] arguments) => Expression.Property(instance, indexer, arguments);
+        public virtual IndexExpression Property(Expression instance, PropertyInfo indexer, Expression[] arguments) => Expression.Property(instance, indexer, arguments);
 
         /// <summary>Creates an <see cref="T:System.Linq.Expressions.IndexExpression" /> representing the access to an indexed property.</summary>
         /// <param name="instance">The object to which the property belongs. If the property is static/shared, it must be null.</param>
         /// <param name="indexer">The <see cref="T:System.Reflection.PropertyInfo" /> that represents the property to index.</param>
         /// <param name="arguments">An <see cref="T:System.Collections.Generic.IEnumerable`1" /> of <see cref="T:System.Linq.Expressions.Expression" /> objects that are used to index the property.</param>
         /// <returns>The created <see cref="T:System.Linq.Expressions.IndexExpression" />.</returns>
-        public IndexExpression Property(Expression instance, PropertyInfo indexer, IEnumerable<Expression> arguments) => Expression.Property(instance, indexer, arguments);
+        public virtual IndexExpression Property(Expression instance, PropertyInfo indexer, IEnumerable<Expression> arguments) => Expression.Property(instance, indexer, arguments);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.MemberExpression" /> that represents accessing a property or field.</summary>
         /// <param name="expression">An <see cref="T:System.Linq.Expressions.Expression" /> whose <see cref="P:System.Linq.Expressions.Expression.Type" /> contains a property or field named <paramref name="propertyOrFieldName" />. This can be null for static members.</param>
@@ -2195,59 +2198,59 @@ namespace System.Linq.Expressions
         /// <exception cref="T:System.ArgumentNullException">
         ///   <paramref name="expression" /> or <paramref name="propertyOrFieldName" /> is <see langword="null" />.</exception>
         /// <exception cref="T:System.ArgumentException">No property or field named <paramref name="propertyOrFieldName" /> is defined in <paramref name="expression" />.Type or its base types.</exception>
-        public MemberExpression PropertyOrField(Expression expression, String propertyOrFieldName) => Expression.PropertyOrField(expression, propertyOrFieldName);
+        public virtual MemberExpression PropertyOrField(Expression expression, String propertyOrFieldName) => Expression.PropertyOrField(expression, propertyOrFieldName);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.UnaryExpression" /> that represents an expression that has a constant value of type <see cref="T:System.Linq.Expressions.Expression" />.</summary>
         /// <param name="expression">An <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.UnaryExpression.Operand" /> property equal to.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.UnaryExpression" /> that has the <see cref="P:System.Linq.Expressions.Expression.NodeType" /> property equal to <see cref="F:System.Linq.Expressions.ExpressionType.Quote" /> and the <see cref="P:System.Linq.Expressions.UnaryExpression.Operand" /> property set to the specified value.</returns>
         /// <exception cref="T:System.ArgumentNullException">
         ///   <paramref name="expression" /> is <see langword="null" />.</exception>
-        public UnaryExpression Quote(Expression expression) => Expression.Quote(expression);
+        public virtual UnaryExpression Quote(Expression expression) => Expression.Quote(expression);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.BinaryExpression" /> that represents a reference equality comparison.</summary>
         /// <param name="left">An <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Left" /> property equal to.</param>
         /// <param name="right">An <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Right" /> property equal to.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.BinaryExpression" /> that has the <see cref="P:System.Linq.Expressions.Expression.NodeType" /> property equal to <see cref="F:System.Linq.Expressions.ExpressionType.Equal" /> and the <see cref="P:System.Linq.Expressions.BinaryExpression.Left" /> and <see cref="P:System.Linq.Expressions.BinaryExpression.Right" /> properties set to the specified values.</returns>
-        public BinaryExpression ReferenceEqual(Expression left, Expression right) => Expression.ReferenceEqual(left, right);
+        public virtual BinaryExpression ReferenceEqual(Expression left, Expression right) => Expression.ReferenceEqual(left, right);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.BinaryExpression" /> that represents a reference inequality comparison.</summary>
         /// <param name="left">An <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Left" /> property equal to.</param>
         /// <param name="right">An <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Right" /> property equal to.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.BinaryExpression" /> that has the <see cref="P:System.Linq.Expressions.Expression.NodeType" /> property equal to <see cref="F:System.Linq.Expressions.ExpressionType.NotEqual" /> and the <see cref="P:System.Linq.Expressions.BinaryExpression.Left" /> and <see cref="P:System.Linq.Expressions.BinaryExpression.Right" /> properties set to the specified values.</returns>
-        public BinaryExpression ReferenceNotEqual(Expression left, Expression right) => Expression.ReferenceNotEqual(left, right);
+        public virtual BinaryExpression ReferenceNotEqual(Expression left, Expression right) => Expression.ReferenceNotEqual(left, right);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.UnaryExpression" /> that represents a rethrowing of an exception.</summary>
         /// <returns>A <see cref="T:System.Linq.Expressions.UnaryExpression" /> that represents a rethrowing of an exception.</returns>
-        public UnaryExpression Rethrow() => Expression.Rethrow();
+        public virtual UnaryExpression Rethrow() => Expression.Rethrow();
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.UnaryExpression" /> that represents a rethrowing of an exception with a given type.</summary>
         /// <param name="type">The new <see cref="T:System.Type" /> of the expression.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.UnaryExpression" /> that represents a rethrowing of an exception.</returns>
-        public UnaryExpression Rethrow(Type type) => Expression.Rethrow(type);
+        public virtual UnaryExpression Rethrow(Type type) => Expression.Rethrow(type);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.GotoExpression" /> representing a return statement.</summary>
         /// <param name="target">The <see cref="T:System.Linq.Expressions.LabelTarget" /> that the <see cref="T:System.Linq.Expressions.GotoExpression" /> will jump to.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.GotoExpression" /> with <see cref="P:System.Linq.Expressions.GotoExpression.Kind" /> equal to Return, the <see cref="P:System.Linq.Expressions.GotoExpression.Target" /> property set to <paramref name="target" />, and a null value to be passed to the target label upon jumping.</returns>
-        public GotoExpression Return(LabelTarget target) => Expression.Return(target);
+        public virtual GotoExpression Return(LabelTarget target) => Expression.Return(target);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.GotoExpression" /> representing a return statement with the specified type.</summary>
         /// <param name="target">The <see cref="T:System.Linq.Expressions.LabelTarget" /> that the <see cref="T:System.Linq.Expressions.GotoExpression" /> will jump to.</param>
         /// <param name="type">An <see cref="T:System.Type" /> to set the <see cref="P:System.Linq.Expressions.Expression.Type" /> property equal to.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.GotoExpression" /> with <see cref="P:System.Linq.Expressions.GotoExpression.Kind" /> equal to Return, the <see cref="P:System.Linq.Expressions.GotoExpression.Target" /> property set to <paramref name="target" />, the <see cref="P:System.Linq.Expressions.Expression.Type" /> property set to <paramref name="type" />, and a null value to be passed to the target label upon jumping.</returns>
-        public GotoExpression Return(LabelTarget target, Type type) => Expression.Return(target, type);
+        public virtual GotoExpression Return(LabelTarget target, Type type) => Expression.Return(target, type);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.GotoExpression" /> representing a return statement. The value passed to the label upon jumping can be specified.</summary>
         /// <param name="target">The <see cref="T:System.Linq.Expressions.LabelTarget" /> that the <see cref="T:System.Linq.Expressions.GotoExpression" /> will jump to.</param>
         /// <param name="value">The value that will be passed to the associated label upon jumping.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.GotoExpression" /> with <see cref="P:System.Linq.Expressions.GotoExpression.Kind" /> equal to Continue, the <see cref="P:System.Linq.Expressions.GotoExpression.Target" /> property set to <paramref name="target" />, and <paramref name="value" /> to be passed to the target label upon jumping.</returns>
-        public GotoExpression Return(LabelTarget target, Expression value) => Expression.Return(target, value);
+        public virtual GotoExpression Return(LabelTarget target, Expression value) => Expression.Return(target, value);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.GotoExpression" /> representing a return statement with the specified type. The value passed to the label upon jumping can be specified.</summary>
         /// <param name="target">The <see cref="T:System.Linq.Expressions.LabelTarget" /> that the <see cref="T:System.Linq.Expressions.GotoExpression" /> will jump to.</param>
         /// <param name="value">The value that will be passed to the associated label upon jumping.</param>
         /// <param name="type">An <see cref="T:System.Type" /> to set the <see cref="P:System.Linq.Expressions.Expression.Type" /> property equal to.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.GotoExpression" /> with <see cref="P:System.Linq.Expressions.GotoExpression.Kind" /> equal to Continue, the <see cref="P:System.Linq.Expressions.GotoExpression.Target" /> property set to <paramref name="target" />, the <see cref="P:System.Linq.Expressions.Expression.Type" /> property set to <paramref name="type" />, and <paramref name="value" /> to be passed to the target label upon jumping.</returns>
-        public GotoExpression Return(LabelTarget target, Expression value, Type type) => Expression.Return(target, value, type);
+        public virtual GotoExpression Return(LabelTarget target, Expression value, Type type) => Expression.Return(target, value, type);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.BinaryExpression" /> that represents a bitwise right-shift operation.</summary>
         /// <param name="left">An <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Left" /> property equal to.</param>
@@ -2256,7 +2259,7 @@ namespace System.Linq.Expressions
         /// <exception cref="T:System.ArgumentNullException">
         ///   <paramref name="left" /> or <paramref name="right" /> is <see langword="null" />.</exception>
         /// <exception cref="T:System.InvalidOperationException">The right-shift operator is not defined for <paramref name="left" />.Type and <paramref name="right" />.Type.</exception>
-        public BinaryExpression RightShift(Expression left, Expression right) => Expression.RightShift(left, right);
+        public virtual BinaryExpression RightShift(Expression left, Expression right) => Expression.RightShift(left, right);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.BinaryExpression" /> that represents a bitwise right-shift operation.</summary>
         /// <param name="left">An <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Left" /> property equal to.</param>
@@ -2269,20 +2272,20 @@ namespace System.Linq.Expressions
         ///   <paramref name="method" /> is not <see langword="null" /> and the method it represents returns <see langword="void" />, is not <see langword="static" /> (<see langword="Shared" /> in Visual Basic), or does not take exactly two arguments.</exception>
         /// <exception cref="T:System.InvalidOperationException">
         ///   <paramref name="method" /> is <see langword="null" /> and the right-shift operator is not defined for <paramref name="left" />.Type and <paramref name="right" />.Type.</exception>
-        public BinaryExpression RightShift(Expression left, Expression right, MethodInfo method) => Expression.RightShift(left, right, method);
+        public virtual BinaryExpression RightShift(Expression left, Expression right, MethodInfo method) => Expression.RightShift(left, right, method);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.BinaryExpression" /> that represents a bitwise right-shift assignment operation.</summary>
         /// <param name="left">An <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Left" /> property equal to.</param>
         /// <param name="right">An <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Right" /> property equal to.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.BinaryExpression" /> that has the <see cref="P:System.Linq.Expressions.Expression.NodeType" /> property equal to <see cref="F:System.Linq.Expressions.ExpressionType.RightShiftAssign" /> and the <see cref="P:System.Linq.Expressions.BinaryExpression.Left" /> and <see cref="P:System.Linq.Expressions.BinaryExpression.Right" /> properties set to the specified values.</returns>
-        public BinaryExpression RightShiftAssign(Expression left, Expression right) => Expression.RightShiftAssign(left, right);
+        public virtual BinaryExpression RightShiftAssign(Expression left, Expression right) => Expression.RightShiftAssign(left, right);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.BinaryExpression" /> that represents a bitwise right-shift assignment operation.</summary>
         /// <param name="left">An <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Left" /> property equal to.</param>
         /// <param name="right">An <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Right" /> property equal to.</param>
         /// <param name="method">A <see cref="T:System.Reflection.MethodInfo" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Method" /> property equal to.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.BinaryExpression" /> that has the <see cref="P:System.Linq.Expressions.Expression.NodeType" /> property equal to <see cref="F:System.Linq.Expressions.ExpressionType.RightShiftAssign" /> and the <see cref="P:System.Linq.Expressions.BinaryExpression.Left" />, <see cref="P:System.Linq.Expressions.BinaryExpression.Right" />, and <see cref="P:System.Linq.Expressions.BinaryExpression.Method" /> properties set to the specified values.</returns>
-        public BinaryExpression RightShiftAssign(Expression left, Expression right, MethodInfo method) => Expression.RightShiftAssign(left, right, method);
+        public virtual BinaryExpression RightShiftAssign(Expression left, Expression right, MethodInfo method) => Expression.RightShiftAssign(left, right, method);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.BinaryExpression" /> that represents a bitwise right-shift assignment operation.</summary>
         /// <param name="left">An <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Left" /> property equal to.</param>
@@ -2290,17 +2293,17 @@ namespace System.Linq.Expressions
         /// <param name="method">A <see cref="T:System.Reflection.MethodInfo" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Method" /> property equal to.</param>
         /// <param name="conversion">A <see cref="T:System.Linq.Expressions.LambdaExpression" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Conversion" /> property equal to.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.BinaryExpression" /> that has the <see cref="P:System.Linq.Expressions.Expression.NodeType" /> property equal to <see cref="F:System.Linq.Expressions.ExpressionType.RightShiftAssign" /> and the <see cref="P:System.Linq.Expressions.BinaryExpression.Left" />, <see cref="P:System.Linq.Expressions.BinaryExpression.Right" />, <see cref="P:System.Linq.Expressions.BinaryExpression.Method" />, and <see cref="P:System.Linq.Expressions.BinaryExpression.Conversion" /> properties set to the specified values.</returns>
-        public BinaryExpression RightShiftAssign(Expression left, Expression right, MethodInfo method, LambdaExpression conversion) => Expression.RightShiftAssign(left, right, method, conversion);
+        public virtual BinaryExpression RightShiftAssign(Expression left, Expression right, MethodInfo method, LambdaExpression conversion) => Expression.RightShiftAssign(left, right, method, conversion);
 
         /// <summary>Creates an instance of <see cref="T:System.Linq.Expressions.RuntimeVariablesExpression" />.</summary>
         /// <param name="variables">An array of <see cref="T:System.Linq.Expressions.ParameterExpression" /> objects to use to populate the <see cref="P:System.Linq.Expressions.RuntimeVariablesExpression.Variables" /> collection.</param>
         /// <returns>An instance of <see cref="T:System.Linq.Expressions.RuntimeVariablesExpression" /> that has the <see cref="P:System.Linq.Expressions.Expression.NodeType" /> property equal to <see cref="F:System.Linq.Expressions.ExpressionType.RuntimeVariables" /> and the <see cref="P:System.Linq.Expressions.RuntimeVariablesExpression.Variables" /> property set to the specified value.</returns>
-        public RuntimeVariablesExpression RuntimeVariables(ParameterExpression[] variables) => Expression.RuntimeVariables(variables);
+        public virtual RuntimeVariablesExpression RuntimeVariables(ParameterExpression[] variables) => Expression.RuntimeVariables(variables);
 
         /// <summary>Creates an instance of <see cref="T:System.Linq.Expressions.RuntimeVariablesExpression" />.</summary>
         /// <param name="variables">A collection of <see cref="T:System.Linq.Expressions.ParameterExpression" /> objects to use to populate the <see cref="P:System.Linq.Expressions.RuntimeVariablesExpression.Variables" /> collection.</param>
         /// <returns>An instance of <see cref="T:System.Linq.Expressions.RuntimeVariablesExpression" /> that has the <see cref="P:System.Linq.Expressions.Expression.NodeType" /> property equal to <see cref="F:System.Linq.Expressions.ExpressionType.RuntimeVariables" /> and the <see cref="P:System.Linq.Expressions.RuntimeVariablesExpression.Variables" /> property set to the specified value.</returns>
-        public RuntimeVariablesExpression RuntimeVariables(IEnumerable<ParameterExpression> variables) => Expression.RuntimeVariables(variables);
+        public virtual RuntimeVariablesExpression RuntimeVariables(IEnumerable<ParameterExpression> variables) => Expression.RuntimeVariables(variables);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.BinaryExpression" /> that represents an arithmetic subtraction operation that does not have overflow checking.</summary>
         /// <param name="left">An <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Left" /> property equal to.</param>
@@ -2309,7 +2312,7 @@ namespace System.Linq.Expressions
         /// <exception cref="T:System.ArgumentNullException">
         ///   <paramref name="left" /> or <paramref name="right" /> is <see langword="null" />.</exception>
         /// <exception cref="T:System.InvalidOperationException">The subtraction operator is not defined for <paramref name="left" />.Type and <paramref name="right" />.Type.</exception>
-        public BinaryExpression Subtract(Expression left, Expression right) => Expression.Subtract(left, right);
+        public virtual BinaryExpression Subtract(Expression left, Expression right) => Expression.Subtract(left, right);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.BinaryExpression" /> that represents an arithmetic subtraction operation that does not have overflow checking.</summary>
         /// <param name="left">A <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Left" /> property equal to.</param>
@@ -2322,20 +2325,20 @@ namespace System.Linq.Expressions
         ///   <paramref name="method" /> is not <see langword="null" /> and the method it represents returns <see langword="void" />, is not <see langword="static" /> (<see langword="Shared" /> in Visual Basic), or does not take exactly two arguments.</exception>
         /// <exception cref="T:System.InvalidOperationException">
         ///   <paramref name="method" /> is <see langword="null" /> and the subtraction operator is not defined for <paramref name="left" />.Type and <paramref name="right" />.Type.</exception>
-        public BinaryExpression Subtract(Expression left, Expression right, MethodInfo method) => Expression.Subtract(left, right, method);
+        public virtual BinaryExpression Subtract(Expression left, Expression right, MethodInfo method) => Expression.Subtract(left, right, method);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.BinaryExpression" /> that represents a subtraction assignment operation that does not have overflow checking.</summary>
         /// <param name="left">An <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Left" /> property equal to.</param>
         /// <param name="right">An <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Right" /> property equal to.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.BinaryExpression" /> that has the <see cref="P:System.Linq.Expressions.Expression.NodeType" /> property equal to <see cref="F:System.Linq.Expressions.ExpressionType.SubtractAssign" /> and the <see cref="P:System.Linq.Expressions.BinaryExpression.Left" /> and <see cref="P:System.Linq.Expressions.BinaryExpression.Right" /> properties set to the specified values.</returns>
-        public BinaryExpression SubtractAssign(Expression left, Expression right) => Expression.SubtractAssign(left, right);
+        public virtual BinaryExpression SubtractAssign(Expression left, Expression right) => Expression.SubtractAssign(left, right);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.BinaryExpression" /> that represents a subtraction assignment operation that does not have overflow checking.</summary>
         /// <param name="left">An <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Left" /> property equal to.</param>
         /// <param name="right">An <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Right" /> property equal to.</param>
         /// <param name="method">A <see cref="T:System.Reflection.MethodInfo" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Method" /> property equal to.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.BinaryExpression" /> that has the <see cref="P:System.Linq.Expressions.Expression.NodeType" /> property equal to <see cref="F:System.Linq.Expressions.ExpressionType.SubtractAssign" /> and the <see cref="P:System.Linq.Expressions.BinaryExpression.Left" />, <see cref="P:System.Linq.Expressions.BinaryExpression.Right" />, and <see cref="P:System.Linq.Expressions.BinaryExpression.Method" /> properties set to the specified values.</returns>
-        public BinaryExpression SubtractAssign(Expression left, Expression right, MethodInfo method) => Expression.SubtractAssign(left, right, method);
+        public virtual BinaryExpression SubtractAssign(Expression left, Expression right, MethodInfo method) => Expression.SubtractAssign(left, right, method);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.BinaryExpression" /> that represents a subtraction assignment operation that does not have overflow checking.</summary>
         /// <param name="left">An <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Left" /> property equal to.</param>
@@ -2343,20 +2346,20 @@ namespace System.Linq.Expressions
         /// <param name="method">A <see cref="T:System.Reflection.MethodInfo" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Method" /> property equal to.</param>
         /// <param name="conversion">A <see cref="T:System.Linq.Expressions.LambdaExpression" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Conversion" /> property equal to.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.BinaryExpression" /> that has the <see cref="P:System.Linq.Expressions.Expression.NodeType" /> property equal to <see cref="F:System.Linq.Expressions.ExpressionType.SubtractAssign" /> and the <see cref="P:System.Linq.Expressions.BinaryExpression.Left" />, <see cref="P:System.Linq.Expressions.BinaryExpression.Right" />, <see cref="P:System.Linq.Expressions.BinaryExpression.Method" />, and <see cref="P:System.Linq.Expressions.BinaryExpression.Conversion" /> properties set to the specified values.</returns>
-        public BinaryExpression SubtractAssign(Expression left, Expression right, MethodInfo method, LambdaExpression conversion) => Expression.SubtractAssign(left, right, method, conversion);
+        public virtual BinaryExpression SubtractAssign(Expression left, Expression right, MethodInfo method, LambdaExpression conversion) => Expression.SubtractAssign(left, right, method, conversion);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.BinaryExpression" /> that represents a subtraction assignment operation that has overflow checking.</summary>
         /// <param name="left">An <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Left" /> property equal to.</param>
         /// <param name="right">An <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Right" /> property equal to.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.BinaryExpression" /> that has the <see cref="P:System.Linq.Expressions.Expression.NodeType" /> property equal to <see cref="F:System.Linq.Expressions.ExpressionType.SubtractAssignChecked" /> and the <see cref="P:System.Linq.Expressions.BinaryExpression.Left" /> and <see cref="P:System.Linq.Expressions.BinaryExpression.Right" /> properties set to the specified values.</returns>
-        public BinaryExpression SubtractAssignChecked(Expression left, Expression right) => Expression.SubtractAssignChecked(left, right);
+        public virtual BinaryExpression SubtractAssignChecked(Expression left, Expression right) => Expression.SubtractAssignChecked(left, right);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.BinaryExpression" /> that represents a subtraction assignment operation that has overflow checking.</summary>
         /// <param name="left">An <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Left" /> property equal to.</param>
         /// <param name="right">An <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Right" /> property equal to.</param>
         /// <param name="method">A <see cref="T:System.Reflection.MethodInfo" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Method" /> property equal to.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.BinaryExpression" /> that has the <see cref="P:System.Linq.Expressions.Expression.NodeType" /> property equal to <see cref="F:System.Linq.Expressions.ExpressionType.SubtractAssignChecked" /> and the <see cref="P:System.Linq.Expressions.BinaryExpression.Left" />, <see cref="P:System.Linq.Expressions.BinaryExpression.Right" />, and <see cref="P:System.Linq.Expressions.BinaryExpression.Method" /> properties set to the specified values.</returns>
-        public BinaryExpression SubtractAssignChecked(Expression left, Expression right, MethodInfo method) => Expression.SubtractAssignChecked(left, right, method);
+        public virtual BinaryExpression SubtractAssignChecked(Expression left, Expression right, MethodInfo method) => Expression.SubtractAssignChecked(left, right, method);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.BinaryExpression" /> that represents a subtraction assignment operation that has overflow checking.</summary>
         /// <param name="left">An <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Left" /> property equal to.</param>
@@ -2364,7 +2367,7 @@ namespace System.Linq.Expressions
         /// <param name="method">A <see cref="T:System.Reflection.MethodInfo" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Method" /> property equal to.</param>
         /// <param name="conversion">A <see cref="T:System.Linq.Expressions.LambdaExpression" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Conversion" /> property equal to.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.BinaryExpression" /> that has the <see cref="P:System.Linq.Expressions.Expression.NodeType" /> property equal to <see cref="F:System.Linq.Expressions.ExpressionType.SubtractAssignChecked" /> and the <see cref="P:System.Linq.Expressions.BinaryExpression.Left" />, <see cref="P:System.Linq.Expressions.BinaryExpression.Right" />, <see cref="P:System.Linq.Expressions.BinaryExpression.Method" />, and <see cref="P:System.Linq.Expressions.BinaryExpression.Conversion" /> properties set to the specified values.</returns>
-        public BinaryExpression SubtractAssignChecked(Expression left, Expression right, MethodInfo method, LambdaExpression conversion) => Expression.SubtractAssignChecked(left, right, method, conversion);
+        public virtual BinaryExpression SubtractAssignChecked(Expression left, Expression right, MethodInfo method, LambdaExpression conversion) => Expression.SubtractAssignChecked(left, right, method, conversion);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.BinaryExpression" /> that represents an arithmetic subtraction operation that has overflow checking.</summary>
         /// <param name="left">A <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Left" /> property equal to.</param>
@@ -2373,7 +2376,7 @@ namespace System.Linq.Expressions
         /// <exception cref="T:System.ArgumentNullException">
         ///   <paramref name="left" /> or <paramref name="right" /> is <see langword="null" />.</exception>
         /// <exception cref="T:System.InvalidOperationException">The subtraction operator is not defined for <paramref name="left" />.Type and <paramref name="right" />.Type.</exception>
-        public BinaryExpression SubtractChecked(Expression left, Expression right) => Expression.SubtractChecked(left, right);
+        public virtual BinaryExpression SubtractChecked(Expression left, Expression right) => Expression.SubtractChecked(left, right);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.BinaryExpression" /> that represents an arithmetic subtraction operation that has overflow checking.</summary>
         /// <param name="left">A <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Left" /> property equal to.</param>
@@ -2386,28 +2389,20 @@ namespace System.Linq.Expressions
         ///   <paramref name="method" /> is not <see langword="null" /> and the method it represents returns <see langword="void" />, is not <see langword="static" /> (<see langword="Shared" /> in Visual Basic), or does not take exactly two arguments.</exception>
         /// <exception cref="T:System.InvalidOperationException">
         ///   <paramref name="method" /> is <see langword="null" /> and the subtraction operator is not defined for <paramref name="left" />.Type and <paramref name="right" />.Type.</exception>
-        public BinaryExpression SubtractChecked(Expression left, Expression right, MethodInfo method) => Expression.SubtractChecked(left, right, method);
+        public virtual BinaryExpression SubtractChecked(Expression left, Expression right, MethodInfo method) => Expression.SubtractChecked(left, right, method);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.SwitchExpression" /> that represents a <see langword="switch" /> statement without a default case.</summary>
         /// <param name="switchValue">The value to be tested against each case.</param>
         /// <param name="cases">The set of cases for this switch expression.</param>
         /// <returns>The created <see cref="T:System.Linq.Expressions.SwitchExpression" />.</returns>
-        public SwitchExpression Switch(Expression switchValue, SwitchCase[] cases) => Expression.Switch(switchValue, cases);
+        public virtual SwitchExpression Switch(Expression switchValue, SwitchCase[] cases) => Expression.Switch(switchValue, cases);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.SwitchExpression" /> that represents a <see langword="switch" /> statement that has a default case.</summary>
         /// <param name="switchValue">The value to be tested against each case.</param>
         /// <param name="defaultBody">The result of the switch if <paramref name="switchValue" /> does not match any of the cases.</param>
         /// <param name="cases">The set of cases for this switch expression.</param>
         /// <returns>The created <see cref="T:System.Linq.Expressions.SwitchExpression" />.</returns>
-        public SwitchExpression Switch(Expression switchValue, Expression defaultBody, SwitchCase[] cases) => Expression.Switch(switchValue, defaultBody, cases);
-
-        /// <summary>Creates a <see cref="T:System.Linq.Expressions.SwitchExpression" /> that represents a <see langword="switch" /> statement that has a default case.</summary>
-        /// <param name="switchValue">The value to be tested against each case.</param>
-        /// <param name="defaultBody">The result of the switch if <paramref name="switchValue" /> does not match any of the cases.</param>
-        /// <param name="comparison">The equality comparison method to use.</param>
-        /// <param name="cases">The set of cases for this switch expression.</param>
-        /// <returns>The created <see cref="T:System.Linq.Expressions.SwitchExpression" />.</returns>
-        public SwitchExpression Switch(Expression switchValue, Expression defaultBody, MethodInfo comparison, SwitchCase[] cases) => Expression.Switch(switchValue, defaultBody, comparison, cases);
+        public virtual SwitchExpression Switch(Expression switchValue, Expression defaultBody, SwitchCase[] cases) => Expression.Switch(switchValue, defaultBody, cases);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.SwitchExpression" /> that represents a <see langword="switch" /> statement that has a default case.</summary>
         /// <param name="switchValue">The value to be tested against each case.</param>
@@ -2415,7 +2410,15 @@ namespace System.Linq.Expressions
         /// <param name="comparison">The equality comparison method to use.</param>
         /// <param name="cases">The set of cases for this switch expression.</param>
         /// <returns>The created <see cref="T:System.Linq.Expressions.SwitchExpression" />.</returns>
-        public SwitchExpression Switch(Expression switchValue, Expression defaultBody, MethodInfo comparison, IEnumerable<SwitchCase> cases) => Expression.Switch(switchValue, defaultBody, comparison, cases);
+        public virtual SwitchExpression Switch(Expression switchValue, Expression defaultBody, MethodInfo comparison, SwitchCase[] cases) => Expression.Switch(switchValue, defaultBody, comparison, cases);
+
+        /// <summary>Creates a <see cref="T:System.Linq.Expressions.SwitchExpression" /> that represents a <see langword="switch" /> statement that has a default case.</summary>
+        /// <param name="switchValue">The value to be tested against each case.</param>
+        /// <param name="defaultBody">The result of the switch if <paramref name="switchValue" /> does not match any of the cases.</param>
+        /// <param name="comparison">The equality comparison method to use.</param>
+        /// <param name="cases">The set of cases for this switch expression.</param>
+        /// <returns>The created <see cref="T:System.Linq.Expressions.SwitchExpression" />.</returns>
+        public virtual SwitchExpression Switch(Expression switchValue, Expression defaultBody, MethodInfo comparison, IEnumerable<SwitchCase> cases) => Expression.Switch(switchValue, defaultBody, comparison, cases);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.SwitchExpression" /> that represents a <see langword="switch" /> statement that has a default case.</summary>
         /// <param name="type">The result type of the switch.</param>
@@ -2424,7 +2427,7 @@ namespace System.Linq.Expressions
         /// <param name="comparison">The equality comparison method to use.</param>
         /// <param name="cases">The set of cases for this switch expression.</param>
         /// <returns>The created <see cref="T:System.Linq.Expressions.SwitchExpression" />.</returns>
-        public SwitchExpression Switch(Type type, Expression switchValue, Expression defaultBody, MethodInfo comparison, IEnumerable<SwitchCase> cases) => Expression.Switch(type, switchValue, defaultBody, comparison, cases);
+        public virtual SwitchExpression Switch(Type type, Expression switchValue, Expression defaultBody, MethodInfo comparison, IEnumerable<SwitchCase> cases) => Expression.Switch(type, switchValue, defaultBody, comparison, cases);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.SwitchExpression" /> that represents a <see langword="switch" /> statement that has a default case..</summary>
         /// <param name="type">The result type of the switch.</param>
@@ -2433,37 +2436,37 @@ namespace System.Linq.Expressions
         /// <param name="comparison">The equality comparison method to use.</param>
         /// <param name="cases">The set of cases for this switch expression.</param>
         /// <returns>The created <see cref="T:System.Linq.Expressions.SwitchExpression" />.</returns>
-        public SwitchExpression Switch(Type type, Expression switchValue, Expression defaultBody, MethodInfo comparison, SwitchCase[] cases) => Expression.Switch(type, switchValue, defaultBody, comparison, cases);
+        public virtual SwitchExpression Switch(Type type, Expression switchValue, Expression defaultBody, MethodInfo comparison, SwitchCase[] cases) => Expression.Switch(type, switchValue, defaultBody, comparison, cases);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.SwitchCase" /> for use in a <see cref="T:System.Linq.Expressions.SwitchExpression" />.</summary>
         /// <param name="body">The body of the case.</param>
         /// <param name="testValues">The test values of the case.</param>
         /// <returns>The created <see cref="T:System.Linq.Expressions.SwitchCase" />.</returns>
-        public SwitchCase SwitchCase(Expression body, Expression[] testValues) => Expression.SwitchCase(body, testValues);
+        public virtual SwitchCase SwitchCase(Expression body, Expression[] testValues) => Expression.SwitchCase(body, testValues);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.SwitchCase" /> object to be used in a <see cref="T:System.Linq.Expressions.SwitchExpression" /> object.</summary>
         /// <param name="body">The body of the case.</param>
         /// <param name="testValues">The test values of the case.</param>
         /// <returns>The created <see cref="T:System.Linq.Expressions.SwitchCase" />.</returns>
-        public SwitchCase SwitchCase(Expression body, IEnumerable<Expression> testValues) => Expression.SwitchCase(body, testValues);
+        public virtual SwitchCase SwitchCase(Expression body, IEnumerable<Expression> testValues) => Expression.SwitchCase(body, testValues);
 
         /// <summary>Creates an instance of <see cref="T:System.Linq.Expressions.SymbolDocumentInfo" />.</summary>
         /// <param name="fileName">A <see cref="T:System.String" /> to set the <see cref="P:System.Linq.Expressions.SymbolDocumentInfo.FileName" /> equal to.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.SymbolDocumentInfo" /> that has the <see cref="P:System.Linq.Expressions.SymbolDocumentInfo.FileName" /> property set to the specified value.</returns>
-        public SymbolDocumentInfo SymbolDocument(String fileName) => Expression.SymbolDocument(fileName);
+        public virtual SymbolDocumentInfo SymbolDocument(String fileName) => Expression.SymbolDocument(fileName);
 
         /// <summary>Creates an instance of <see cref="T:System.Linq.Expressions.SymbolDocumentInfo" />.</summary>
         /// <param name="fileName">A <see cref="T:System.String" /> to set the <see cref="P:System.Linq.Expressions.SymbolDocumentInfo.FileName" /> equal to.</param>
         /// <param name="language">A <see cref="T:System.Guid" /> to set the <see cref="P:System.Linq.Expressions.SymbolDocumentInfo.Language" /> equal to.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.SymbolDocumentInfo" /> that has the <see cref="P:System.Linq.Expressions.SymbolDocumentInfo.FileName" /> and <see cref="P:System.Linq.Expressions.SymbolDocumentInfo.Language" /> properties set to the specified value.</returns>
-        public SymbolDocumentInfo SymbolDocument(String fileName, Guid language) => Expression.SymbolDocument(fileName, language);
+        public virtual SymbolDocumentInfo SymbolDocument(String fileName, Guid language) => Expression.SymbolDocument(fileName, language);
 
         /// <summary>Creates an instance of <see cref="T:System.Linq.Expressions.SymbolDocumentInfo" />.</summary>
         /// <param name="fileName">A <see cref="T:System.String" /> to set the <see cref="P:System.Linq.Expressions.SymbolDocumentInfo.FileName" /> equal to.</param>
         /// <param name="language">A <see cref="T:System.Guid" /> to set the <see cref="P:System.Linq.Expressions.SymbolDocumentInfo.Language" /> equal to.</param>
         /// <param name="languageVendor">A <see cref="T:System.Guid" /> to set the <see cref="P:System.Linq.Expressions.SymbolDocumentInfo.LanguageVendor" /> equal to.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.SymbolDocumentInfo" /> that has the <see cref="P:System.Linq.Expressions.SymbolDocumentInfo.FileName" /> and <see cref="P:System.Linq.Expressions.SymbolDocumentInfo.Language" /> and <see cref="P:System.Linq.Expressions.SymbolDocumentInfo.LanguageVendor" /> properties set to the specified value.</returns>
-        public SymbolDocumentInfo SymbolDocument(String fileName, Guid language, Guid languageVendor) => Expression.SymbolDocument(fileName, language, languageVendor);
+        public virtual SymbolDocumentInfo SymbolDocument(String fileName, Guid language, Guid languageVendor) => Expression.SymbolDocument(fileName, language, languageVendor);
 
         /// <summary>Creates an instance of <see cref="T:System.Linq.Expressions.SymbolDocumentInfo" />.</summary>
         /// <param name="fileName">A <see cref="T:System.String" /> to set the <see cref="P:System.Linq.Expressions.SymbolDocumentInfo.FileName" /> equal to.</param>
@@ -2471,43 +2474,43 @@ namespace System.Linq.Expressions
         /// <param name="languageVendor">A <see cref="T:System.Guid" /> to set the <see cref="P:System.Linq.Expressions.SymbolDocumentInfo.LanguageVendor" /> equal to.</param>
         /// <param name="documentType">A <see cref="T:System.Guid" /> to set the <see cref="P:System.Linq.Expressions.SymbolDocumentInfo.DocumentType" /> equal to.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.SymbolDocumentInfo" /> that has the <see cref="P:System.Linq.Expressions.SymbolDocumentInfo.FileName" /> and <see cref="P:System.Linq.Expressions.SymbolDocumentInfo.Language" /> and <see cref="P:System.Linq.Expressions.SymbolDocumentInfo.LanguageVendor" /> and <see cref="P:System.Linq.Expressions.SymbolDocumentInfo.DocumentType" /> properties set to the specified value.</returns>
-        public SymbolDocumentInfo SymbolDocument(String fileName, Guid language, Guid languageVendor, Guid documentType) => Expression.SymbolDocument(fileName, language, languageVendor, documentType);
+        public virtual SymbolDocumentInfo SymbolDocument(String fileName, Guid language, Guid languageVendor, Guid documentType) => Expression.SymbolDocument(fileName, language, languageVendor, documentType);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.UnaryExpression" /> that represents a throwing of an exception.</summary>
         /// <param name="value">An <see cref="T:System.Linq.Expressions.Expression" />.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.UnaryExpression" /> that represents the exception.</returns>
-        public UnaryExpression Throw(Expression value) => Expression.Throw(value);
+        public virtual UnaryExpression Throw(Expression value) => Expression.Throw(value);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.UnaryExpression" /> that represents a throwing of an exception with a given type.</summary>
         /// <param name="value">An <see cref="T:System.Linq.Expressions.Expression" />.</param>
         /// <param name="type">The new <see cref="T:System.Type" /> of the expression.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.UnaryExpression" /> that represents the exception.</returns>
-        public UnaryExpression Throw(Expression value, Type type) => Expression.Throw(value, type);
+        public virtual UnaryExpression Throw(Expression value, Type type) => Expression.Throw(value, type);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.TryExpression" /> representing a try block with any number of catch statements and neither a fault nor finally block.</summary>
         /// <param name="body">The body of the try block.</param>
         /// <param name="handlers">The array of zero or more <see cref="T:System.Linq.Expressions.CatchBlock" /> expressions representing the catch statements to be associated with the try block.</param>
         /// <returns>The created <see cref="T:System.Linq.Expressions.TryExpression" />.</returns>
-        public TryExpression TryCatch(Expression body, CatchBlock[] handlers) => Expression.TryCatch(body, handlers);
+        public virtual TryExpression TryCatch(Expression body, CatchBlock[] handlers) => Expression.TryCatch(body, handlers);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.TryExpression" /> representing a try block with any number of catch statements and a finally block.</summary>
         /// <param name="body">The body of the try block.</param>
         /// <param name="finally">The body of the finally block.</param>
         /// <param name="handlers">The array of zero or more <see cref="T:System.Linq.Expressions.CatchBlock" /> expressions representing the catch statements to be associated with the try block.</param>
         /// <returns>The created <see cref="T:System.Linq.Expressions.TryExpression" />.</returns>
-        public TryExpression TryCatchFinally(Expression body, Expression @finally, CatchBlock[] handlers) => Expression.TryCatchFinally(body, @finally, handlers);
+        public virtual TryExpression TryCatchFinally(Expression body, Expression @finally, CatchBlock[] handlers) => Expression.TryCatchFinally(body, @finally, handlers);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.TryExpression" /> representing a try block with a fault block and no catch statements.</summary>
         /// <param name="body">The body of the try block.</param>
         /// <param name="fault">The body of the fault block.</param>
         /// <returns>The created <see cref="T:System.Linq.Expressions.TryExpression" />.</returns>
-        public TryExpression TryFault(Expression body, Expression fault) => Expression.TryFault(body, fault);
+        public virtual TryExpression TryFault(Expression body, Expression fault) => Expression.TryFault(body, fault);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.TryExpression" /> representing a try block with a finally block and no catch statements.</summary>
         /// <param name="body">The body of the try block.</param>
         /// <param name="finally">The body of the finally block.</param>
         /// <returns>The created <see cref="T:System.Linq.Expressions.TryExpression" />.</returns>
-        public TryExpression TryFinally(Expression body, Expression @finally) => Expression.TryFinally(body, @finally);
+        public virtual TryExpression TryFinally(Expression body, Expression @finally) => Expression.TryFinally(body, @finally);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.UnaryExpression" /> that represents an explicit reference or boxing conversion where <see langword="null" /> is supplied if the conversion fails.</summary>
         /// <param name="expression">An <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.UnaryExpression.Operand" /> property equal to.</param>
@@ -2515,13 +2518,13 @@ namespace System.Linq.Expressions
         /// <returns>A <see cref="T:System.Linq.Expressions.UnaryExpression" /> that has the <see cref="P:System.Linq.Expressions.Expression.NodeType" /> property equal to <see cref="F:System.Linq.Expressions.ExpressionType.TypeAs" /> and the <see cref="P:System.Linq.Expressions.UnaryExpression.Operand" /> and <see cref="P:System.Linq.Expressions.Expression.Type" /> properties set to the specified values.</returns>
         /// <exception cref="T:System.ArgumentNullException">
         ///   <paramref name="expression" /> or <paramref name="type" /> is <see langword="null" />.</exception>
-        public UnaryExpression TypeAs(Expression expression, Type type) => Expression.TypeAs(expression, type);
+        public virtual UnaryExpression TypeAs(Expression expression, Type type) => Expression.TypeAs(expression, type);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.TypeBinaryExpression" /> that compares run-time type identity.</summary>
         /// <param name="expression">An <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="T:System.Linq.Expressions.Expression" /> property equal to.</param>
         /// <param name="type">A <see cref="P:System.Linq.Expressions.Expression.Type" /> to set the <see cref="P:System.Linq.Expressions.TypeBinaryExpression.TypeOperand" /> property equal to.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.TypeBinaryExpression" /> for which the <see cref="P:System.Linq.Expressions.Expression.NodeType" /> property is equal to <see cref="M:System.Linq.Expressions.Expression.TypeEqual(System.Linq.Expressions.Expression,System.Type)" /> and for which the <see cref="T:System.Linq.Expressions.Expression" /> and <see cref="P:System.Linq.Expressions.TypeBinaryExpression.TypeOperand" /> properties are set to the specified values.</returns>
-        public TypeBinaryExpression TypeEqual(Expression expression, Type type) => Expression.TypeEqual(expression, type);
+        public virtual TypeBinaryExpression TypeEqual(Expression expression, Type type) => Expression.TypeEqual(expression, type);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.TypeBinaryExpression" />.</summary>
         /// <param name="expression">An <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.TypeBinaryExpression.Expression" /> property equal to.</param>
@@ -2529,7 +2532,7 @@ namespace System.Linq.Expressions
         /// <returns>A <see cref="T:System.Linq.Expressions.TypeBinaryExpression" /> for which the <see cref="P:System.Linq.Expressions.Expression.NodeType" /> property is equal to <see cref="F:System.Linq.Expressions.ExpressionType.TypeIs" /> and for which the <see cref="P:System.Linq.Expressions.TypeBinaryExpression.Expression" /> and <see cref="P:System.Linq.Expressions.TypeBinaryExpression.TypeOperand" /> properties are set to the specified values.</returns>
         /// <exception cref="T:System.ArgumentNullException">
         ///   <paramref name="expression" /> or <paramref name="type" /> is <see langword="null" />.</exception>
-        public TypeBinaryExpression TypeIs(Expression expression, Type type) => Expression.TypeIs(expression, type);
+        public virtual TypeBinaryExpression TypeIs(Expression expression, Type type) => Expression.TypeIs(expression, type);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.UnaryExpression" /> that represents a unary plus operation.</summary>
         /// <param name="expression">An <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.UnaryExpression.Operand" /> property equal to.</param>
@@ -2537,7 +2540,7 @@ namespace System.Linq.Expressions
         /// <exception cref="T:System.ArgumentNullException">
         ///   <paramref name="expression" /> is <see langword="null" />.</exception>
         /// <exception cref="T:System.InvalidOperationException">The unary plus operator is not defined for <paramref name="expression" />.Type.</exception>
-        public UnaryExpression UnaryPlus(Expression expression) => Expression.UnaryPlus(expression);
+        public virtual UnaryExpression UnaryPlus(Expression expression) => Expression.UnaryPlus(expression);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.UnaryExpression" /> that represents a unary plus operation.</summary>
         /// <param name="expression">An <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.UnaryExpression.Operand" /> property equal to.</param>
@@ -2550,24 +2553,24 @@ namespace System.Linq.Expressions
         /// <exception cref="T:System.InvalidOperationException">
         ///   <paramref name="method" /> is <see langword="null" /> and the unary plus operator is not defined for <paramref name="expression" />.Type.-or-
         ///               <paramref name="expression" />.Type (or its corresponding non-nullable type if it is a nullable value type) is not assignable to the argument type of the method represented by <paramref name="method" />.</exception>
-        public UnaryExpression UnaryPlus(Expression expression, MethodInfo method) => Expression.UnaryPlus(expression, method);
+        public virtual UnaryExpression UnaryPlus(Expression expression, MethodInfo method) => Expression.UnaryPlus(expression, method);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.UnaryExpression" /> that represents an explicit unboxing.</summary>
         /// <param name="expression">An <see cref="T:System.Linq.Expressions.Expression" /> to unbox.</param>
         /// <param name="type">The new <see cref="T:System.Type" /> of the expression.</param>
         /// <returns>An instance of <see cref="T:System.Linq.Expressions.UnaryExpression" />.</returns>
-        public UnaryExpression Unbox(Expression expression, Type type) => Expression.Unbox(expression, type);
+        public virtual UnaryExpression Unbox(Expression expression, Type type) => Expression.Unbox(expression, type);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.ParameterExpression" /> node that can be used to identify a parameter or a variable in an expression tree.</summary>
         /// <param name="type">The type of the parameter or variable.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.ParameterExpression" /> node with the specified name and type</returns>
-        public ParameterExpression Variable(Type type) => Expression.Variable(type);
+        public virtual ParameterExpression Variable(Type type) => Expression.Variable(type);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.ParameterExpression" /> node that can be used to identify a parameter or a variable in an expression tree.</summary>
         /// <param name="type">The type of the parameter or variable.</param>
         /// <param name="name">The name of the parameter or variable. This name is used for debugging or printing purpose only.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.ParameterExpression" /> node with the specified name and type.</returns>
-        public ParameterExpression Variable(Type type, String name) => Expression.Variable(type, name);
+        public virtual ParameterExpression Variable(Type type, String name) => Expression.Variable(type, name);
 
     }
 }

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices/Expressions/ExpressionFactory.tt
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices/Expressions/ExpressionFactory.tt
@@ -50,14 +50,17 @@ namespace System.Linq.Expressions
     /// <summary>
     /// Factory for expression trees that uses the default factory methods on <see cref="T:System.Linq.Expressions.Expression" />.
     /// </summary>
-    public sealed class ExpressionFactory : IExpressionFactory
+    public class ExpressionFactory : IExpressionFactory
     {
         /// <summary>
-        /// Gets the singleton instance of the factory.
+        /// Gets a singleton instance of the factory.
         /// </summary>
-        public static readonly IExpressionFactory Instance = new ExpressionFactory();
+        public static readonly ExpressionFactory Instance = new();
 
-        private ExpressionFactory() {}
+        /// <summary>
+        /// Default constructor.
+        /// </summary>
+        protected ExpressionFactory() {}
 
 <#
 foreach (var m in typeof(Expression).GetMethods().Where(m => m.IsStatic && m.DeclaringType == typeof(Expression)).Where(m => !exclude.Contains(m.Name)).OrderBy(m => m.Name).ThenBy(m => m.GetParameters().Length))
@@ -86,7 +89,7 @@ foreach (var m in typeof(Expression).GetMethods().Where(m => m.IsStatic && m.Dec
     var isDyn = m.Name.Contains("Dynamic");
 #>
 <#=doc#>
-        public <#=ret#> <#=name#><#=genArgs#>(<#=pars#>) => Expression.<#=name#><#=genArgs#>(<#=args#>);
+        public virtual <#=ret#> <#=name#><#=genArgs#>(<#=pars#>) => Expression.<#=name#><#=genArgs#>(<#=args#>);
 
 <#
 }

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices/Expressions/ExpressionUnsafeFactory.generated.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices/Expressions/ExpressionUnsafeFactory.generated.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 
@@ -13,21 +13,24 @@ namespace System.Linq.Expressions
     /// with extreme caution, only if type safety guarantees are provided elsewhere. A typical use of this
     /// factory is for expression deserialization.
     /// </summary>
-    public sealed class ExpressionUnsafeFactory : IExpressionFactory
+    public class ExpressionUnsafeFactory : IExpressionFactory
     {
         /// <summary>
         /// Gets the singleton instance of the factory.
         /// </summary>
-        public static readonly IExpressionFactory Instance = new ExpressionUnsafeFactory();
+        public static readonly ExpressionUnsafeFactory Instance = new();
 
-        private ExpressionUnsafeFactory() {}
+        /// <summary>
+        /// Default constructor.
+        /// </summary>
+        protected ExpressionUnsafeFactory() {}
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.BinaryExpression" /> that represents an arithmetic addition operation that does not have overflow checking.</summary>
         /// <param name="left">A <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Left" /> property equal to.</param>
         /// <param name="right">A <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Right" /> property equal to.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.BinaryExpression" /> that has the <see cref="P:System.Linq.Expressions.Expression.NodeType" /> property equal to <see cref="F:System.Linq.Expressions.ExpressionType.Add" /> and the <see cref="P:System.Linq.Expressions.BinaryExpression.Left" /> and <see cref="P:System.Linq.Expressions.BinaryExpression.Right" /> properties set to the specified values.</returns>
         /// <remarks>This method does not provide any guarantees with regards to argument validation or type checking.</remarks>
-        public BinaryExpression Add(Expression left, Expression right) => ExpressionUnsafe.Add(left, right);
+        public virtual BinaryExpression Add(Expression left, Expression right) => ExpressionUnsafe.Add(left, right);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.BinaryExpression" /> that represents an arithmetic addition operation that does not have overflow checking. The implementing method can be specified.</summary>
         /// <param name="left">A <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Left" /> property equal to.</param>
@@ -35,14 +38,14 @@ namespace System.Linq.Expressions
         /// <param name="method">A <see cref="T:System.Reflection.MethodInfo" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Method" /> property equal to.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.BinaryExpression" /> that has the <see cref="P:System.Linq.Expressions.Expression.NodeType" /> property equal to <see cref="F:System.Linq.Expressions.ExpressionType.Add" /> and the <see cref="P:System.Linq.Expressions.BinaryExpression.Left" />, <see cref="P:System.Linq.Expressions.BinaryExpression.Right" /> and <see cref="P:System.Linq.Expressions.BinaryExpression.Method" /> properties set to the specified values.</returns>
         /// <remarks>This method does not provide any guarantees with regards to argument validation or type checking.</remarks>
-        public BinaryExpression Add(Expression left, Expression right, MethodInfo method) => ExpressionUnsafe.Add(left, right, method);
+        public virtual BinaryExpression Add(Expression left, Expression right, MethodInfo method) => ExpressionUnsafe.Add(left, right, method);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.BinaryExpression" /> that represents an addition assignment operation that does not have overflow checking.</summary>
         /// <param name="left">An <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Left" /> property equal to.</param>
         /// <param name="right">An <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Right" /> property equal to.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.BinaryExpression" /> that has the <see cref="P:System.Linq.Expressions.Expression.NodeType" /> property equal to <see cref="F:System.Linq.Expressions.ExpressionType.AddAssign" /> and the <see cref="P:System.Linq.Expressions.BinaryExpression.Left" /> and <see cref="P:System.Linq.Expressions.BinaryExpression.Right" /> properties set to the specified values.</returns>
         /// <remarks>This method does not provide any guarantees with regards to argument validation or type checking.</remarks>
-        public BinaryExpression AddAssign(Expression left, Expression right) => ExpressionUnsafe.AddAssign(left, right);
+        public virtual BinaryExpression AddAssign(Expression left, Expression right) => ExpressionUnsafe.AddAssign(left, right);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.BinaryExpression" /> that represents an addition assignment operation that does not have overflow checking.</summary>
         /// <param name="left">An <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Left" /> property equal to.</param>
@@ -50,7 +53,7 @@ namespace System.Linq.Expressions
         /// <param name="method">A <see cref="T:System.Reflection.MethodInfo" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Method" /> property equal to.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.BinaryExpression" /> that has the <see cref="P:System.Linq.Expressions.Expression.NodeType" /> property equal to <see cref="F:System.Linq.Expressions.ExpressionType.AddAssign" /> and the <see cref="P:System.Linq.Expressions.BinaryExpression.Left" />, <see cref="P:System.Linq.Expressions.BinaryExpression.Right" />, and <see cref="P:System.Linq.Expressions.BinaryExpression.Method" /> properties set to the specified values.</returns>
         /// <remarks>This method does not provide any guarantees with regards to argument validation or type checking.</remarks>
-        public BinaryExpression AddAssign(Expression left, Expression right, MethodInfo method) => ExpressionUnsafe.AddAssign(left, right, method);
+        public virtual BinaryExpression AddAssign(Expression left, Expression right, MethodInfo method) => ExpressionUnsafe.AddAssign(left, right, method);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.BinaryExpression" /> that represents an addition assignment operation that does not have overflow checking.</summary>
         /// <param name="left">An <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Left" /> property equal to.</param>
@@ -59,14 +62,14 @@ namespace System.Linq.Expressions
         /// <param name="conversion">A <see cref="T:System.Linq.Expressions.LambdaExpression" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Conversion" /> property equal to.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.BinaryExpression" /> that has the <see cref="P:System.Linq.Expressions.Expression.NodeType" /> property equal to <see cref="F:System.Linq.Expressions.ExpressionType.AddAssign" /> and the <see cref="P:System.Linq.Expressions.BinaryExpression.Left" />, <see cref="P:System.Linq.Expressions.BinaryExpression.Right" />, <see cref="P:System.Linq.Expressions.BinaryExpression.Method" />, and <see cref="P:System.Linq.Expressions.BinaryExpression.Conversion" /> properties set to the specified values.</returns>
         /// <remarks>This method does not provide any guarantees with regards to argument validation or type checking.</remarks>
-        public BinaryExpression AddAssign(Expression left, Expression right, MethodInfo method, LambdaExpression conversion) => ExpressionUnsafe.AddAssign(left, right, method, conversion);
+        public virtual BinaryExpression AddAssign(Expression left, Expression right, MethodInfo method, LambdaExpression conversion) => ExpressionUnsafe.AddAssign(left, right, method, conversion);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.BinaryExpression" /> that represents an addition assignment operation that has overflow checking.</summary>
         /// <param name="left">An <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Left" /> property equal to.</param>
         /// <param name="right">An <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Right" /> property equal to.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.BinaryExpression" /> that has the <see cref="P:System.Linq.Expressions.Expression.NodeType" /> property equal to <see cref="F:System.Linq.Expressions.ExpressionType.AddAssignChecked" /> and the <see cref="P:System.Linq.Expressions.BinaryExpression.Left" /> and <see cref="P:System.Linq.Expressions.BinaryExpression.Right" /> properties set to the specified values.</returns>
         /// <remarks>This method does not provide any guarantees with regards to argument validation or type checking.</remarks>
-        public BinaryExpression AddAssignChecked(Expression left, Expression right) => ExpressionUnsafe.AddAssignChecked(left, right);
+        public virtual BinaryExpression AddAssignChecked(Expression left, Expression right) => ExpressionUnsafe.AddAssignChecked(left, right);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.BinaryExpression" /> that represents an addition assignment operation that has overflow checking.</summary>
         /// <param name="left">An <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Left" /> property equal to.</param>
@@ -74,7 +77,7 @@ namespace System.Linq.Expressions
         /// <param name="method">A <see cref="T:System.Reflection.MethodInfo" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Method" /> property equal to.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.BinaryExpression" /> that has the <see cref="P:System.Linq.Expressions.Expression.NodeType" /> property equal to <see cref="F:System.Linq.Expressions.ExpressionType.AddAssignChecked" /> and the <see cref="P:System.Linq.Expressions.BinaryExpression.Left" />, <see cref="P:System.Linq.Expressions.BinaryExpression.Right" />, and <see cref="P:System.Linq.Expressions.BinaryExpression.Method" /> properties set to the specified values.</returns>
         /// <remarks>This method does not provide any guarantees with regards to argument validation or type checking.</remarks>
-        public BinaryExpression AddAssignChecked(Expression left, Expression right, MethodInfo method) => ExpressionUnsafe.AddAssignChecked(left, right, method);
+        public virtual BinaryExpression AddAssignChecked(Expression left, Expression right, MethodInfo method) => ExpressionUnsafe.AddAssignChecked(left, right, method);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.BinaryExpression" /> that represents an addition assignment operation that has overflow checking.</summary>
         /// <param name="left">An <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Left" /> property equal to.</param>
@@ -83,14 +86,14 @@ namespace System.Linq.Expressions
         /// <param name="conversion">A <see cref="T:System.Linq.Expressions.LambdaExpression" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Conversion" /> property equal to.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.BinaryExpression" /> that has the <see cref="P:System.Linq.Expressions.Expression.NodeType" /> property equal to <see cref="F:System.Linq.Expressions.ExpressionType.AddAssignChecked" /> and the <see cref="P:System.Linq.Expressions.BinaryExpression.Left" />, <see cref="P:System.Linq.Expressions.BinaryExpression.Right" />, <see cref="P:System.Linq.Expressions.BinaryExpression.Method" />, and <see cref="P:System.Linq.Expressions.BinaryExpression.Conversion" /> properties set to the specified values.</returns>
         /// <remarks>This method does not provide any guarantees with regards to argument validation or type checking.</remarks>
-        public BinaryExpression AddAssignChecked(Expression left, Expression right, MethodInfo method, LambdaExpression conversion) => ExpressionUnsafe.AddAssignChecked(left, right, method, conversion);
+        public virtual BinaryExpression AddAssignChecked(Expression left, Expression right, MethodInfo method, LambdaExpression conversion) => ExpressionUnsafe.AddAssignChecked(left, right, method, conversion);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.BinaryExpression" /> that represents an arithmetic addition operation that has overflow checking.</summary>
         /// <param name="left">A <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Left" /> property equal to.</param>
         /// <param name="right">A <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Right" /> property equal to.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.BinaryExpression" /> that has the <see cref="P:System.Linq.Expressions.Expression.NodeType" /> property equal to <see cref="F:System.Linq.Expressions.ExpressionType.AddChecked" /> and the <see cref="P:System.Linq.Expressions.BinaryExpression.Left" /> and <see cref="P:System.Linq.Expressions.BinaryExpression.Right" /> properties set to the specified values.</returns>
         /// <remarks>This method does not provide any guarantees with regards to argument validation or type checking.</remarks>
-        public BinaryExpression AddChecked(Expression left, Expression right) => ExpressionUnsafe.AddChecked(left, right);
+        public virtual BinaryExpression AddChecked(Expression left, Expression right) => ExpressionUnsafe.AddChecked(left, right);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.BinaryExpression" /> that represents an arithmetic addition operation that has overflow checking. The implementing method can be specified.</summary>
         /// <param name="left">A <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Left" /> property equal to.</param>
@@ -98,14 +101,14 @@ namespace System.Linq.Expressions
         /// <param name="method">A <see cref="T:System.Reflection.MethodInfo" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Method" /> property equal to.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.BinaryExpression" /> that has the <see cref="P:System.Linq.Expressions.Expression.NodeType" /> property equal to <see cref="F:System.Linq.Expressions.ExpressionType.AddChecked" /> and the <see cref="P:System.Linq.Expressions.BinaryExpression.Left" />, <see cref="P:System.Linq.Expressions.BinaryExpression.Right" /> and <see cref="P:System.Linq.Expressions.BinaryExpression.Method" /> properties set to the specified values.</returns>
         /// <remarks>This method does not provide any guarantees with regards to argument validation or type checking.</remarks>
-        public BinaryExpression AddChecked(Expression left, Expression right, MethodInfo method) => ExpressionUnsafe.AddChecked(left, right, method);
+        public virtual BinaryExpression AddChecked(Expression left, Expression right, MethodInfo method) => ExpressionUnsafe.AddChecked(left, right, method);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.BinaryExpression" /> that represents a bitwise <see langword="AND" /> operation.</summary>
         /// <param name="left">A <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Left" /> property equal to.</param>
         /// <param name="right">A <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Right" /> property equal to.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.BinaryExpression" /> that has the <see cref="P:System.Linq.Expressions.Expression.NodeType" /> property equal to <see cref="F:System.Linq.Expressions.ExpressionType.And" /> and the <see cref="P:System.Linq.Expressions.BinaryExpression.Left" /> and <see cref="P:System.Linq.Expressions.BinaryExpression.Right" /> properties set to the specified values.</returns>
         /// <remarks>This method does not provide any guarantees with regards to argument validation or type checking.</remarks>
-        public BinaryExpression And(Expression left, Expression right) => ExpressionUnsafe.And(left, right);
+        public virtual BinaryExpression And(Expression left, Expression right) => ExpressionUnsafe.And(left, right);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.BinaryExpression" /> that represents a bitwise <see langword="AND" /> operation. The implementing method can be specified.</summary>
         /// <param name="left">An <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Left" /> property equal to.</param>
@@ -113,14 +116,14 @@ namespace System.Linq.Expressions
         /// <param name="method">A <see cref="T:System.Reflection.MethodInfo" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Method" /> property equal to.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.BinaryExpression" /> that has the <see cref="P:System.Linq.Expressions.Expression.NodeType" /> property equal to <see cref="F:System.Linq.Expressions.ExpressionType.And" /> and the <see cref="P:System.Linq.Expressions.BinaryExpression.Left" />, <see cref="P:System.Linq.Expressions.BinaryExpression.Right" />, and <see cref="P:System.Linq.Expressions.BinaryExpression.Method" /> properties set to the specified values.</returns>
         /// <remarks>This method does not provide any guarantees with regards to argument validation or type checking.</remarks>
-        public BinaryExpression And(Expression left, Expression right, MethodInfo method) => ExpressionUnsafe.And(left, right, method);
+        public virtual BinaryExpression And(Expression left, Expression right, MethodInfo method) => ExpressionUnsafe.And(left, right, method);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.BinaryExpression" /> that represents a conditional <see langword="AND" /> operation that evaluates the second operand only if the first operand evaluates to <see langword="true" />.</summary>
         /// <param name="left">A <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Left" /> property equal to.</param>
         /// <param name="right">A <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Right" /> property equal to.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.BinaryExpression" /> that has the <see cref="P:System.Linq.Expressions.Expression.NodeType" /> property equal to <see cref="F:System.Linq.Expressions.ExpressionType.AndAlso" /> and the <see cref="P:System.Linq.Expressions.BinaryExpression.Left" /> and <see cref="P:System.Linq.Expressions.BinaryExpression.Right" /> properties set to the specified values.</returns>
         /// <remarks>This method does not provide any guarantees with regards to argument validation or type checking.</remarks>
-        public BinaryExpression AndAlso(Expression left, Expression right) => ExpressionUnsafe.AndAlso(left, right);
+        public virtual BinaryExpression AndAlso(Expression left, Expression right) => ExpressionUnsafe.AndAlso(left, right);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.BinaryExpression" /> that represents a conditional <see langword="AND" /> operation that evaluates the second operand only if the first operand is resolved to true. The implementing method can be specified.</summary>
         /// <param name="left">A <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Left" /> property equal to.</param>
@@ -128,14 +131,14 @@ namespace System.Linq.Expressions
         /// <param name="method">A <see cref="T:System.Reflection.MethodInfo" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Method" /> property equal to.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.BinaryExpression" /> that has the <see cref="P:System.Linq.Expressions.Expression.NodeType" /> property equal to <see cref="F:System.Linq.Expressions.ExpressionType.AndAlso" /> and the <see cref="P:System.Linq.Expressions.BinaryExpression.Left" />, <see cref="P:System.Linq.Expressions.BinaryExpression.Right" />, and <see cref="P:System.Linq.Expressions.BinaryExpression.Method" /> properties set to the specified values.</returns>
         /// <remarks>This method does not provide any guarantees with regards to argument validation or type checking.</remarks>
-        public BinaryExpression AndAlso(Expression left, Expression right, MethodInfo method) => ExpressionUnsafe.AndAlso(left, right, method);
+        public virtual BinaryExpression AndAlso(Expression left, Expression right, MethodInfo method) => ExpressionUnsafe.AndAlso(left, right, method);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.BinaryExpression" /> that represents a bitwise AND assignment operation.</summary>
         /// <param name="left">An <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Left" /> property equal to.</param>
         /// <param name="right">An <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Right" /> property equal to.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.BinaryExpression" /> that has the <see cref="P:System.Linq.Expressions.Expression.NodeType" /> property equal to <see cref="F:System.Linq.Expressions.ExpressionType.AndAssign" /> and the <see cref="P:System.Linq.Expressions.BinaryExpression.Left" /> and <see cref="P:System.Linq.Expressions.BinaryExpression.Right" /> properties set to the specified values.</returns>
         /// <remarks>This method does not provide any guarantees with regards to argument validation or type checking.</remarks>
-        public BinaryExpression AndAssign(Expression left, Expression right) => ExpressionUnsafe.AndAssign(left, right);
+        public virtual BinaryExpression AndAssign(Expression left, Expression right) => ExpressionUnsafe.AndAssign(left, right);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.BinaryExpression" /> that represents a bitwise AND assignment operation.</summary>
         /// <param name="left">An <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Left" /> property equal to.</param>
@@ -143,7 +146,7 @@ namespace System.Linq.Expressions
         /// <param name="method">A <see cref="T:System.Reflection.MethodInfo" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Method" /> property equal to.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.BinaryExpression" /> that has the <see cref="P:System.Linq.Expressions.Expression.NodeType" /> property equal to <see cref="F:System.Linq.Expressions.ExpressionType.AndAssign" /> and the <see cref="P:System.Linq.Expressions.BinaryExpression.Left" />, <see cref="P:System.Linq.Expressions.BinaryExpression.Right" />, and <see cref="P:System.Linq.Expressions.BinaryExpression.Method" /> properties set to the specified values.</returns>
         /// <remarks>This method does not provide any guarantees with regards to argument validation or type checking.</remarks>
-        public BinaryExpression AndAssign(Expression left, Expression right, MethodInfo method) => ExpressionUnsafe.AndAssign(left, right, method);
+        public virtual BinaryExpression AndAssign(Expression left, Expression right, MethodInfo method) => ExpressionUnsafe.AndAssign(left, right, method);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.BinaryExpression" /> that represents a bitwise AND assignment operation.</summary>
         /// <param name="left">An <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Left" /> property equal to.</param>
@@ -152,116 +155,116 @@ namespace System.Linq.Expressions
         /// <param name="conversion">A <see cref="T:System.Linq.Expressions.LambdaExpression" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Conversion" /> property equal to.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.BinaryExpression" /> that has the <see cref="P:System.Linq.Expressions.Expression.NodeType" /> property equal to <see cref="F:System.Linq.Expressions.ExpressionType.AndAssign" /> and the <see cref="P:System.Linq.Expressions.BinaryExpression.Left" />, <see cref="P:System.Linq.Expressions.BinaryExpression.Right" />, <see cref="P:System.Linq.Expressions.BinaryExpression.Method" />, and <see cref="P:System.Linq.Expressions.BinaryExpression.Conversion" /> properties set to the specified values.</returns>
         /// <remarks>This method does not provide any guarantees with regards to argument validation or type checking.</remarks>
-        public BinaryExpression AndAssign(Expression left, Expression right, MethodInfo method, LambdaExpression conversion) => ExpressionUnsafe.AndAssign(left, right, method, conversion);
+        public virtual BinaryExpression AndAssign(Expression left, Expression right, MethodInfo method, LambdaExpression conversion) => ExpressionUnsafe.AndAssign(left, right, method, conversion);
 
         /// <summary>Creates an <see cref="T:System.Linq.Expressions.IndexExpression" /> to access an array.</summary>
         /// <param name="array">An expression representing the array to index.</param>
         /// <param name="indexes">An array that contains expressions used to index the array.</param>
         /// <returns>The created <see cref="T:System.Linq.Expressions.IndexExpression" />.</returns>
         /// <remarks>This method does not provide any guarantees with regards to argument validation or type checking.</remarks>
-        public IndexExpression ArrayAccess(Expression array, Expression[] indexes) => ExpressionUnsafe.ArrayAccess(array, indexes);
+        public virtual IndexExpression ArrayAccess(Expression array, Expression[] indexes) => ExpressionUnsafe.ArrayAccess(array, indexes);
 
         /// <summary>Creates an <see cref="T:System.Linq.Expressions.IndexExpression" /> to access a multidimensional array.</summary>
         /// <param name="array">An expression that represents the multidimensional array.</param>
         /// <param name="indexes">An <see cref="T:System.Collections.Generic.IEnumerable`1" /> containing expressions used to index the array.</param>
         /// <returns>The created <see cref="T:System.Linq.Expressions.IndexExpression" />.</returns>
         /// <remarks>This method does not provide any guarantees with regards to argument validation or type checking.</remarks>
-        public IndexExpression ArrayAccess(Expression array, IEnumerable<Expression> indexes) => ExpressionUnsafe.ArrayAccess(array, indexes);
+        public virtual IndexExpression ArrayAccess(Expression array, IEnumerable<Expression> indexes) => ExpressionUnsafe.ArrayAccess(array, indexes);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.MethodCallExpression" /> that represents applying an array index operator to a multidimensional array.</summary>
         /// <param name="array">An array of <see cref="T:System.Linq.Expressions.Expression" /> instances - indexes for the array index operation.</param>
         /// <param name="indexes">An array of <see cref="T:System.Linq.Expressions.Expression" /> objects to use to populate the <see cref="P:System.Linq.Expressions.MethodCallExpression.Arguments" /> collection.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.MethodCallExpression" /> that has the <see cref="P:System.Linq.Expressions.Expression.NodeType" /> property equal to <see cref="F:System.Linq.Expressions.ExpressionType.Call" /> and the <see cref="P:System.Linq.Expressions.MethodCallExpression.Object" /> and <see cref="P:System.Linq.Expressions.MethodCallExpression.Arguments" /> properties set to the specified values.</returns>
         /// <remarks>This method does not provide any guarantees with regards to argument validation or type checking.</remarks>
-        public MethodCallExpression ArrayIndex(Expression array, Expression[] indexes) => ExpressionUnsafe.ArrayIndex(array, indexes);
+        public virtual MethodCallExpression ArrayIndex(Expression array, Expression[] indexes) => ExpressionUnsafe.ArrayIndex(array, indexes);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.MethodCallExpression" /> that represents applying an array index operator to an array of rank more than one.</summary>
         /// <param name="array">An <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.MethodCallExpression.Object" /> property equal to.</param>
         /// <param name="indexes">An <see cref="T:System.Collections.Generic.IEnumerable`1" /> that contains <see cref="T:System.Linq.Expressions.Expression" /> objects to use to populate the <see cref="P:System.Linq.Expressions.MethodCallExpression.Arguments" /> collection.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.MethodCallExpression" /> that has the <see cref="P:System.Linq.Expressions.Expression.NodeType" /> property equal to <see cref="F:System.Linq.Expressions.ExpressionType.Call" /> and the <see cref="P:System.Linq.Expressions.MethodCallExpression.Object" /> and <see cref="P:System.Linq.Expressions.MethodCallExpression.Arguments" /> properties set to the specified values.</returns>
         /// <remarks>This method does not provide any guarantees with regards to argument validation or type checking.</remarks>
-        public MethodCallExpression ArrayIndex(Expression array, IEnumerable<Expression> indexes) => ExpressionUnsafe.ArrayIndex(array, indexes);
+        public virtual MethodCallExpression ArrayIndex(Expression array, IEnumerable<Expression> indexes) => ExpressionUnsafe.ArrayIndex(array, indexes);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.BinaryExpression" /> that represents applying an array index operator to an array of rank one.</summary>
         /// <param name="array">A <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Left" /> property equal to.</param>
         /// <param name="index">A <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Right" /> property equal to.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.BinaryExpression" /> that has the <see cref="P:System.Linq.Expressions.Expression.NodeType" /> property equal to <see cref="F:System.Linq.Expressions.ExpressionType.ArrayIndex" /> and the <see cref="P:System.Linq.Expressions.BinaryExpression.Left" /> and <see cref="P:System.Linq.Expressions.BinaryExpression.Right" /> properties set to the specified values.</returns>
         /// <remarks>This method does not provide any guarantees with regards to argument validation or type checking.</remarks>
-        public BinaryExpression ArrayIndex(Expression array, Expression index) => ExpressionUnsafe.ArrayIndex(array, index);
+        public virtual BinaryExpression ArrayIndex(Expression array, Expression index) => ExpressionUnsafe.ArrayIndex(array, index);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.UnaryExpression" /> that represents an expression for obtaining the length of a one-dimensional array.</summary>
         /// <param name="array">An <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.UnaryExpression.Operand" /> property equal to.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.UnaryExpression" /> that has the <see cref="P:System.Linq.Expressions.Expression.NodeType" /> property equal to <see cref="F:System.Linq.Expressions.ExpressionType.ArrayLength" /> and the <see cref="P:System.Linq.Expressions.UnaryExpression.Operand" /> property equal to <paramref name="array" />.</returns>
         /// <remarks>This method does not provide any guarantees with regards to argument validation or type checking.</remarks>
-        public UnaryExpression ArrayLength(Expression array) => ExpressionUnsafe.ArrayLength(array);
+        public virtual UnaryExpression ArrayLength(Expression array) => ExpressionUnsafe.ArrayLength(array);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.BinaryExpression" /> that represents an assignment operation.</summary>
         /// <param name="left">An <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Left" /> property equal to.</param>
         /// <param name="right">An <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Right" /> property equal to.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.BinaryExpression" /> that has the <see cref="P:System.Linq.Expressions.Expression.NodeType" /> property equal to <see cref="F:System.Linq.Expressions.ExpressionType.Assign" /> and the <see cref="P:System.Linq.Expressions.BinaryExpression.Left" /> and <see cref="P:System.Linq.Expressions.BinaryExpression.Right" /> properties set to the specified values.</returns>
         /// <remarks>This method does not provide any guarantees with regards to argument validation or type checking.</remarks>
-        public BinaryExpression Assign(Expression left, Expression right) => ExpressionUnsafe.Assign(left, right);
+        public virtual BinaryExpression Assign(Expression left, Expression right) => ExpressionUnsafe.Assign(left, right);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.MemberAssignment" /> that represents the initialization of a field or property.</summary>
         /// <param name="member">A <see cref="T:System.Reflection.MemberInfo" /> to set the <see cref="P:System.Linq.Expressions.MemberBinding.Member" /> property equal to.</param>
         /// <param name="expression">An <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.MemberAssignment.Expression" /> property equal to.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.MemberAssignment" /> that has <see cref="P:System.Linq.Expressions.MemberBinding.BindingType" /> equal to <see cref="F:System.Linq.Expressions.MemberBindingType.Assignment" /> and the <see cref="P:System.Linq.Expressions.MemberBinding.Member" /> and <see cref="P:System.Linq.Expressions.MemberAssignment.Expression" /> properties set to the specified values.</returns>
         /// <remarks>This method does not provide any guarantees with regards to argument validation or type checking.</remarks>
-        public MemberAssignment Bind(MemberInfo member, Expression expression) => ExpressionUnsafe.Bind(member, expression);
+        public virtual MemberAssignment Bind(MemberInfo member, Expression expression) => ExpressionUnsafe.Bind(member, expression);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.MemberAssignment" /> that represents the initialization of a member by using a property accessor method.</summary>
         /// <param name="propertyAccessor">A <see cref="T:System.Reflection.MethodInfo" /> that represents a property accessor method.</param>
         /// <param name="expression">An <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.MemberAssignment.Expression" /> property equal to.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.MemberAssignment" /> that has the <see cref="P:System.Linq.Expressions.MemberBinding.BindingType" /> property equal to <see cref="F:System.Linq.Expressions.MemberBindingType.Assignment" />, the <see cref="P:System.Linq.Expressions.MemberBinding.Member" /> property set to the <see cref="T:System.Reflection.PropertyInfo" /> that represents the property accessed in <paramref name="propertyAccessor" />, and the <see cref="P:System.Linq.Expressions.MemberAssignment.Expression" /> property set to <paramref name="expression" />.</returns>
         /// <remarks>This method does not provide any guarantees with regards to argument validation or type checking.</remarks>
-        public MemberAssignment Bind(MethodInfo propertyAccessor, Expression expression) => ExpressionUnsafe.Bind(propertyAccessor, expression);
+        public virtual MemberAssignment Bind(MethodInfo propertyAccessor, Expression expression) => ExpressionUnsafe.Bind(propertyAccessor, expression);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.BlockExpression" /> that contains the given expressions and has no variables.</summary>
         /// <param name="expressions">The expressions in the block.</param>
         /// <returns>The created <see cref="T:System.Linq.Expressions.BlockExpression" />.</returns>
         /// <remarks>This method does not provide any guarantees with regards to argument validation or type checking.</remarks>
-        public BlockExpression Block(Expression[] expressions) => ExpressionUnsafe.Block(expressions);
+        public virtual BlockExpression Block(Expression[] expressions) => ExpressionUnsafe.Block(expressions);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.BlockExpression" /> that contains the given expressions and has no variables.</summary>
         /// <param name="expressions">The expressions in the block.</param>
         /// <returns>The created <see cref="T:System.Linq.Expressions.BlockExpression" />.</returns>
         /// <remarks>This method does not provide any guarantees with regards to argument validation or type checking.</remarks>
-        public BlockExpression Block(IEnumerable<Expression> expressions) => ExpressionUnsafe.Block(expressions);
+        public virtual BlockExpression Block(IEnumerable<Expression> expressions) => ExpressionUnsafe.Block(expressions);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.BlockExpression" /> that contains two expressions and has no variables.</summary>
         /// <param name="arg0">The first expression in the block.</param>
         /// <param name="arg1">The second expression in the block.</param>
         /// <returns>The created <see cref="T:System.Linq.Expressions.BlockExpression" />.</returns>
         /// <remarks>This method does not provide any guarantees with regards to argument validation or type checking.</remarks>
-        public BlockExpression Block(Expression arg0, Expression arg1) => ExpressionUnsafe.Block(arg0, arg1);
+        public virtual BlockExpression Block(Expression arg0, Expression arg1) => ExpressionUnsafe.Block(arg0, arg1);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.BlockExpression" /> that contains the given expressions, has no variables and has specific result type.</summary>
         /// <param name="type">The result type of the block.</param>
         /// <param name="expressions">The expressions in the block.</param>
         /// <returns>The created <see cref="T:System.Linq.Expressions.BlockExpression" />.</returns>
         /// <remarks>This method does not provide any guarantees with regards to argument validation or type checking.</remarks>
-        public BlockExpression Block(Type type, Expression[] expressions) => ExpressionUnsafe.Block(type, expressions);
+        public virtual BlockExpression Block(Type type, Expression[] expressions) => ExpressionUnsafe.Block(type, expressions);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.BlockExpression" /> that contains the given expressions, has no variables and has specific result type.</summary>
         /// <param name="type">The result type of the block.</param>
         /// <param name="expressions">The expressions in the block.</param>
         /// <returns>The created <see cref="T:System.Linq.Expressions.BlockExpression" />.</returns>
         /// <remarks>This method does not provide any guarantees with regards to argument validation or type checking.</remarks>
-        public BlockExpression Block(Type type, IEnumerable<Expression> expressions) => ExpressionUnsafe.Block(type, expressions);
+        public virtual BlockExpression Block(Type type, IEnumerable<Expression> expressions) => ExpressionUnsafe.Block(type, expressions);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.BlockExpression" /> that contains the given variables and expressions.</summary>
         /// <param name="variables">The variables in the block.</param>
         /// <param name="expressions">The expressions in the block.</param>
         /// <returns>The created <see cref="T:System.Linq.Expressions.BlockExpression" />.</returns>
         /// <remarks>This method does not provide any guarantees with regards to argument validation or type checking.</remarks>
-        public BlockExpression Block(IEnumerable<ParameterExpression> variables, Expression[] expressions) => ExpressionUnsafe.Block(variables, expressions);
+        public virtual BlockExpression Block(IEnumerable<ParameterExpression> variables, Expression[] expressions) => ExpressionUnsafe.Block(variables, expressions);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.BlockExpression" /> that contains the given variables and expressions.</summary>
         /// <param name="variables">The variables in the block.</param>
         /// <param name="expressions">The expressions in the block.</param>
         /// <returns>The created <see cref="T:System.Linq.Expressions.BlockExpression" />.</returns>
         /// <remarks>This method does not provide any guarantees with regards to argument validation or type checking.</remarks>
-        public BlockExpression Block(IEnumerable<ParameterExpression> variables, IEnumerable<Expression> expressions) => ExpressionUnsafe.Block(variables, expressions);
+        public virtual BlockExpression Block(IEnumerable<ParameterExpression> variables, IEnumerable<Expression> expressions) => ExpressionUnsafe.Block(variables, expressions);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.BlockExpression" /> that contains three expressions and has no variables.</summary>
         /// <param name="arg0">The first expression in the block.</param>
@@ -269,7 +272,7 @@ namespace System.Linq.Expressions
         /// <param name="arg2">The third expression in the block.</param>
         /// <returns>The created <see cref="T:System.Linq.Expressions.BlockExpression" />.</returns>
         /// <remarks>This method does not provide any guarantees with regards to argument validation or type checking.</remarks>
-        public BlockExpression Block(Expression arg0, Expression arg1, Expression arg2) => ExpressionUnsafe.Block(arg0, arg1, arg2);
+        public virtual BlockExpression Block(Expression arg0, Expression arg1, Expression arg2) => ExpressionUnsafe.Block(arg0, arg1, arg2);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.BlockExpression" /> that contains the given variables and expressions.</summary>
         /// <param name="type">The result type of the block.</param>
@@ -277,7 +280,7 @@ namespace System.Linq.Expressions
         /// <param name="expressions">The expressions in the block.</param>
         /// <returns>The created <see cref="T:System.Linq.Expressions.BlockExpression" />.</returns>
         /// <remarks>This method does not provide any guarantees with regards to argument validation or type checking.</remarks>
-        public BlockExpression Block(Type type, IEnumerable<ParameterExpression> variables, Expression[] expressions) => ExpressionUnsafe.Block(type, variables, expressions);
+        public virtual BlockExpression Block(Type type, IEnumerable<ParameterExpression> variables, Expression[] expressions) => ExpressionUnsafe.Block(type, variables, expressions);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.BlockExpression" /> that contains the given variables and expressions.</summary>
         /// <param name="type">The result type of the block.</param>
@@ -285,7 +288,7 @@ namespace System.Linq.Expressions
         /// <param name="expressions">The expressions in the block.</param>
         /// <returns>The created <see cref="T:System.Linq.Expressions.BlockExpression" />.</returns>
         /// <remarks>This method does not provide any guarantees with regards to argument validation or type checking.</remarks>
-        public BlockExpression Block(Type type, IEnumerable<ParameterExpression> variables, IEnumerable<Expression> expressions) => ExpressionUnsafe.Block(type, variables, expressions);
+        public virtual BlockExpression Block(Type type, IEnumerable<ParameterExpression> variables, IEnumerable<Expression> expressions) => ExpressionUnsafe.Block(type, variables, expressions);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.BlockExpression" /> that contains four expressions and has no variables.</summary>
         /// <param name="arg0">The first expression in the block.</param>
@@ -294,7 +297,7 @@ namespace System.Linq.Expressions
         /// <param name="arg3">The fourth expression in the block.</param>
         /// <returns>The created <see cref="T:System.Linq.Expressions.BlockExpression" />.</returns>
         /// <remarks>This method does not provide any guarantees with regards to argument validation or type checking.</remarks>
-        public BlockExpression Block(Expression arg0, Expression arg1, Expression arg2, Expression arg3) => ExpressionUnsafe.Block(arg0, arg1, arg2, arg3);
+        public virtual BlockExpression Block(Expression arg0, Expression arg1, Expression arg2, Expression arg3) => ExpressionUnsafe.Block(arg0, arg1, arg2, arg3);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.BlockExpression" /> that contains five expressions and has no variables.</summary>
         /// <param name="arg0">The first expression in the block.</param>
@@ -304,27 +307,27 @@ namespace System.Linq.Expressions
         /// <param name="arg4">The fifth expression in the block.</param>
         /// <returns>The created <see cref="T:System.Linq.Expressions.BlockExpression" />.</returns>
         /// <remarks>This method does not provide any guarantees with regards to argument validation or type checking.</remarks>
-        public BlockExpression Block(Expression arg0, Expression arg1, Expression arg2, Expression arg3, Expression arg4) => ExpressionUnsafe.Block(arg0, arg1, arg2, arg3, arg4);
+        public virtual BlockExpression Block(Expression arg0, Expression arg1, Expression arg2, Expression arg3, Expression arg4) => ExpressionUnsafe.Block(arg0, arg1, arg2, arg3, arg4);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.GotoExpression" /> representing a break statement.</summary>
         /// <param name="target">The <see cref="T:System.Linq.Expressions.LabelTarget" /> that the <see cref="T:System.Linq.Expressions.GotoExpression" /> will jump to.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.GotoExpression" /> with <see cref="P:System.Linq.Expressions.GotoExpression.Kind" /> equal to Break, the <see cref="P:System.Linq.Expressions.GotoExpression.Target" /> property set to <paramref name="target" />, and a null value to be passed to the target label upon jumping.</returns>
         /// <remarks>This method does not provide any guarantees with regards to argument validation or type checking.</remarks>
-        public GotoExpression Break(LabelTarget target) => ExpressionUnsafe.Break(target);
+        public virtual GotoExpression Break(LabelTarget target) => ExpressionUnsafe.Break(target);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.GotoExpression" /> representing a break statement. The value passed to the label upon jumping can be specified.</summary>
         /// <param name="target">The <see cref="T:System.Linq.Expressions.LabelTarget" /> that the <see cref="T:System.Linq.Expressions.GotoExpression" /> will jump to.</param>
         /// <param name="value">The value that will be passed to the associated label upon jumping.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.GotoExpression" /> with <see cref="P:System.Linq.Expressions.GotoExpression.Kind" /> equal to Break, the <see cref="P:System.Linq.Expressions.GotoExpression.Target" /> property set to <paramref name="target" />, and <paramref name="value" /> to be passed to the target label upon jumping.</returns>
         /// <remarks>This method does not provide any guarantees with regards to argument validation or type checking.</remarks>
-        public GotoExpression Break(LabelTarget target, Expression value) => ExpressionUnsafe.Break(target, value);
+        public virtual GotoExpression Break(LabelTarget target, Expression value) => ExpressionUnsafe.Break(target, value);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.GotoExpression" /> representing a break statement with the specified type.</summary>
         /// <param name="target">The <see cref="T:System.Linq.Expressions.LabelTarget" /> that the <see cref="T:System.Linq.Expressions.GotoExpression" /> will jump to.</param>
         /// <param name="type">An <see cref="T:System.Type" /> to set the <see cref="P:System.Linq.Expressions.Expression.Type" /> property equal to.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.GotoExpression" /> with <see cref="P:System.Linq.Expressions.GotoExpression.Kind" /> equal to Break, the <see cref="P:System.Linq.Expressions.GotoExpression.Target" /> property set to <paramref name="target" />, and the <see cref="P:System.Linq.Expressions.Expression.Type" /> property set to <paramref name="type" />.</returns>
         /// <remarks>This method does not provide any guarantees with regards to argument validation or type checking.</remarks>
-        public GotoExpression Break(LabelTarget target, Type type) => ExpressionUnsafe.Break(target, type);
+        public virtual GotoExpression Break(LabelTarget target, Type type) => ExpressionUnsafe.Break(target, type);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.GotoExpression" /> representing a break statement with the specified type. The value passed to the label upon jumping can be specified.</summary>
         /// <param name="target">The <see cref="T:System.Linq.Expressions.LabelTarget" /> that the <see cref="T:System.Linq.Expressions.GotoExpression" /> will jump to.</param>
@@ -332,35 +335,35 @@ namespace System.Linq.Expressions
         /// <param name="type">An <see cref="T:System.Type" /> to set the <see cref="P:System.Linq.Expressions.Expression.Type" /> property equal to.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.GotoExpression" /> with <see cref="P:System.Linq.Expressions.GotoExpression.Kind" /> equal to Break, the <see cref="P:System.Linq.Expressions.GotoExpression.Target" /> property set to <paramref name="target" />, the <see cref="P:System.Linq.Expressions.Expression.Type" /> property set to <paramref name="type" />, and <paramref name="value" /> to be passed to the target label upon jumping.</returns>
         /// <remarks>This method does not provide any guarantees with regards to argument validation or type checking.</remarks>
-        public GotoExpression Break(LabelTarget target, Expression value, Type type) => ExpressionUnsafe.Break(target, value, type);
+        public virtual GotoExpression Break(LabelTarget target, Expression value, Type type) => ExpressionUnsafe.Break(target, value, type);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.MethodCallExpression" /> that represents a call to a <see langword="static" /> (<see langword="Shared" /> in Visual Basic) method that takes one argument.</summary>
         /// <param name="method">A <see cref="T:System.Reflection.MethodInfo" /> to set the <see cref="P:System.Linq.Expressions.MethodCallExpression.Method" /> property equal to.</param>
         /// <param name="arg0">The <see cref="T:System.Linq.Expressions.Expression" /> that represents the first argument.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.MethodCallExpression" /> that has the <see cref="P:System.Linq.Expressions.Expression.NodeType" /> property equal to <see cref="F:System.Linq.Expressions.ExpressionType.Call" /> and the <see cref="P:System.Linq.Expressions.MethodCallExpression.Object" /> and <see cref="P:System.Linq.Expressions.MethodCallExpression.Method" /> properties set to the specified values.</returns>
         /// <remarks>This method does not provide any guarantees with regards to argument validation or type checking.</remarks>
-        public MethodCallExpression Call(MethodInfo method, Expression arg0) => ExpressionUnsafe.Call(method, arg0);
+        public virtual MethodCallExpression Call(MethodInfo method, Expression arg0) => ExpressionUnsafe.Call(method, arg0);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.MethodCallExpression" /> that represents a call to a <see langword="static" /> (<see langword="Shared" /> in Visual Basic) method that has arguments.</summary>
         /// <param name="method">A <see cref="T:System.Reflection.MethodInfo" /> that represents a <see langword="static" /> (<see langword="Shared" /> in Visual Basic) method to set the <see cref="P:System.Linq.Expressions.MethodCallExpression.Method" /> property equal to.</param>
         /// <param name="arguments">An array of <see cref="T:System.Linq.Expressions.Expression" /> objects to use to populate the <see cref="P:System.Linq.Expressions.MethodCallExpression.Arguments" /> collection.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.MethodCallExpression" /> that has the <see cref="P:System.Linq.Expressions.Expression.NodeType" /> property equal to <see cref="F:System.Linq.Expressions.ExpressionType.Call" /> and the <see cref="P:System.Linq.Expressions.MethodCallExpression.Method" /> and <see cref="P:System.Linq.Expressions.MethodCallExpression.Arguments" /> properties set to the specified values.</returns>
         /// <remarks>This method does not provide any guarantees with regards to argument validation or type checking.</remarks>
-        public MethodCallExpression Call(MethodInfo method, Expression[] arguments) => ExpressionUnsafe.Call(method, arguments);
+        public virtual MethodCallExpression Call(MethodInfo method, Expression[] arguments) => ExpressionUnsafe.Call(method, arguments);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.MethodCallExpression" /> that represents a call to a static (Shared in Visual Basic) method.</summary>
         /// <param name="method">The <see cref="T:System.Reflection.MethodInfo" /> that represents the target method.</param>
         /// <param name="arguments">A collection of <see cref="T:System.Linq.Expressions.Expression" /> that represents the call arguments.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.MethodCallExpression" /> that has the <see cref="P:System.Linq.Expressions.Expression.NodeType" /> property equal to <see cref="F:System.Linq.Expressions.ExpressionType.Call" /> and the <see cref="P:System.Linq.Expressions.MethodCallExpression.Object" /> and <see cref="P:System.Linq.Expressions.MethodCallExpression.Method" /> properties set to the specified values.</returns>
         /// <remarks>This method does not provide any guarantees with regards to argument validation or type checking.</remarks>
-        public MethodCallExpression Call(MethodInfo method, IEnumerable<Expression> arguments) => ExpressionUnsafe.Call(method, arguments);
+        public virtual MethodCallExpression Call(MethodInfo method, IEnumerable<Expression> arguments) => ExpressionUnsafe.Call(method, arguments);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.MethodCallExpression" /> that represents a call to a method that takes no arguments.</summary>
         /// <param name="instance">An <see cref="T:System.Linq.Expressions.Expression" /> that specifies the instance for an instance method call (pass <see langword="null" /> for a <see langword="static" /> (<see langword="Shared" /> in Visual Basic) method).</param>
         /// <param name="method">A <see cref="T:System.Reflection.MethodInfo" /> to set the <see cref="P:System.Linq.Expressions.MethodCallExpression.Method" /> property equal to.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.MethodCallExpression" /> that has the <see cref="P:System.Linq.Expressions.Expression.NodeType" /> property equal to <see cref="F:System.Linq.Expressions.ExpressionType.Call" /> and the <see cref="P:System.Linq.Expressions.MethodCallExpression.Object" /> and <see cref="P:System.Linq.Expressions.MethodCallExpression.Method" /> properties set to the specified values.</returns>
         /// <remarks>This method does not provide any guarantees with regards to argument validation or type checking.</remarks>
-        public MethodCallExpression Call(Expression instance, MethodInfo method) => ExpressionUnsafe.Call(instance, method);
+        public virtual MethodCallExpression Call(Expression instance, MethodInfo method) => ExpressionUnsafe.Call(instance, method);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.MethodCallExpression" /> that represents a call to a static method that takes two arguments.</summary>
         /// <param name="method">A <see cref="T:System.Reflection.MethodInfo" /> to set the <see cref="P:System.Linq.Expressions.MethodCallExpression.Method" /> property equal to.</param>
@@ -368,7 +371,7 @@ namespace System.Linq.Expressions
         /// <param name="arg1">The <see cref="T:System.Linq.Expressions.Expression" /> that represents the second argument.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.MethodCallExpression" /> that has the <see cref="P:System.Linq.Expressions.Expression.NodeType" /> property equal to <see cref="F:System.Linq.Expressions.ExpressionType.Call" /> and the <see cref="P:System.Linq.Expressions.MethodCallExpression.Object" /> and <see cref="P:System.Linq.Expressions.MethodCallExpression.Method" /> properties set to the specified values.</returns>
         /// <remarks>This method does not provide any guarantees with regards to argument validation or type checking.</remarks>
-        public MethodCallExpression Call(MethodInfo method, Expression arg0, Expression arg1) => ExpressionUnsafe.Call(method, arg0, arg1);
+        public virtual MethodCallExpression Call(MethodInfo method, Expression arg0, Expression arg1) => ExpressionUnsafe.Call(method, arg0, arg1);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.MethodCallExpression" /> that represents a call to a method that takes arguments.</summary>
         /// <param name="instance">An <see cref="T:System.Linq.Expressions.Expression" /> that specifies the instance for an instance method call (pass <see langword="null" /> for a <see langword="static" /> (<see langword="Shared" /> in Visual Basic) method).</param>
@@ -376,7 +379,7 @@ namespace System.Linq.Expressions
         /// <param name="arguments">An array of <see cref="T:System.Linq.Expressions.Expression" /> objects to use to populate the <see cref="P:System.Linq.Expressions.MethodCallExpression.Arguments" /> collection.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.MethodCallExpression" /> that has the <see cref="P:System.Linq.Expressions.Expression.NodeType" /> property equal to <see cref="F:System.Linq.Expressions.ExpressionType.Call" /> and the <see cref="P:System.Linq.Expressions.MethodCallExpression.Object" />, <see cref="P:System.Linq.Expressions.MethodCallExpression.Method" />, and <see cref="P:System.Linq.Expressions.MethodCallExpression.Arguments" /> properties set to the specified values.</returns>
         /// <remarks>This method does not provide any guarantees with regards to argument validation or type checking.</remarks>
-        public MethodCallExpression Call(Expression instance, MethodInfo method, Expression[] arguments) => ExpressionUnsafe.Call(instance, method, arguments);
+        public virtual MethodCallExpression Call(Expression instance, MethodInfo method, Expression[] arguments) => ExpressionUnsafe.Call(instance, method, arguments);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.MethodCallExpression" /> that represents a call to a method that takes arguments.</summary>
         /// <param name="instance">An <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.MethodCallExpression.Object" /> property equal to (pass <see langword="null" /> for a <see langword="static" /> (<see langword="Shared" /> in Visual Basic) method).</param>
@@ -384,7 +387,7 @@ namespace System.Linq.Expressions
         /// <param name="arguments">An <see cref="T:System.Collections.Generic.IEnumerable`1" /> that contains <see cref="T:System.Linq.Expressions.Expression" /> objects to use to populate the <see cref="P:System.Linq.Expressions.MethodCallExpression.Arguments" /> collection.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.MethodCallExpression" /> that has the <see cref="P:System.Linq.Expressions.Expression.NodeType" /> property equal to <see cref="F:System.Linq.Expressions.ExpressionType.Call" /> and the <see cref="P:System.Linq.Expressions.MethodCallExpression.Object" />, <see cref="P:System.Linq.Expressions.MethodCallExpression.Method" />, and <see cref="P:System.Linq.Expressions.MethodCallExpression.Arguments" /> properties set to the specified values.</returns>
         /// <remarks>This method does not provide any guarantees with regards to argument validation or type checking.</remarks>
-        public MethodCallExpression Call(Expression instance, MethodInfo method, IEnumerable<Expression> arguments) => ExpressionUnsafe.Call(instance, method, arguments);
+        public virtual MethodCallExpression Call(Expression instance, MethodInfo method, IEnumerable<Expression> arguments) => ExpressionUnsafe.Call(instance, method, arguments);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.MethodCallExpression" /> that represents a call to a static method that takes three arguments.</summary>
         /// <param name="method">A <see cref="T:System.Reflection.MethodInfo" /> to set the <see cref="P:System.Linq.Expressions.MethodCallExpression.Method" /> property equal to.</param>
@@ -393,7 +396,7 @@ namespace System.Linq.Expressions
         /// <param name="arg2">The <see cref="T:System.Linq.Expressions.Expression" /> that represents the third argument.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.MethodCallExpression" /> that has the <see cref="P:System.Linq.Expressions.Expression.NodeType" /> property equal to <see cref="F:System.Linq.Expressions.ExpressionType.Call" /> and the <see cref="P:System.Linq.Expressions.MethodCallExpression.Object" /> and <see cref="P:System.Linq.Expressions.MethodCallExpression.Method" /> properties set to the specified values.</returns>
         /// <remarks>This method does not provide any guarantees with regards to argument validation or type checking.</remarks>
-        public MethodCallExpression Call(MethodInfo method, Expression arg0, Expression arg1, Expression arg2) => ExpressionUnsafe.Call(method, arg0, arg1, arg2);
+        public virtual MethodCallExpression Call(MethodInfo method, Expression arg0, Expression arg1, Expression arg2) => ExpressionUnsafe.Call(method, arg0, arg1, arg2);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.MethodCallExpression" /> that represents a call to a method that takes two arguments.</summary>
         /// <param name="instance">An <see cref="T:System.Linq.Expressions.Expression" /> that specifies the instance for an instance call. (pass null for a static (Shared in Visual Basic) method).</param>
@@ -402,7 +405,7 @@ namespace System.Linq.Expressions
         /// <param name="arg1">The <see cref="T:System.Linq.Expressions.Expression" /> that represents the second argument.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.MethodCallExpression" /> that has the <see cref="P:System.Linq.Expressions.Expression.NodeType" /> property equal to <see cref="F:System.Linq.Expressions.ExpressionType.Call" /> and the <see cref="P:System.Linq.Expressions.MethodCallExpression.Object" /> and <see cref="P:System.Linq.Expressions.MethodCallExpression.Method" /> properties set to the specified values.</returns>
         /// <remarks>This method does not provide any guarantees with regards to argument validation or type checking.</remarks>
-        public MethodCallExpression Call(Expression instance, MethodInfo method, Expression arg0, Expression arg1) => ExpressionUnsafe.Call(instance, method, arg0, arg1);
+        public virtual MethodCallExpression Call(Expression instance, MethodInfo method, Expression arg0, Expression arg1) => ExpressionUnsafe.Call(instance, method, arg0, arg1);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.MethodCallExpression" /> that represents a call to a method by calling the appropriate factory method.</summary>
         /// <param name="instance">An <see cref="T:System.Linq.Expressions.Expression" /> whose <see cref="P:System.Linq.Expressions.Expression.Type" /> property value will be searched for a specific method.</param>
@@ -411,7 +414,7 @@ namespace System.Linq.Expressions
         /// <param name="arguments">An array of <see cref="T:System.Linq.Expressions.Expression" /> objects that represents the arguments to the method.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.MethodCallExpression" /> that has the <see cref="P:System.Linq.Expressions.Expression.NodeType" /> property equal to <see cref="F:System.Linq.Expressions.ExpressionType.Call" />, the <see cref="P:System.Linq.Expressions.MethodCallExpression.Object" /> property equal to <paramref name="instance" />, <see cref="P:System.Linq.Expressions.MethodCallExpression.Method" /> set to the <see cref="T:System.Reflection.MethodInfo" /> that represents the specified instance method, and <see cref="P:System.Linq.Expressions.MethodCallExpression.Arguments" /> set to the specified arguments.</returns>
         /// <remarks>This method does not provide any guarantees with regards to argument validation or type checking.</remarks>
-        public MethodCallExpression Call(Expression instance, String methodName, Type[] typeArguments, Expression[] arguments) => ExpressionUnsafe.Call(instance, methodName, typeArguments, arguments);
+        public virtual MethodCallExpression Call(Expression instance, String methodName, Type[] typeArguments, Expression[] arguments) => ExpressionUnsafe.Call(instance, methodName, typeArguments, arguments);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.MethodCallExpression" /> that represents a call to a <see langword="static" /> (<see langword="Shared" /> in Visual Basic) method by calling the appropriate factory method.</summary>
         /// <param name="type">The <see cref="T:System.Type" /> that specifies the type that contains the specified <see langword="static" /> (<see langword="Shared" /> in Visual Basic) method.</param>
@@ -420,7 +423,7 @@ namespace System.Linq.Expressions
         /// <param name="arguments">An array of <see cref="T:System.Linq.Expressions.Expression" /> objects that represent the arguments to the method.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.MethodCallExpression" /> that has the <see cref="P:System.Linq.Expressions.Expression.NodeType" /> property equal to <see cref="F:System.Linq.Expressions.ExpressionType.Call" />, the <see cref="P:System.Linq.Expressions.MethodCallExpression.Method" /> property set to the <see cref="T:System.Reflection.MethodInfo" /> that represents the specified <see langword="static" /> (<see langword="Shared" /> in Visual Basic) method, and the <see cref="P:System.Linq.Expressions.MethodCallExpression.Arguments" /> property set to the specified arguments.</returns>
         /// <remarks>This method does not provide any guarantees with regards to argument validation or type checking.</remarks>
-        public MethodCallExpression Call(Type type, String methodName, Type[] typeArguments, Expression[] arguments) => ExpressionUnsafe.Call(type, methodName, typeArguments, arguments);
+        public virtual MethodCallExpression Call(Type type, String methodName, Type[] typeArguments, Expression[] arguments) => ExpressionUnsafe.Call(type, methodName, typeArguments, arguments);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.MethodCallExpression" /> that represents a call to a static method that takes four arguments.</summary>
         /// <param name="method">A <see cref="T:System.Reflection.MethodInfo" /> to set the <see cref="P:System.Linq.Expressions.MethodCallExpression.Method" /> property equal to.</param>
@@ -430,7 +433,7 @@ namespace System.Linq.Expressions
         /// <param name="arg3">The <see cref="T:System.Linq.Expressions.Expression" /> that represents the fourth argument.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.MethodCallExpression" /> that has the <see cref="P:System.Linq.Expressions.Expression.NodeType" /> property equal to <see cref="F:System.Linq.Expressions.ExpressionType.Call" /> and the <see cref="P:System.Linq.Expressions.MethodCallExpression.Object" /> and <see cref="P:System.Linq.Expressions.MethodCallExpression.Method" /> properties set to the specified values.</returns>
         /// <remarks>This method does not provide any guarantees with regards to argument validation or type checking.</remarks>
-        public MethodCallExpression Call(MethodInfo method, Expression arg0, Expression arg1, Expression arg2, Expression arg3) => ExpressionUnsafe.Call(method, arg0, arg1, arg2, arg3);
+        public virtual MethodCallExpression Call(MethodInfo method, Expression arg0, Expression arg1, Expression arg2, Expression arg3) => ExpressionUnsafe.Call(method, arg0, arg1, arg2, arg3);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.MethodCallExpression" /> that represents a call to a method that takes three arguments.</summary>
         /// <param name="instance">An <see cref="T:System.Linq.Expressions.Expression" /> that specifies the instance for an instance call. (pass null for a static (Shared in Visual Basic) method).</param>
@@ -440,7 +443,7 @@ namespace System.Linq.Expressions
         /// <param name="arg2">The <see cref="T:System.Linq.Expressions.Expression" /> that represents the third argument.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.MethodCallExpression" /> that has the <see cref="P:System.Linq.Expressions.Expression.NodeType" /> property equal to <see cref="F:System.Linq.Expressions.ExpressionType.Call" /> and the <see cref="P:System.Linq.Expressions.MethodCallExpression.Object" /> and <see cref="P:System.Linq.Expressions.MethodCallExpression.Method" /> properties set to the specified values.</returns>
         /// <remarks>This method does not provide any guarantees with regards to argument validation or type checking.</remarks>
-        public MethodCallExpression Call(Expression instance, MethodInfo method, Expression arg0, Expression arg1, Expression arg2) => ExpressionUnsafe.Call(instance, method, arg0, arg1, arg2);
+        public virtual MethodCallExpression Call(Expression instance, MethodInfo method, Expression arg0, Expression arg1, Expression arg2) => ExpressionUnsafe.Call(instance, method, arg0, arg1, arg2);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.MethodCallExpression" /> that represents a call to a static method that takes five arguments.</summary>
         /// <param name="method">A <see cref="T:System.Reflection.MethodInfo" /> to set the <see cref="P:System.Linq.Expressions.MethodCallExpression.Method" /> property equal to.</param>
@@ -451,21 +454,21 @@ namespace System.Linq.Expressions
         /// <param name="arg4">The <see cref="T:System.Linq.Expressions.Expression" /> that represents the fifth argument.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.MethodCallExpression" /> that has the <see cref="P:System.Linq.Expressions.Expression.NodeType" /> property equal to <see cref="F:System.Linq.Expressions.ExpressionType.Call" /> and the <see cref="P:System.Linq.Expressions.MethodCallExpression.Object" /> and <see cref="P:System.Linq.Expressions.MethodCallExpression.Method" /> properties set to the specified values.</returns>
         /// <remarks>This method does not provide any guarantees with regards to argument validation or type checking.</remarks>
-        public MethodCallExpression Call(MethodInfo method, Expression arg0, Expression arg1, Expression arg2, Expression arg3, Expression arg4) => ExpressionUnsafe.Call(method, arg0, arg1, arg2, arg3, arg4);
+        public virtual MethodCallExpression Call(MethodInfo method, Expression arg0, Expression arg1, Expression arg2, Expression arg3, Expression arg4) => ExpressionUnsafe.Call(method, arg0, arg1, arg2, arg3, arg4);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.CatchBlock" /> representing a catch statement.</summary>
         /// <param name="type">The <see cref="P:System.Linq.Expressions.Expression.Type" /> of <see cref="T:System.Exception" /> this <see cref="T:System.Linq.Expressions.CatchBlock" /> will handle.</param>
         /// <param name="body">The body of the catch statement.</param>
         /// <returns>The created <see cref="T:System.Linq.Expressions.CatchBlock" />.</returns>
         /// <remarks>This method does not provide any guarantees with regards to argument validation or type checking.</remarks>
-        public CatchBlock Catch(Type type, Expression body) => ExpressionUnsafe.Catch(type, body);
+        public virtual CatchBlock Catch(Type type, Expression body) => ExpressionUnsafe.Catch(type, body);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.CatchBlock" /> representing a catch statement with a reference to the caught <see cref="T:System.Exception" /> object for use in the handler body.</summary>
         /// <param name="variable">A <see cref="T:System.Linq.Expressions.ParameterExpression" /> representing a reference to the <see cref="T:System.Exception" /> object caught by this handler.</param>
         /// <param name="body">The body of the catch statement.</param>
         /// <returns>The created <see cref="T:System.Linq.Expressions.CatchBlock" />.</returns>
         /// <remarks>This method does not provide any guarantees with regards to argument validation or type checking.</remarks>
-        public CatchBlock Catch(ParameterExpression variable, Expression body) => ExpressionUnsafe.Catch(variable, body);
+        public virtual CatchBlock Catch(ParameterExpression variable, Expression body) => ExpressionUnsafe.Catch(variable, body);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.CatchBlock" /> representing a catch statement with an <see cref="T:System.Exception" /> filter but no reference to the caught <see cref="T:System.Exception" /> object.</summary>
         /// <param name="type">The <see cref="P:System.Linq.Expressions.Expression.Type" /> of <see cref="T:System.Exception" /> this <see cref="T:System.Linq.Expressions.CatchBlock" /> will handle.</param>
@@ -473,7 +476,7 @@ namespace System.Linq.Expressions
         /// <param name="filter">The body of the <see cref="T:System.Exception" /> filter.</param>
         /// <returns>The created <see cref="T:System.Linq.Expressions.CatchBlock" />.</returns>
         /// <remarks>This method does not provide any guarantees with regards to argument validation or type checking.</remarks>
-        public CatchBlock Catch(Type type, Expression body, Expression filter) => ExpressionUnsafe.Catch(type, body, filter);
+        public virtual CatchBlock Catch(Type type, Expression body, Expression filter) => ExpressionUnsafe.Catch(type, body, filter);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.CatchBlock" /> representing a catch statement with an <see cref="T:System.Exception" /> filter and a reference to the caught <see cref="T:System.Exception" /> object.</summary>
         /// <param name="variable">A <see cref="T:System.Linq.Expressions.ParameterExpression" /> representing a reference to the <see cref="T:System.Exception" /> object caught by this handler.</param>
@@ -481,20 +484,20 @@ namespace System.Linq.Expressions
         /// <param name="filter">The body of the <see cref="T:System.Exception" /> filter.</param>
         /// <returns>The created <see cref="T:System.Linq.Expressions.CatchBlock" />.</returns>
         /// <remarks>This method does not provide any guarantees with regards to argument validation or type checking.</remarks>
-        public CatchBlock Catch(ParameterExpression variable, Expression body, Expression filter) => ExpressionUnsafe.Catch(variable, body, filter);
+        public virtual CatchBlock Catch(ParameterExpression variable, Expression body, Expression filter) => ExpressionUnsafe.Catch(variable, body, filter);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.DebugInfoExpression" /> for clearing a sequence point.</summary>
         /// <param name="document">The <see cref="T:System.Linq.Expressions.SymbolDocumentInfo" /> that represents the source file.</param>
         /// <returns>An instance of <see cref="T:System.Linq.Expressions.DebugInfoExpression" /> for clearning a sequence point.</returns>
         /// <remarks>This method does not provide any guarantees with regards to argument validation or type checking.</remarks>
-        public DebugInfoExpression ClearDebugInfo(SymbolDocumentInfo document) => ExpressionUnsafe.ClearDebugInfo(document);
+        public virtual DebugInfoExpression ClearDebugInfo(SymbolDocumentInfo document) => ExpressionUnsafe.ClearDebugInfo(document);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.BinaryExpression" /> that represents a coalescing operation.</summary>
         /// <param name="left">An <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Left" /> property equal to.</param>
         /// <param name="right">An <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Right" /> property equal to.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.BinaryExpression" /> that has the <see cref="P:System.Linq.Expressions.Expression.NodeType" /> property equal to <see cref="F:System.Linq.Expressions.ExpressionType.Coalesce" /> and the <see cref="P:System.Linq.Expressions.BinaryExpression.Left" /> and <see cref="P:System.Linq.Expressions.BinaryExpression.Right" /> properties set to the specified values.</returns>
         /// <remarks>This method does not provide any guarantees with regards to argument validation or type checking.</remarks>
-        public BinaryExpression Coalesce(Expression left, Expression right) => ExpressionUnsafe.Coalesce(left, right);
+        public virtual BinaryExpression Coalesce(Expression left, Expression right) => ExpressionUnsafe.Coalesce(left, right);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.BinaryExpression" /> that represents a coalescing operation, given a conversion function.</summary>
         /// <param name="left">An <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Left" /> property equal to.</param>
@@ -502,7 +505,7 @@ namespace System.Linq.Expressions
         /// <param name="conversion">A <see cref="T:System.Linq.Expressions.LambdaExpression" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Conversion" /> property equal to.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.BinaryExpression" /> that has the <see cref="P:System.Linq.Expressions.Expression.NodeType" /> property equal to <see cref="F:System.Linq.Expressions.ExpressionType.Coalesce" /> and the <see cref="P:System.Linq.Expressions.BinaryExpression.Left" />, <see cref="P:System.Linq.Expressions.BinaryExpression.Right" /> and <see cref="P:System.Linq.Expressions.BinaryExpression.Conversion" /> properties set to the specified values.</returns>
         /// <remarks>This method does not provide any guarantees with regards to argument validation or type checking.</remarks>
-        public BinaryExpression Coalesce(Expression left, Expression right, LambdaExpression conversion) => ExpressionUnsafe.Coalesce(left, right, conversion);
+        public virtual BinaryExpression Coalesce(Expression left, Expression right, LambdaExpression conversion) => ExpressionUnsafe.Coalesce(left, right, conversion);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.ConditionalExpression" /> that represents a conditional statement.</summary>
         /// <param name="test">An <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.ConditionalExpression.Test" /> property equal to.</param>
@@ -510,7 +513,7 @@ namespace System.Linq.Expressions
         /// <param name="ifFalse">An <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.ConditionalExpression.IfFalse" /> property equal to.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.ConditionalExpression" /> that has the <see cref="P:System.Linq.Expressions.Expression.NodeType" /> property equal to <see cref="F:System.Linq.Expressions.ExpressionType.Conditional" /> and the <see cref="P:System.Linq.Expressions.ConditionalExpression.Test" />, <see cref="P:System.Linq.Expressions.ConditionalExpression.IfTrue" />, and <see cref="P:System.Linq.Expressions.ConditionalExpression.IfFalse" /> properties set to the specified values.</returns>
         /// <remarks>This method does not provide any guarantees with regards to argument validation or type checking.</remarks>
-        public ConditionalExpression Condition(Expression test, Expression ifTrue, Expression ifFalse) => ExpressionUnsafe.Condition(test, ifTrue, ifFalse);
+        public virtual ConditionalExpression Condition(Expression test, Expression ifTrue, Expression ifFalse) => ExpressionUnsafe.Condition(test, ifTrue, ifFalse);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.ConditionalExpression" /> that represents a conditional statement.</summary>
         /// <param name="test">An <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.ConditionalExpression.Test" /> property equal to.</param>
@@ -519,40 +522,40 @@ namespace System.Linq.Expressions
         /// <param name="type">A <see cref="P:System.Linq.Expressions.Expression.Type" /> to set the <see cref="P:System.Linq.Expressions.Expression.Type" /> property equal to.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.ConditionalExpression" /> that has the <see cref="P:System.Linq.Expressions.Expression.NodeType" /> property equal to <see cref="F:System.Linq.Expressions.ExpressionType.Conditional" /> and the <see cref="P:System.Linq.Expressions.ConditionalExpression.Test" />, <see cref="P:System.Linq.Expressions.ConditionalExpression.IfTrue" />, and <see cref="P:System.Linq.Expressions.ConditionalExpression.IfFalse" /> properties set to the specified values.</returns>
         /// <remarks>This method does not provide any guarantees with regards to argument validation or type checking.</remarks>
-        public ConditionalExpression Condition(Expression test, Expression ifTrue, Expression ifFalse, Type type) => ExpressionUnsafe.Condition(test, ifTrue, ifFalse, type);
+        public virtual ConditionalExpression Condition(Expression test, Expression ifTrue, Expression ifFalse, Type type) => ExpressionUnsafe.Condition(test, ifTrue, ifFalse, type);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.ConstantExpression" /> that has the <see cref="P:System.Linq.Expressions.ConstantExpression.Value" /> property set to the specified value.</summary>
         /// <param name="value">An <see cref="T:System.Object" /> to set the <see cref="P:System.Linq.Expressions.ConstantExpression.Value" /> property equal to.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.ConstantExpression" /> that has the <see cref="P:System.Linq.Expressions.Expression.NodeType" /> property equal to <see cref="F:System.Linq.Expressions.ExpressionType.Constant" /> and the <see cref="P:System.Linq.Expressions.ConstantExpression.Value" /> property set to the specified value.</returns>
         /// <remarks>This method does not provide any guarantees with regards to argument validation or type checking.</remarks>
-        public ConstantExpression Constant(Object value) => ExpressionUnsafe.Constant(value);
+        public virtual ConstantExpression Constant(Object value) => ExpressionUnsafe.Constant(value);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.ConstantExpression" /> that has the <see cref="P:System.Linq.Expressions.ConstantExpression.Value" /> and <see cref="P:System.Linq.Expressions.Expression.Type" /> properties set to the specified values.</summary>
         /// <param name="value">An <see cref="T:System.Object" /> to set the <see cref="P:System.Linq.Expressions.ConstantExpression.Value" /> property equal to.</param>
         /// <param name="type">A <see cref="T:System.Type" /> to set the <see cref="P:System.Linq.Expressions.Expression.Type" /> property equal to.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.ConstantExpression" /> that has the <see cref="P:System.Linq.Expressions.Expression.NodeType" /> property equal to <see cref="F:System.Linq.Expressions.ExpressionType.Constant" /> and the <see cref="P:System.Linq.Expressions.ConstantExpression.Value" /> and <see cref="P:System.Linq.Expressions.Expression.Type" /> properties set to the specified values.</returns>
         /// <remarks>This method does not provide any guarantees with regards to argument validation or type checking.</remarks>
-        public ConstantExpression Constant(Object value, Type type) => ExpressionUnsafe.Constant(value, type);
+        public virtual ConstantExpression Constant(Object value, Type type) => ExpressionUnsafe.Constant(value, type);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.GotoExpression" /> representing a continue statement.</summary>
         /// <param name="target">The <see cref="T:System.Linq.Expressions.LabelTarget" /> that the <see cref="T:System.Linq.Expressions.GotoExpression" /> will jump to.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.GotoExpression" /> with <see cref="P:System.Linq.Expressions.GotoExpression.Kind" /> equal to Continue, the <see cref="P:System.Linq.Expressions.GotoExpression.Target" /> property set to <paramref name="target" />, and a null value to be passed to the target label upon jumping.</returns>
         /// <remarks>This method does not provide any guarantees with regards to argument validation or type checking.</remarks>
-        public GotoExpression Continue(LabelTarget target) => ExpressionUnsafe.Continue(target);
+        public virtual GotoExpression Continue(LabelTarget target) => ExpressionUnsafe.Continue(target);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.GotoExpression" /> representing a continue statement with the specified type.</summary>
         /// <param name="target">The <see cref="T:System.Linq.Expressions.LabelTarget" /> that the <see cref="T:System.Linq.Expressions.GotoExpression" /> will jump to.</param>
         /// <param name="type">An <see cref="T:System.Type" /> to set the <see cref="P:System.Linq.Expressions.Expression.Type" /> property equal to.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.GotoExpression" /> with <see cref="P:System.Linq.Expressions.GotoExpression.Kind" /> equal to Continue, the <see cref="P:System.Linq.Expressions.GotoExpression.Target" /> property set to <paramref name="target" />, the <see cref="P:System.Linq.Expressions.Expression.Type" /> property set to <paramref name="type" />, and a null value to be passed to the target label upon jumping.</returns>
         /// <remarks>This method does not provide any guarantees with regards to argument validation or type checking.</remarks>
-        public GotoExpression Continue(LabelTarget target, Type type) => ExpressionUnsafe.Continue(target, type);
+        public virtual GotoExpression Continue(LabelTarget target, Type type) => ExpressionUnsafe.Continue(target, type);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.UnaryExpression" /> that represents a type conversion operation.</summary>
         /// <param name="expression">An <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.UnaryExpression.Operand" /> property equal to.</param>
         /// <param name="type">A <see cref="T:System.Type" /> to set the <see cref="P:System.Linq.Expressions.Expression.Type" /> property equal to.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.UnaryExpression" /> that has the <see cref="P:System.Linq.Expressions.Expression.NodeType" /> property equal to <see cref="F:System.Linq.Expressions.ExpressionType.Convert" /> and the <see cref="P:System.Linq.Expressions.UnaryExpression.Operand" /> and <see cref="P:System.Linq.Expressions.Expression.Type" /> properties set to the specified values.</returns>
         /// <remarks>This method does not provide any guarantees with regards to argument validation or type checking.</remarks>
-        public UnaryExpression Convert(Expression expression, Type type) => ExpressionUnsafe.Convert(expression, type);
+        public virtual UnaryExpression Convert(Expression expression, Type type) => ExpressionUnsafe.Convert(expression, type);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.UnaryExpression" /> that represents a conversion operation for which the implementing method is specified.</summary>
         /// <param name="expression">An <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.UnaryExpression.Operand" /> property equal to.</param>
@@ -560,14 +563,14 @@ namespace System.Linq.Expressions
         /// <param name="method">A <see cref="T:System.Reflection.MethodInfo" /> to set the <see cref="P:System.Linq.Expressions.UnaryExpression.Method" /> property equal to.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.UnaryExpression" /> that has the <see cref="P:System.Linq.Expressions.Expression.NodeType" /> property equal to <see cref="F:System.Linq.Expressions.ExpressionType.Convert" /> and the <see cref="P:System.Linq.Expressions.UnaryExpression.Operand" />, <see cref="P:System.Linq.Expressions.Expression.Type" />, and <see cref="P:System.Linq.Expressions.UnaryExpression.Method" /> properties set to the specified values.</returns>
         /// <remarks>This method does not provide any guarantees with regards to argument validation or type checking.</remarks>
-        public UnaryExpression Convert(Expression expression, Type type, MethodInfo method) => ExpressionUnsafe.Convert(expression, type, method);
+        public virtual UnaryExpression Convert(Expression expression, Type type, MethodInfo method) => ExpressionUnsafe.Convert(expression, type, method);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.UnaryExpression" /> that represents a conversion operation that throws an exception if the target type is overflowed.</summary>
         /// <param name="expression">An <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.UnaryExpression.Operand" /> property equal to.</param>
         /// <param name="type">A <see cref="T:System.Type" /> to set the <see cref="P:System.Linq.Expressions.Expression.Type" /> property equal to.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.UnaryExpression" /> that has the <see cref="P:System.Linq.Expressions.Expression.NodeType" /> property equal to <see cref="F:System.Linq.Expressions.ExpressionType.ConvertChecked" /> and the <see cref="P:System.Linq.Expressions.UnaryExpression.Operand" /> and <see cref="P:System.Linq.Expressions.Expression.Type" /> properties set to the specified values.</returns>
         /// <remarks>This method does not provide any guarantees with regards to argument validation or type checking.</remarks>
-        public UnaryExpression ConvertChecked(Expression expression, Type type) => ExpressionUnsafe.ConvertChecked(expression, type);
+        public virtual UnaryExpression ConvertChecked(Expression expression, Type type) => ExpressionUnsafe.ConvertChecked(expression, type);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.UnaryExpression" /> that represents a conversion operation that throws an exception if the target type is overflowed and for which the implementing method is specified.</summary>
         /// <param name="expression">An <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.UnaryExpression.Operand" /> property equal to.</param>
@@ -575,7 +578,7 @@ namespace System.Linq.Expressions
         /// <param name="method">A <see cref="T:System.Reflection.MethodInfo" /> to set the <see cref="P:System.Linq.Expressions.UnaryExpression.Method" /> property equal to.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.UnaryExpression" /> that has the <see cref="P:System.Linq.Expressions.Expression.NodeType" /> property equal to <see cref="F:System.Linq.Expressions.ExpressionType.ConvertChecked" /> and the <see cref="P:System.Linq.Expressions.UnaryExpression.Operand" />, <see cref="P:System.Linq.Expressions.Expression.Type" />, and <see cref="P:System.Linq.Expressions.UnaryExpression.Method" /> properties set to the specified values.</returns>
         /// <remarks>This method does not provide any guarantees with regards to argument validation or type checking.</remarks>
-        public UnaryExpression ConvertChecked(Expression expression, Type type, MethodInfo method) => ExpressionUnsafe.ConvertChecked(expression, type, method);
+        public virtual UnaryExpression ConvertChecked(Expression expression, Type type, MethodInfo method) => ExpressionUnsafe.ConvertChecked(expression, type, method);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.DebugInfoExpression" /> with the specified span.</summary>
         /// <param name="document">The <see cref="T:System.Linq.Expressions.SymbolDocumentInfo" /> that represents the source file.</param>
@@ -585,33 +588,33 @@ namespace System.Linq.Expressions
         /// <param name="endColumn">The end column of this <see cref="T:System.Linq.Expressions.DebugInfoExpression" />. If the end line is the same as the start line, it must be greater or equal than the start column. In any case, must be greater than 0.</param>
         /// <returns>An instance of <see cref="T:System.Linq.Expressions.DebugInfoExpression" />.</returns>
         /// <remarks>This method does not provide any guarantees with regards to argument validation or type checking.</remarks>
-        public DebugInfoExpression DebugInfo(SymbolDocumentInfo document, Int32 startLine, Int32 startColumn, Int32 endLine, Int32 endColumn) => ExpressionUnsafe.DebugInfo(document, startLine, startColumn, endLine, endColumn);
+        public virtual DebugInfoExpression DebugInfo(SymbolDocumentInfo document, Int32 startLine, Int32 startColumn, Int32 endLine, Int32 endColumn) => ExpressionUnsafe.DebugInfo(document, startLine, startColumn, endLine, endColumn);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.UnaryExpression" /> that represents the decrementing of the expression by 1.</summary>
         /// <param name="expression">An <see cref="T:System.Linq.Expressions.Expression" /> to decrement.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.UnaryExpression" /> that represents the decremented expression.</returns>
         /// <remarks>This method does not provide any guarantees with regards to argument validation or type checking.</remarks>
-        public UnaryExpression Decrement(Expression expression) => ExpressionUnsafe.Decrement(expression);
+        public virtual UnaryExpression Decrement(Expression expression) => ExpressionUnsafe.Decrement(expression);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.UnaryExpression" /> that represents the decrementing of the expression by 1.</summary>
         /// <param name="expression">An <see cref="T:System.Linq.Expressions.Expression" /> to decrement.</param>
         /// <param name="method">A <see cref="T:System.Reflection.MethodInfo" /> that represents the implementing method.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.UnaryExpression" /> that represents the decremented expression.</returns>
         /// <remarks>This method does not provide any guarantees with regards to argument validation or type checking.</remarks>
-        public UnaryExpression Decrement(Expression expression, MethodInfo method) => ExpressionUnsafe.Decrement(expression, method);
+        public virtual UnaryExpression Decrement(Expression expression, MethodInfo method) => ExpressionUnsafe.Decrement(expression, method);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.DefaultExpression" /> that has the <see cref="P:System.Linq.Expressions.Expression.Type" /> property set to the specified type.</summary>
         /// <param name="type">A <see cref="T:System.Type" /> to set the <see cref="P:System.Linq.Expressions.Expression.Type" /> property equal to.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.DefaultExpression" /> that has the <see cref="P:System.Linq.Expressions.Expression.NodeType" /> property equal to <see cref="F:System.Linq.Expressions.ExpressionType.Default" /> and the <see cref="P:System.Linq.Expressions.Expression.Type" /> property set to the specified type.</returns>
         /// <remarks>This method does not provide any guarantees with regards to argument validation or type checking.</remarks>
-        public DefaultExpression Default(Type type) => ExpressionUnsafe.Default(type);
+        public virtual DefaultExpression Default(Type type) => ExpressionUnsafe.Default(type);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.BinaryExpression" /> that represents an arithmetic division operation.</summary>
         /// <param name="left">An <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Left" /> property to.</param>
         /// <param name="right">An <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Right" /> property to.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.BinaryExpression" /> that has the <see cref="P:System.Linq.Expressions.Expression.NodeType" /> property equal to <see cref="F:System.Linq.Expressions.ExpressionType.Divide" /> and the <see cref="P:System.Linq.Expressions.BinaryExpression.Left" /> and <see cref="P:System.Linq.Expressions.BinaryExpression.Right" /> properties set to the specified values.</returns>
         /// <remarks>This method does not provide any guarantees with regards to argument validation or type checking.</remarks>
-        public BinaryExpression Divide(Expression left, Expression right) => ExpressionUnsafe.Divide(left, right);
+        public virtual BinaryExpression Divide(Expression left, Expression right) => ExpressionUnsafe.Divide(left, right);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.BinaryExpression" /> that represents an arithmetic division operation. The implementing method can be specified.</summary>
         /// <param name="left">An <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Left" /> property equal to.</param>
@@ -619,14 +622,14 @@ namespace System.Linq.Expressions
         /// <param name="method">A <see cref="T:System.Reflection.MethodInfo" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Method" /> property equal to.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.BinaryExpression" /> that has the <see cref="P:System.Linq.Expressions.Expression.NodeType" /> property equal to <see cref="F:System.Linq.Expressions.ExpressionType.Divide" /> and the <see cref="P:System.Linq.Expressions.BinaryExpression.Left" />, <see cref="P:System.Linq.Expressions.BinaryExpression.Right" />, and <see cref="P:System.Linq.Expressions.BinaryExpression.Method" /> properties set to the specified values.</returns>
         /// <remarks>This method does not provide any guarantees with regards to argument validation or type checking.</remarks>
-        public BinaryExpression Divide(Expression left, Expression right, MethodInfo method) => ExpressionUnsafe.Divide(left, right, method);
+        public virtual BinaryExpression Divide(Expression left, Expression right, MethodInfo method) => ExpressionUnsafe.Divide(left, right, method);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.BinaryExpression" /> that represents a division assignment operation that does not have overflow checking.</summary>
         /// <param name="left">An <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Left" /> property equal to.</param>
         /// <param name="right">An <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Right" /> property equal to.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.BinaryExpression" /> that has the <see cref="P:System.Linq.Expressions.Expression.NodeType" /> property equal to <see cref="F:System.Linq.Expressions.ExpressionType.DivideAssign" /> and the <see cref="P:System.Linq.Expressions.BinaryExpression.Left" /> and <see cref="P:System.Linq.Expressions.BinaryExpression.Right" /> properties set to the specified values.</returns>
         /// <remarks>This method does not provide any guarantees with regards to argument validation or type checking.</remarks>
-        public BinaryExpression DivideAssign(Expression left, Expression right) => ExpressionUnsafe.DivideAssign(left, right);
+        public virtual BinaryExpression DivideAssign(Expression left, Expression right) => ExpressionUnsafe.DivideAssign(left, right);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.BinaryExpression" /> that represents a division assignment operation that does not have overflow checking.</summary>
         /// <param name="left">An <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Left" /> property equal to.</param>
@@ -634,7 +637,7 @@ namespace System.Linq.Expressions
         /// <param name="method">A <see cref="T:System.Reflection.MethodInfo" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Method" /> property equal to.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.BinaryExpression" /> that has the <see cref="P:System.Linq.Expressions.Expression.NodeType" /> property equal to <see cref="F:System.Linq.Expressions.ExpressionType.DivideAssign" /> and the <see cref="P:System.Linq.Expressions.BinaryExpression.Left" />, <see cref="P:System.Linq.Expressions.BinaryExpression.Right" />, and <see cref="P:System.Linq.Expressions.BinaryExpression.Method" /> properties set to the specified values.</returns>
         /// <remarks>This method does not provide any guarantees with regards to argument validation or type checking.</remarks>
-        public BinaryExpression DivideAssign(Expression left, Expression right, MethodInfo method) => ExpressionUnsafe.DivideAssign(left, right, method);
+        public virtual BinaryExpression DivideAssign(Expression left, Expression right, MethodInfo method) => ExpressionUnsafe.DivideAssign(left, right, method);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.BinaryExpression" /> that represents a division assignment operation that does not have overflow checking.</summary>
         /// <param name="left">An <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Left" /> property equal to.</param>
@@ -643,7 +646,7 @@ namespace System.Linq.Expressions
         /// <param name="conversion">A <see cref="T:System.Linq.Expressions.LambdaExpression" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Conversion" /> property equal to.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.BinaryExpression" /> that has the <see cref="P:System.Linq.Expressions.Expression.NodeType" /> property equal to <see cref="F:System.Linq.Expressions.ExpressionType.DivideAssign" /> and the <see cref="P:System.Linq.Expressions.BinaryExpression.Left" />, <see cref="P:System.Linq.Expressions.BinaryExpression.Right" />, <see cref="P:System.Linq.Expressions.BinaryExpression.Method" />, and <see cref="P:System.Linq.Expressions.BinaryExpression.Conversion" /> properties set to the specified values.</returns>
         /// <remarks>This method does not provide any guarantees with regards to argument validation or type checking.</remarks>
-        public BinaryExpression DivideAssign(Expression left, Expression right, MethodInfo method, LambdaExpression conversion) => ExpressionUnsafe.DivideAssign(left, right, method, conversion);
+        public virtual BinaryExpression DivideAssign(Expression left, Expression right, MethodInfo method, LambdaExpression conversion) => ExpressionUnsafe.DivideAssign(left, right, method, conversion);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.DynamicExpression" /> that represents a dynamic operation bound by the provided <see cref="T:System.Runtime.CompilerServices.CallSiteBinder" />.</summary>
         /// <param name="binder">The runtime binder for the dynamic operation.</param>
@@ -651,7 +654,7 @@ namespace System.Linq.Expressions
         /// <param name="arguments">The arguments to the dynamic operation.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.DynamicExpression" /> that has <see cref="P:System.Linq.Expressions.Expression.NodeType" /> equal to <see cref="F:System.Linq.Expressions.ExpressionType.Dynamic" /> and has the <see cref="P:System.Linq.Expressions.DynamicExpression.Binder" /> and <see cref="P:System.Linq.Expressions.DynamicExpression.Arguments" /> set to the specified values.</returns>
         /// <remarks>This method does not provide any guarantees with regards to argument validation or type checking.</remarks>
-        public DynamicExpression Dynamic(CallSiteBinder binder, Type returnType, Expression[] arguments) => ExpressionUnsafe.Dynamic(binder, returnType, arguments);
+        public virtual DynamicExpression Dynamic(CallSiteBinder binder, Type returnType, Expression[] arguments) => ExpressionUnsafe.Dynamic(binder, returnType, arguments);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.DynamicExpression" /> that represents a dynamic operation bound by the provided <see cref="T:System.Runtime.CompilerServices.CallSiteBinder" />.</summary>
         /// <param name="binder">The runtime binder for the dynamic operation.</param>
@@ -659,7 +662,7 @@ namespace System.Linq.Expressions
         /// <param name="arg0">The first argument to the dynamic operation.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.DynamicExpression" /> that has <see cref="P:System.Linq.Expressions.Expression.NodeType" /> equal to <see cref="F:System.Linq.Expressions.ExpressionType.Dynamic" /> and has the <see cref="P:System.Linq.Expressions.DynamicExpression.Binder" /> and <see cref="P:System.Linq.Expressions.DynamicExpression.Arguments" /> set to the specified values.</returns>
         /// <remarks>This method does not provide any guarantees with regards to argument validation or type checking.</remarks>
-        public DynamicExpression Dynamic(CallSiteBinder binder, Type returnType, Expression arg0) => ExpressionUnsafe.Dynamic(binder, returnType, arg0);
+        public virtual DynamicExpression Dynamic(CallSiteBinder binder, Type returnType, Expression arg0) => ExpressionUnsafe.Dynamic(binder, returnType, arg0);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.DynamicExpression" /> that represents a dynamic operation bound by the provided <see cref="T:System.Runtime.CompilerServices.CallSiteBinder" />.</summary>
         /// <param name="binder">The runtime binder for the dynamic operation.</param>
@@ -667,7 +670,7 @@ namespace System.Linq.Expressions
         /// <param name="arguments">The arguments to the dynamic operation.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.DynamicExpression" /> that has <see cref="P:System.Linq.Expressions.Expression.NodeType" /> equal to <see cref="F:System.Linq.Expressions.ExpressionType.Dynamic" /> and has the <see cref="P:System.Linq.Expressions.DynamicExpression.Binder" /> and <see cref="P:System.Linq.Expressions.DynamicExpression.Arguments" /> set to the specified values.</returns>
         /// <remarks>This method does not provide any guarantees with regards to argument validation or type checking.</remarks>
-        public DynamicExpression Dynamic(CallSiteBinder binder, Type returnType, IEnumerable<Expression> arguments) => ExpressionUnsafe.Dynamic(binder, returnType, arguments);
+        public virtual DynamicExpression Dynamic(CallSiteBinder binder, Type returnType, IEnumerable<Expression> arguments) => ExpressionUnsafe.Dynamic(binder, returnType, arguments);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.DynamicExpression" /> that represents a dynamic operation bound by the provided <see cref="T:System.Runtime.CompilerServices.CallSiteBinder" />.</summary>
         /// <param name="binder">The runtime binder for the dynamic operation.</param>
@@ -676,7 +679,7 @@ namespace System.Linq.Expressions
         /// <param name="arg1">The second argument to the dynamic operation.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.DynamicExpression" /> that has <see cref="P:System.Linq.Expressions.Expression.NodeType" /> equal to <see cref="F:System.Linq.Expressions.ExpressionType.Dynamic" /> and has the <see cref="P:System.Linq.Expressions.DynamicExpression.Binder" /> and <see cref="P:System.Linq.Expressions.DynamicExpression.Arguments" /> set to the specified values.</returns>
         /// <remarks>This method does not provide any guarantees with regards to argument validation or type checking.</remarks>
-        public DynamicExpression Dynamic(CallSiteBinder binder, Type returnType, Expression arg0, Expression arg1) => ExpressionUnsafe.Dynamic(binder, returnType, arg0, arg1);
+        public virtual DynamicExpression Dynamic(CallSiteBinder binder, Type returnType, Expression arg0, Expression arg1) => ExpressionUnsafe.Dynamic(binder, returnType, arg0, arg1);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.DynamicExpression" /> that represents a dynamic operation bound by the provided <see cref="T:System.Runtime.CompilerServices.CallSiteBinder" />.</summary>
         /// <param name="binder">The runtime binder for the dynamic operation.</param>
@@ -686,7 +689,7 @@ namespace System.Linq.Expressions
         /// <param name="arg2">The third argument to the dynamic operation.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.DynamicExpression" /> that has <see cref="P:System.Linq.Expressions.Expression.NodeType" /> equal to <see cref="F:System.Linq.Expressions.ExpressionType.Dynamic" /> and has the <see cref="P:System.Linq.Expressions.DynamicExpression.Binder" /> and <see cref="P:System.Linq.Expressions.DynamicExpression.Arguments" /> set to the specified values.</returns>
         /// <remarks>This method does not provide any guarantees with regards to argument validation or type checking.</remarks>
-        public DynamicExpression Dynamic(CallSiteBinder binder, Type returnType, Expression arg0, Expression arg1, Expression arg2) => ExpressionUnsafe.Dynamic(binder, returnType, arg0, arg1, arg2);
+        public virtual DynamicExpression Dynamic(CallSiteBinder binder, Type returnType, Expression arg0, Expression arg1, Expression arg2) => ExpressionUnsafe.Dynamic(binder, returnType, arg0, arg1, arg2);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.DynamicExpression" /> that represents a dynamic operation bound by the provided <see cref="T:System.Runtime.CompilerServices.CallSiteBinder" />.</summary>
         /// <param name="binder">The runtime binder for the dynamic operation.</param>
@@ -697,33 +700,33 @@ namespace System.Linq.Expressions
         /// <param name="arg3">The fourth argument to the dynamic operation.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.DynamicExpression" /> that has <see cref="P:System.Linq.Expressions.Expression.NodeType" /> equal to <see cref="F:System.Linq.Expressions.ExpressionType.Dynamic" /> and has the <see cref="P:System.Linq.Expressions.DynamicExpression.Binder" /> and <see cref="P:System.Linq.Expressions.DynamicExpression.Arguments" /> set to the specified values.</returns>
         /// <remarks>This method does not provide any guarantees with regards to argument validation or type checking.</remarks>
-        public DynamicExpression Dynamic(CallSiteBinder binder, Type returnType, Expression arg0, Expression arg1, Expression arg2, Expression arg3) => ExpressionUnsafe.Dynamic(binder, returnType, arg0, arg1, arg2, arg3);
+        public virtual DynamicExpression Dynamic(CallSiteBinder binder, Type returnType, Expression arg0, Expression arg1, Expression arg2, Expression arg3) => ExpressionUnsafe.Dynamic(binder, returnType, arg0, arg1, arg2, arg3);
 
         /// <summary>Creates an <see cref="T:System.Linq.Expressions.ElementInit" />, given an array of values as the second argument.</summary>
         /// <param name="addMethod">A <see cref="T:System.Reflection.MethodInfo" /> to set the <see cref="P:System.Linq.Expressions.ElementInit.AddMethod" /> property equal to.</param>
         /// <param name="arguments">An array of <see cref="T:System.Linq.Expressions.Expression" /> objects to set the <see cref="P:System.Linq.Expressions.ElementInit.Arguments" /> property equal to.</param>
         /// <returns>An <see cref="T:System.Linq.Expressions.ElementInit" /> that has the <see cref="P:System.Linq.Expressions.ElementInit.AddMethod" /> and <see cref="P:System.Linq.Expressions.ElementInit.Arguments" /> properties set to the specified values.</returns>
         /// <remarks>This method does not provide any guarantees with regards to argument validation or type checking.</remarks>
-        public ElementInit ElementInit(MethodInfo addMethod, Expression[] arguments) => ExpressionUnsafe.ElementInit(addMethod, arguments);
+        public virtual ElementInit ElementInit(MethodInfo addMethod, Expression[] arguments) => ExpressionUnsafe.ElementInit(addMethod, arguments);
 
         /// <summary>Creates an <see cref="T:System.Linq.Expressions.ElementInit" />, given an <see cref="T:System.Collections.Generic.IEnumerable`1" /> as the second argument.</summary>
         /// <param name="addMethod">A <see cref="T:System.Reflection.MethodInfo" /> to set the <see cref="P:System.Linq.Expressions.ElementInit.AddMethod" /> property equal to.</param>
         /// <param name="arguments">An <see cref="T:System.Collections.Generic.IEnumerable`1" /> that contains <see cref="T:System.Linq.Expressions.Expression" /> objects to set the <see cref="P:System.Linq.Expressions.ElementInit.Arguments" /> property equal to.</param>
         /// <returns>An <see cref="T:System.Linq.Expressions.ElementInit" /> that has the <see cref="P:System.Linq.Expressions.ElementInit.AddMethod" /> and <see cref="P:System.Linq.Expressions.ElementInit.Arguments" /> properties set to the specified values.</returns>
         /// <remarks>This method does not provide any guarantees with regards to argument validation or type checking.</remarks>
-        public ElementInit ElementInit(MethodInfo addMethod, IEnumerable<Expression> arguments) => ExpressionUnsafe.ElementInit(addMethod, arguments);
+        public virtual ElementInit ElementInit(MethodInfo addMethod, IEnumerable<Expression> arguments) => ExpressionUnsafe.ElementInit(addMethod, arguments);
 
         /// <summary>Creates an empty expression that has <see cref="T:System.Void" /> type.</summary>
         /// <returns>A <see cref="T:System.Linq.Expressions.DefaultExpression" /> that has the <see cref="P:System.Linq.Expressions.Expression.NodeType" /> property equal to <see cref="F:System.Linq.Expressions.ExpressionType.Default" /> and the <see cref="P:System.Linq.Expressions.Expression.Type" /> property set to <see cref="T:System.Void" />.</returns>
         /// <remarks>This method does not provide any guarantees with regards to argument validation or type checking.</remarks>
-        public DefaultExpression Empty() => ExpressionUnsafe.Empty();
+        public virtual DefaultExpression Empty() => ExpressionUnsafe.Empty();
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.BinaryExpression" /> that represents an equality comparison.</summary>
         /// <param name="left">An <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Left" /> property equal to.</param>
         /// <param name="right">An <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Right" /> property equal to.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.BinaryExpression" /> that has the <see cref="P:System.Linq.Expressions.Expression.NodeType" /> property equal to <see cref="F:System.Linq.Expressions.ExpressionType.Equal" /> and the <see cref="P:System.Linq.Expressions.BinaryExpression.Left" /> and <see cref="P:System.Linq.Expressions.BinaryExpression.Right" /> properties set to the specified values.</returns>
         /// <remarks>This method does not provide any guarantees with regards to argument validation or type checking.</remarks>
-        public BinaryExpression Equal(Expression left, Expression right) => ExpressionUnsafe.Equal(left, right);
+        public virtual BinaryExpression Equal(Expression left, Expression right) => ExpressionUnsafe.Equal(left, right);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.BinaryExpression" /> that represents an equality comparison. The implementing method can be specified.</summary>
         /// <param name="left">An <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Left" /> property equal to.</param>
@@ -733,14 +736,14 @@ namespace System.Linq.Expressions
         /// <param name="method">A <see cref="T:System.Reflection.MethodInfo" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Method" /> property equal to.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.BinaryExpression" /> that has the <see cref="P:System.Linq.Expressions.Expression.NodeType" /> property equal to <see cref="F:System.Linq.Expressions.ExpressionType.Equal" /> and the <see cref="P:System.Linq.Expressions.BinaryExpression.Left" />, <see cref="P:System.Linq.Expressions.BinaryExpression.Right" />, <see cref="P:System.Linq.Expressions.BinaryExpression.IsLiftedToNull" />, and <see cref="P:System.Linq.Expressions.BinaryExpression.Method" /> properties set to the specified values.</returns>
         /// <remarks>This method does not provide any guarantees with regards to argument validation or type checking.</remarks>
-        public BinaryExpression Equal(Expression left, Expression right, Boolean liftToNull, MethodInfo method) => ExpressionUnsafe.Equal(left, right, liftToNull, method);
+        public virtual BinaryExpression Equal(Expression left, Expression right, Boolean liftToNull, MethodInfo method) => ExpressionUnsafe.Equal(left, right, liftToNull, method);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.BinaryExpression" /> that represents a bitwise <see langword="XOR" /> operation, using op_ExclusiveOr for user-defined types.</summary>
         /// <param name="left">An <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Left" /> property equal to.</param>
         /// <param name="right">An <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Right" /> property equal to.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.BinaryExpression" /> that has the <see cref="P:System.Linq.Expressions.Expression.NodeType" /> property equal to <see cref="F:System.Linq.Expressions.ExpressionType.ExclusiveOr" /> and the <see cref="P:System.Linq.Expressions.BinaryExpression.Left" /> and <see cref="P:System.Linq.Expressions.BinaryExpression.Right" /> properties set to the specified values.</returns>
         /// <remarks>This method does not provide any guarantees with regards to argument validation or type checking.</remarks>
-        public BinaryExpression ExclusiveOr(Expression left, Expression right) => ExpressionUnsafe.ExclusiveOr(left, right);
+        public virtual BinaryExpression ExclusiveOr(Expression left, Expression right) => ExpressionUnsafe.ExclusiveOr(left, right);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.BinaryExpression" /> that represents a bitwise <see langword="XOR" /> operation, using op_ExclusiveOr for user-defined types. The implementing method can be specified.</summary>
         /// <param name="left">An <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Left" /> property equal to.</param>
@@ -748,14 +751,14 @@ namespace System.Linq.Expressions
         /// <param name="method">A <see cref="T:System.Reflection.MethodInfo" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Method" /> property equal to.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.BinaryExpression" /> that has the <see cref="P:System.Linq.Expressions.Expression.NodeType" /> property equal to <see cref="F:System.Linq.Expressions.ExpressionType.ExclusiveOr" /> and the <see cref="P:System.Linq.Expressions.BinaryExpression.Left" />, <see cref="P:System.Linq.Expressions.BinaryExpression.Right" />, and <see cref="P:System.Linq.Expressions.BinaryExpression.Method" /> properties set to the specified values.</returns>
         /// <remarks>This method does not provide any guarantees with regards to argument validation or type checking.</remarks>
-        public BinaryExpression ExclusiveOr(Expression left, Expression right, MethodInfo method) => ExpressionUnsafe.ExclusiveOr(left, right, method);
+        public virtual BinaryExpression ExclusiveOr(Expression left, Expression right, MethodInfo method) => ExpressionUnsafe.ExclusiveOr(left, right, method);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.BinaryExpression" /> that represents a bitwise XOR assignment operation, using op_ExclusiveOr for user-defined types.</summary>
         /// <param name="left">An <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Left" /> property equal to.</param>
         /// <param name="right">An <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Right" /> property equal to.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.BinaryExpression" /> that has the <see cref="P:System.Linq.Expressions.Expression.NodeType" /> property equal to <see cref="F:System.Linq.Expressions.ExpressionType.ExclusiveOrAssign" /> and the <see cref="P:System.Linq.Expressions.BinaryExpression.Left" /> and <see cref="P:System.Linq.Expressions.BinaryExpression.Right" /> properties set to the specified values.</returns>
         /// <remarks>This method does not provide any guarantees with regards to argument validation or type checking.</remarks>
-        public BinaryExpression ExclusiveOrAssign(Expression left, Expression right) => ExpressionUnsafe.ExclusiveOrAssign(left, right);
+        public virtual BinaryExpression ExclusiveOrAssign(Expression left, Expression right) => ExpressionUnsafe.ExclusiveOrAssign(left, right);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.BinaryExpression" /> that represents a bitwise XOR assignment operation, using op_ExclusiveOr for user-defined types.</summary>
         /// <param name="left">An <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Left" /> property equal to.</param>
@@ -763,7 +766,7 @@ namespace System.Linq.Expressions
         /// <param name="method">A <see cref="T:System.Reflection.MethodInfo" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Method" /> property equal to.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.BinaryExpression" /> that has the <see cref="P:System.Linq.Expressions.Expression.NodeType" /> property equal to <see cref="F:System.Linq.Expressions.ExpressionType.ExclusiveOrAssign" /> and the <see cref="P:System.Linq.Expressions.BinaryExpression.Left" />, <see cref="P:System.Linq.Expressions.BinaryExpression.Right" />, and <see cref="P:System.Linq.Expressions.BinaryExpression.Method" /> properties set to the specified values.</returns>
         /// <remarks>This method does not provide any guarantees with regards to argument validation or type checking.</remarks>
-        public BinaryExpression ExclusiveOrAssign(Expression left, Expression right, MethodInfo method) => ExpressionUnsafe.ExclusiveOrAssign(left, right, method);
+        public virtual BinaryExpression ExclusiveOrAssign(Expression left, Expression right, MethodInfo method) => ExpressionUnsafe.ExclusiveOrAssign(left, right, method);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.BinaryExpression" /> that represents a bitwise XOR assignment operation, using op_ExclusiveOr for user-defined types.</summary>
         /// <param name="left">An <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Left" /> property equal to.</param>
@@ -772,21 +775,21 @@ namespace System.Linq.Expressions
         /// <param name="conversion">A <see cref="T:System.Linq.Expressions.LambdaExpression" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Conversion" /> property equal to.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.BinaryExpression" /> that has the <see cref="P:System.Linq.Expressions.Expression.NodeType" /> property equal to <see cref="F:System.Linq.Expressions.ExpressionType.ExclusiveOrAssign" /> and the <see cref="P:System.Linq.Expressions.BinaryExpression.Left" />, <see cref="P:System.Linq.Expressions.BinaryExpression.Right" />, <see cref="P:System.Linq.Expressions.BinaryExpression.Method" />, and <see cref="P:System.Linq.Expressions.BinaryExpression.Conversion" /> properties set to the specified values.</returns>
         /// <remarks>This method does not provide any guarantees with regards to argument validation or type checking.</remarks>
-        public BinaryExpression ExclusiveOrAssign(Expression left, Expression right, MethodInfo method, LambdaExpression conversion) => ExpressionUnsafe.ExclusiveOrAssign(left, right, method, conversion);
+        public virtual BinaryExpression ExclusiveOrAssign(Expression left, Expression right, MethodInfo method, LambdaExpression conversion) => ExpressionUnsafe.ExclusiveOrAssign(left, right, method, conversion);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.MemberExpression" /> that represents accessing a field.</summary>
         /// <param name="expression">An <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.MemberExpression.Expression" /> property equal to. For <see langword="static" /> (<see langword="Shared" /> in Visual Basic), <paramref name="expression" /> must be <see langword="null" />.</param>
         /// <param name="field">The <see cref="T:System.Reflection.FieldInfo" /> to set the <see cref="P:System.Linq.Expressions.MemberExpression.Member" /> property equal to.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.MemberExpression" /> that has the <see cref="P:System.Linq.Expressions.Expression.NodeType" /> property equal to <see cref="F:System.Linq.Expressions.ExpressionType.MemberAccess" /> and the <see cref="P:System.Linq.Expressions.MemberExpression.Expression" /> and <see cref="P:System.Linq.Expressions.MemberExpression.Member" /> properties set to the specified values.</returns>
         /// <remarks>This method does not provide any guarantees with regards to argument validation or type checking.</remarks>
-        public MemberExpression Field(Expression expression, FieldInfo field) => ExpressionUnsafe.Field(expression, field);
+        public virtual MemberExpression Field(Expression expression, FieldInfo field) => ExpressionUnsafe.Field(expression, field);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.MemberExpression" /> that represents accessing a field given the name of the field.</summary>
         /// <param name="expression">An <see cref="T:System.Linq.Expressions.Expression" /> whose <see cref="P:System.Linq.Expressions.Expression.Type" /> contains a field named <paramref name="fieldName" />. This can be null for static fields.</param>
         /// <param name="fieldName">The name of a field to be accessed.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.MemberExpression" /> that has the <see cref="P:System.Linq.Expressions.Expression.NodeType" /> property equal to <see cref="F:System.Linq.Expressions.ExpressionType.MemberAccess" />, the <see cref="P:System.Linq.Expressions.MemberExpression.Expression" /> property set to <paramref name="expression" />, and the <see cref="P:System.Linq.Expressions.MemberExpression.Member" /> property set to the <see cref="T:System.Reflection.FieldInfo" /> that represents the field denoted by <paramref name="fieldName" />.</returns>
         /// <remarks>This method does not provide any guarantees with regards to argument validation or type checking.</remarks>
-        public MemberExpression Field(Expression expression, String fieldName) => ExpressionUnsafe.Field(expression, fieldName);
+        public virtual MemberExpression Field(Expression expression, String fieldName) => ExpressionUnsafe.Field(expression, fieldName);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.MemberExpression" /> that represents accessing a field.</summary>
         /// <param name="expression">The containing object of the field. This can be null for static fields.</param>
@@ -794,27 +797,27 @@ namespace System.Linq.Expressions
         /// <param name="fieldName">The field to be accessed.</param>
         /// <returns>The created <see cref="T:System.Linq.Expressions.MemberExpression" />.</returns>
         /// <remarks>This method does not provide any guarantees with regards to argument validation or type checking.</remarks>
-        public MemberExpression Field(Expression expression, Type type, String fieldName) => ExpressionUnsafe.Field(expression, type, fieldName);
+        public virtual MemberExpression Field(Expression expression, Type type, String fieldName) => ExpressionUnsafe.Field(expression, type, fieldName);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.GotoExpression" /> representing a "go to" statement.</summary>
         /// <param name="target">The <see cref="T:System.Linq.Expressions.LabelTarget" /> that the <see cref="T:System.Linq.Expressions.GotoExpression" /> will jump to.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.GotoExpression" /> with <see cref="P:System.Linq.Expressions.GotoExpression.Kind" /> equal to Goto, the <see cref="P:System.Linq.Expressions.GotoExpression.Target" /> property set to the specified value, and a null value to be passed to the target label upon jumping.</returns>
         /// <remarks>This method does not provide any guarantees with regards to argument validation or type checking.</remarks>
-        public GotoExpression Goto(LabelTarget target) => ExpressionUnsafe.Goto(target);
+        public virtual GotoExpression Goto(LabelTarget target) => ExpressionUnsafe.Goto(target);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.GotoExpression" /> representing a "go to" statement with the specified type.</summary>
         /// <param name="target">The <see cref="T:System.Linq.Expressions.LabelTarget" /> that the <see cref="T:System.Linq.Expressions.GotoExpression" /> will jump to.</param>
         /// <param name="type">An <see cref="T:System.Type" /> to set the <see cref="P:System.Linq.Expressions.Expression.Type" /> property equal to.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.GotoExpression" /> with <see cref="P:System.Linq.Expressions.GotoExpression.Kind" /> equal to Goto, the <see cref="P:System.Linq.Expressions.GotoExpression.Target" /> property set to the specified value, the <see cref="P:System.Linq.Expressions.Expression.Type" /> property set to <paramref name="type" />, and a null value to be passed to the target label upon jumping.</returns>
         /// <remarks>This method does not provide any guarantees with regards to argument validation or type checking.</remarks>
-        public GotoExpression Goto(LabelTarget target, Type type) => ExpressionUnsafe.Goto(target, type);
+        public virtual GotoExpression Goto(LabelTarget target, Type type) => ExpressionUnsafe.Goto(target, type);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.GotoExpression" /> representing a "go to" statement. The value passed to the label upon jumping can be specified.</summary>
         /// <param name="target">The <see cref="T:System.Linq.Expressions.LabelTarget" /> that the <see cref="T:System.Linq.Expressions.GotoExpression" /> will jump to.</param>
         /// <param name="value">The value that will be passed to the associated label upon jumping.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.GotoExpression" /> with <see cref="P:System.Linq.Expressions.GotoExpression.Kind" /> equal to Goto, the <see cref="P:System.Linq.Expressions.GotoExpression.Target" /> property set to <paramref name="target" />, and <paramref name="value" /> to be passed to the target label upon jumping.</returns>
         /// <remarks>This method does not provide any guarantees with regards to argument validation or type checking.</remarks>
-        public GotoExpression Goto(LabelTarget target, Expression value) => ExpressionUnsafe.Goto(target, value);
+        public virtual GotoExpression Goto(LabelTarget target, Expression value) => ExpressionUnsafe.Goto(target, value);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.GotoExpression" /> representing a "go to" statement with the specified type. The value passed to the label upon jumping can be specified.</summary>
         /// <param name="target">The <see cref="T:System.Linq.Expressions.LabelTarget" /> that the <see cref="T:System.Linq.Expressions.GotoExpression" /> will jump to.</param>
@@ -822,14 +825,14 @@ namespace System.Linq.Expressions
         /// <param name="type">An <see cref="T:System.Type" /> to set the <see cref="P:System.Linq.Expressions.Expression.Type" /> property equal to.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.GotoExpression" /> with <see cref="P:System.Linq.Expressions.GotoExpression.Kind" /> equal to Goto, the <see cref="P:System.Linq.Expressions.GotoExpression.Target" /> property set to <paramref name="target" />, the <see cref="P:System.Linq.Expressions.Expression.Type" /> property set to <paramref name="type" />, and <paramref name="value" /> to be passed to the target label upon jumping.</returns>
         /// <remarks>This method does not provide any guarantees with regards to argument validation or type checking.</remarks>
-        public GotoExpression Goto(LabelTarget target, Expression value, Type type) => ExpressionUnsafe.Goto(target, value, type);
+        public virtual GotoExpression Goto(LabelTarget target, Expression value, Type type) => ExpressionUnsafe.Goto(target, value, type);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.BinaryExpression" /> that represents a "greater than" numeric comparison.</summary>
         /// <param name="left">An <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Left" /> property equal to.</param>
         /// <param name="right">An <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Right" /> property equal to.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.BinaryExpression" /> that has the <see cref="P:System.Linq.Expressions.Expression.NodeType" /> property equal to <see cref="F:System.Linq.Expressions.ExpressionType.GreaterThan" /> and the <see cref="P:System.Linq.Expressions.BinaryExpression.Left" /> and <see cref="P:System.Linq.Expressions.BinaryExpression.Right" /> properties set to the specified values.</returns>
         /// <remarks>This method does not provide any guarantees with regards to argument validation or type checking.</remarks>
-        public BinaryExpression GreaterThan(Expression left, Expression right) => ExpressionUnsafe.GreaterThan(left, right);
+        public virtual BinaryExpression GreaterThan(Expression left, Expression right) => ExpressionUnsafe.GreaterThan(left, right);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.BinaryExpression" /> that represents a "greater than" numeric comparison. The implementing method can be specified.</summary>
         /// <param name="left">An <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Left" /> property equal to.</param>
@@ -839,14 +842,14 @@ namespace System.Linq.Expressions
         /// <param name="method">A <see cref="T:System.Reflection.MethodInfo" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Method" /> property equal to.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.BinaryExpression" /> that has the <see cref="P:System.Linq.Expressions.Expression.NodeType" /> property equal to <see cref="F:System.Linq.Expressions.ExpressionType.GreaterThan" /> and the <see cref="P:System.Linq.Expressions.BinaryExpression.Left" />, <see cref="P:System.Linq.Expressions.BinaryExpression.Right" />, <see cref="P:System.Linq.Expressions.BinaryExpression.IsLiftedToNull" />, and <see cref="P:System.Linq.Expressions.BinaryExpression.Method" /> properties set to the specified values.</returns>
         /// <remarks>This method does not provide any guarantees with regards to argument validation or type checking.</remarks>
-        public BinaryExpression GreaterThan(Expression left, Expression right, Boolean liftToNull, MethodInfo method) => ExpressionUnsafe.GreaterThan(left, right, liftToNull, method);
+        public virtual BinaryExpression GreaterThan(Expression left, Expression right, Boolean liftToNull, MethodInfo method) => ExpressionUnsafe.GreaterThan(left, right, liftToNull, method);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.BinaryExpression" /> that represents a "greater than or equal" numeric comparison.</summary>
         /// <param name="left">An <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Left" /> property equal to.</param>
         /// <param name="right">An <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Right" /> property equal to.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.BinaryExpression" /> that has the <see cref="P:System.Linq.Expressions.Expression.NodeType" /> property equal to <see cref="F:System.Linq.Expressions.ExpressionType.GreaterThanOrEqual" /> and the <see cref="P:System.Linq.Expressions.BinaryExpression.Left" /> and <see cref="P:System.Linq.Expressions.BinaryExpression.Right" /> properties set to the specified values.</returns>
         /// <remarks>This method does not provide any guarantees with regards to argument validation or type checking.</remarks>
-        public BinaryExpression GreaterThanOrEqual(Expression left, Expression right) => ExpressionUnsafe.GreaterThanOrEqual(left, right);
+        public virtual BinaryExpression GreaterThanOrEqual(Expression left, Expression right) => ExpressionUnsafe.GreaterThanOrEqual(left, right);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.BinaryExpression" /> that represents a "greater than or equal" numeric comparison.</summary>
         /// <param name="left">An <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Left" /> property equal to.</param>
@@ -856,14 +859,14 @@ namespace System.Linq.Expressions
         /// <param name="method">A <see cref="T:System.Reflection.MethodInfo" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Method" /> property equal to.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.BinaryExpression" /> that has the <see cref="P:System.Linq.Expressions.Expression.NodeType" /> property equal to <see cref="F:System.Linq.Expressions.ExpressionType.GreaterThanOrEqual" /> and the <see cref="P:System.Linq.Expressions.BinaryExpression.Left" />, <see cref="P:System.Linq.Expressions.BinaryExpression.Right" />, <see cref="P:System.Linq.Expressions.BinaryExpression.IsLiftedToNull" />, and <see cref="P:System.Linq.Expressions.BinaryExpression.Method" /> properties set to the specified values.</returns>
         /// <remarks>This method does not provide any guarantees with regards to argument validation or type checking.</remarks>
-        public BinaryExpression GreaterThanOrEqual(Expression left, Expression right, Boolean liftToNull, MethodInfo method) => ExpressionUnsafe.GreaterThanOrEqual(left, right, liftToNull, method);
+        public virtual BinaryExpression GreaterThanOrEqual(Expression left, Expression right, Boolean liftToNull, MethodInfo method) => ExpressionUnsafe.GreaterThanOrEqual(left, right, liftToNull, method);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.ConditionalExpression" /> that represents a conditional block with an <see langword="if" /> statement.</summary>
         /// <param name="test">An <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.ConditionalExpression.Test" /> property equal to.</param>
         /// <param name="ifTrue">An <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.ConditionalExpression.IfTrue" /> property equal to.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.ConditionalExpression" /> that has the <see cref="P:System.Linq.Expressions.Expression.NodeType" /> property equal to <see cref="F:System.Linq.Expressions.ExpressionType.Conditional" /> and the <see cref="P:System.Linq.Expressions.ConditionalExpression.Test" />, <see cref="P:System.Linq.Expressions.ConditionalExpression.IfTrue" />, properties set to the specified values. The <see cref="P:System.Linq.Expressions.ConditionalExpression.IfFalse" /> property is set to default expression and the type of the resulting <see cref="T:System.Linq.Expressions.ConditionalExpression" /> returned by this method is <see cref="T:System.Void" />.</returns>
         /// <remarks>This method does not provide any guarantees with regards to argument validation or type checking.</remarks>
-        public ConditionalExpression IfThen(Expression test, Expression ifTrue) => ExpressionUnsafe.IfThen(test, ifTrue);
+        public virtual ConditionalExpression IfThen(Expression test, Expression ifTrue) => ExpressionUnsafe.IfThen(test, ifTrue);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.ConditionalExpression" /> that represents a conditional block with <see langword="if" /> and <see langword="else" /> statements.</summary>
         /// <param name="test">An <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.ConditionalExpression.Test" /> property equal to.</param>
@@ -871,97 +874,97 @@ namespace System.Linq.Expressions
         /// <param name="ifFalse">An <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.ConditionalExpression.IfFalse" /> property equal to.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.ConditionalExpression" /> that has the <see cref="P:System.Linq.Expressions.Expression.NodeType" /> property equal to <see cref="F:System.Linq.Expressions.ExpressionType.Conditional" /> and the <see cref="P:System.Linq.Expressions.ConditionalExpression.Test" />, <see cref="P:System.Linq.Expressions.ConditionalExpression.IfTrue" />, and <see cref="P:System.Linq.Expressions.ConditionalExpression.IfFalse" /> properties set to the specified values. The type of the resulting <see cref="T:System.Linq.Expressions.ConditionalExpression" /> returned by this method is <see cref="T:System.Void" />.</returns>
         /// <remarks>This method does not provide any guarantees with regards to argument validation or type checking.</remarks>
-        public ConditionalExpression IfThenElse(Expression test, Expression ifTrue, Expression ifFalse) => ExpressionUnsafe.IfThenElse(test, ifTrue, ifFalse);
+        public virtual ConditionalExpression IfThenElse(Expression test, Expression ifTrue, Expression ifFalse) => ExpressionUnsafe.IfThenElse(test, ifTrue, ifFalse);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.UnaryExpression" /> that represents the incrementing of the expression value by 1.</summary>
         /// <param name="expression">An <see cref="T:System.Linq.Expressions.Expression" /> to increment.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.UnaryExpression" /> that represents the incremented expression.</returns>
         /// <remarks>This method does not provide any guarantees with regards to argument validation or type checking.</remarks>
-        public UnaryExpression Increment(Expression expression) => ExpressionUnsafe.Increment(expression);
+        public virtual UnaryExpression Increment(Expression expression) => ExpressionUnsafe.Increment(expression);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.UnaryExpression" /> that represents the incrementing of the expression by 1.</summary>
         /// <param name="expression">An <see cref="T:System.Linq.Expressions.Expression" /> to increment.</param>
         /// <param name="method">A <see cref="T:System.Reflection.MethodInfo" /> that represents the implementing method.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.UnaryExpression" /> that represents the incremented expression.</returns>
         /// <remarks>This method does not provide any guarantees with regards to argument validation or type checking.</remarks>
-        public UnaryExpression Increment(Expression expression, MethodInfo method) => ExpressionUnsafe.Increment(expression, method);
+        public virtual UnaryExpression Increment(Expression expression, MethodInfo method) => ExpressionUnsafe.Increment(expression, method);
 
         /// <summary>Creates an <see cref="T:System.Linq.Expressions.InvocationExpression" /> that applies a delegate or lambda expression to a list of argument expressions.</summary>
         /// <param name="expression">An <see cref="T:System.Linq.Expressions.Expression" /> that represents the delegate or lambda expression to be applied.</param>
         /// <param name="arguments">An array of <see cref="T:System.Linq.Expressions.Expression" /> objects that represent the arguments that the delegate or lambda expression is applied to.</param>
         /// <returns>An <see cref="T:System.Linq.Expressions.InvocationExpression" /> that applies the specified delegate or lambda expression to the provided arguments.</returns>
         /// <remarks>This method does not provide any guarantees with regards to argument validation or type checking.</remarks>
-        public InvocationExpression Invoke(Expression expression, Expression[] arguments) => ExpressionUnsafe.Invoke(expression, arguments);
+        public virtual InvocationExpression Invoke(Expression expression, Expression[] arguments) => ExpressionUnsafe.Invoke(expression, arguments);
 
         /// <summary>Creates an <see cref="T:System.Linq.Expressions.InvocationExpression" /> that applies a delegate or lambda expression to a list of argument expressions.</summary>
         /// <param name="expression">An <see cref="T:System.Linq.Expressions.Expression" /> that represents the delegate or lambda expression to be applied to.</param>
         /// <param name="arguments">An <see cref="T:System.Collections.Generic.IEnumerable`1" /> that contains <see cref="T:System.Linq.Expressions.Expression" /> objects that represent the arguments that the delegate or lambda expression is applied to.</param>
         /// <returns>An <see cref="T:System.Linq.Expressions.InvocationExpression" /> that applies the specified delegate or lambda expression to the provided arguments.</returns>
         /// <remarks>This method does not provide any guarantees with regards to argument validation or type checking.</remarks>
-        public InvocationExpression Invoke(Expression expression, IEnumerable<Expression> arguments) => ExpressionUnsafe.Invoke(expression, arguments);
+        public virtual InvocationExpression Invoke(Expression expression, IEnumerable<Expression> arguments) => ExpressionUnsafe.Invoke(expression, arguments);
 
         /// <summary>Returns whether the expression evaluates to false.</summary>
         /// <param name="expression">An <see cref="T:System.Linq.Expressions.Expression" /> to evaluate.</param>
         /// <returns>An instance of <see cref="T:System.Linq.Expressions.UnaryExpression" />.</returns>
         /// <remarks>This method does not provide any guarantees with regards to argument validation or type checking.</remarks>
-        public UnaryExpression IsFalse(Expression expression) => ExpressionUnsafe.IsFalse(expression);
+        public virtual UnaryExpression IsFalse(Expression expression) => ExpressionUnsafe.IsFalse(expression);
 
         /// <summary>Returns whether the expression evaluates to false.</summary>
         /// <param name="expression">An <see cref="T:System.Linq.Expressions.Expression" /> to evaluate.</param>
         /// <param name="method">A <see cref="T:System.Reflection.MethodInfo" /> that represents the implementing method.</param>
         /// <returns>An instance of <see cref="T:System.Linq.Expressions.UnaryExpression" />.</returns>
         /// <remarks>This method does not provide any guarantees with regards to argument validation or type checking.</remarks>
-        public UnaryExpression IsFalse(Expression expression, MethodInfo method) => ExpressionUnsafe.IsFalse(expression, method);
+        public virtual UnaryExpression IsFalse(Expression expression, MethodInfo method) => ExpressionUnsafe.IsFalse(expression, method);
 
         /// <summary>Returns whether the expression evaluates to true.</summary>
         /// <param name="expression">An <see cref="T:System.Linq.Expressions.Expression" /> to evaluate.</param>
         /// <returns>An instance of <see cref="T:System.Linq.Expressions.UnaryExpression" />.</returns>
         /// <remarks>This method does not provide any guarantees with regards to argument validation or type checking.</remarks>
-        public UnaryExpression IsTrue(Expression expression) => ExpressionUnsafe.IsTrue(expression);
+        public virtual UnaryExpression IsTrue(Expression expression) => ExpressionUnsafe.IsTrue(expression);
 
         /// <summary>Returns whether the expression evaluates to true.</summary>
         /// <param name="expression">An <see cref="T:System.Linq.Expressions.Expression" /> to evaluate.</param>
         /// <param name="method">A <see cref="T:System.Reflection.MethodInfo" /> that represents the implementing method.</param>
         /// <returns>An instance of <see cref="T:System.Linq.Expressions.UnaryExpression" />.</returns>
         /// <remarks>This method does not provide any guarantees with regards to argument validation or type checking.</remarks>
-        public UnaryExpression IsTrue(Expression expression, MethodInfo method) => ExpressionUnsafe.IsTrue(expression, method);
+        public virtual UnaryExpression IsTrue(Expression expression, MethodInfo method) => ExpressionUnsafe.IsTrue(expression, method);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.LabelTarget" /> representing a label with void type and no name.</summary>
         /// <returns>The new <see cref="T:System.Linq.Expressions.LabelTarget" />.</returns>
         /// <remarks>This method does not provide any guarantees with regards to argument validation or type checking.</remarks>
-        public LabelTarget Label() => ExpressionUnsafe.Label();
+        public virtual LabelTarget Label() => ExpressionUnsafe.Label();
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.LabelExpression" /> representing a label without a default value.</summary>
         /// <param name="target">The <see cref="T:System.Linq.Expressions.LabelTarget" /> which this <see cref="T:System.Linq.Expressions.LabelExpression" /> will be associated with.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.LabelExpression" /> without a default value.</returns>
         /// <remarks>This method does not provide any guarantees with regards to argument validation or type checking.</remarks>
-        public LabelExpression Label(LabelTarget target) => ExpressionUnsafe.Label(target);
+        public virtual LabelExpression Label(LabelTarget target) => ExpressionUnsafe.Label(target);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.LabelTarget" /> representing a label with void type and the given name.</summary>
         /// <param name="name">The name of the label.</param>
         /// <returns>The new <see cref="T:System.Linq.Expressions.LabelTarget" />.</returns>
         /// <remarks>This method does not provide any guarantees with regards to argument validation or type checking.</remarks>
-        public LabelTarget Label(String name) => ExpressionUnsafe.Label(name);
+        public virtual LabelTarget Label(String name) => ExpressionUnsafe.Label(name);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.LabelTarget" /> representing a label with the given type.</summary>
         /// <param name="type">The type of value that is passed when jumping to the label.</param>
         /// <returns>The new <see cref="T:System.Linq.Expressions.LabelTarget" />.</returns>
         /// <remarks>This method does not provide any guarantees with regards to argument validation or type checking.</remarks>
-        public LabelTarget Label(Type type) => ExpressionUnsafe.Label(type);
+        public virtual LabelTarget Label(Type type) => ExpressionUnsafe.Label(type);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.LabelExpression" /> representing a label with the given default value.</summary>
         /// <param name="target">The <see cref="T:System.Linq.Expressions.LabelTarget" /> which this <see cref="T:System.Linq.Expressions.LabelExpression" /> will be associated with.</param>
         /// <param name="defaultValue">The value of this <see cref="T:System.Linq.Expressions.LabelExpression" /> when the label is reached through regular control flow.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.LabelExpression" /> with the given default value.</returns>
         /// <remarks>This method does not provide any guarantees with regards to argument validation or type checking.</remarks>
-        public LabelExpression Label(LabelTarget target, Expression defaultValue) => ExpressionUnsafe.Label(target, defaultValue);
+        public virtual LabelExpression Label(LabelTarget target, Expression defaultValue) => ExpressionUnsafe.Label(target, defaultValue);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.LabelTarget" /> representing a label with the given type and name.</summary>
         /// <param name="type">The type of value that is passed when jumping to the label.</param>
         /// <param name="name">The name of the label.</param>
         /// <returns>The new <see cref="T:System.Linq.Expressions.LabelTarget" />.</returns>
         /// <remarks>This method does not provide any guarantees with regards to argument validation or type checking.</remarks>
-        public LabelTarget Label(Type type, String name) => ExpressionUnsafe.Label(type, name);
+        public virtual LabelTarget Label(Type type, String name) => ExpressionUnsafe.Label(type, name);
 
         /// <summary>Creates an <see cref="T:System.Linq.Expressions.Expression`1" /> where the delegate type is known at compile time.</summary>
         /// <param name="body">An <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.LambdaExpression.Body" /> property equal to.</param>
@@ -969,7 +972,7 @@ namespace System.Linq.Expressions
         /// <typeparam name="TDelegate">A delegate type.</typeparam>
         /// <returns>An <see cref="T:System.Linq.Expressions.Expression`1" /> that has the <see cref="P:System.Linq.Expressions.Expression.NodeType" /> property equal to <see cref="F:System.Linq.Expressions.ExpressionType.Lambda" /> and the <see cref="P:System.Linq.Expressions.LambdaExpression.Body" /> and <see cref="P:System.Linq.Expressions.LambdaExpression.Parameters" /> properties set to the specified values.</returns>
         /// <remarks>This method does not provide any guarantees with regards to argument validation or type checking.</remarks>
-        public Expression<TDelegate> Lambda<TDelegate>(Expression body, ParameterExpression[] parameters) => ExpressionUnsafe.Lambda<TDelegate>(body, parameters);
+        public virtual Expression<TDelegate> Lambda<TDelegate>(Expression body, ParameterExpression[] parameters) => ExpressionUnsafe.Lambda<TDelegate>(body, parameters);
 
         /// <summary>Creates an <see cref="T:System.Linq.Expressions.Expression`1" /> where the delegate type is known at compile time.</summary>
         /// <param name="body">An <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.LambdaExpression.Body" /> property equal to.</param>
@@ -977,21 +980,21 @@ namespace System.Linq.Expressions
         /// <typeparam name="TDelegate">A delegate type.</typeparam>
         /// <returns>An <see cref="T:System.Linq.Expressions.Expression`1" /> that has the <see cref="P:System.Linq.Expressions.Expression.NodeType" /> property equal to <see cref="F:System.Linq.Expressions.ExpressionType.Lambda" /> and the <see cref="P:System.Linq.Expressions.LambdaExpression.Body" /> and <see cref="P:System.Linq.Expressions.LambdaExpression.Parameters" /> properties set to the specified values.</returns>
         /// <remarks>This method does not provide any guarantees with regards to argument validation or type checking.</remarks>
-        public Expression<TDelegate> Lambda<TDelegate>(Expression body, IEnumerable<ParameterExpression> parameters) => ExpressionUnsafe.Lambda<TDelegate>(body, parameters);
+        public virtual Expression<TDelegate> Lambda<TDelegate>(Expression body, IEnumerable<ParameterExpression> parameters) => ExpressionUnsafe.Lambda<TDelegate>(body, parameters);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.LambdaExpression" /> by first constructing a delegate type.</summary>
         /// <param name="body">An <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.LambdaExpression.Body" /> property equal to.</param>
         /// <param name="parameters">An array of <see cref="T:System.Linq.Expressions.ParameterExpression" /> objects to use to populate the <see cref="P:System.Linq.Expressions.LambdaExpression.Parameters" /> collection.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.LambdaExpression" /> that has the <see cref="P:System.Linq.Expressions.Expression.NodeType" /> property equal to <see cref="F:System.Linq.Expressions.ExpressionType.Lambda" /> and the <see cref="P:System.Linq.Expressions.LambdaExpression.Body" /> and <see cref="P:System.Linq.Expressions.LambdaExpression.Parameters" /> properties set to the specified values.</returns>
         /// <remarks>This method does not provide any guarantees with regards to argument validation or type checking.</remarks>
-        public LambdaExpression Lambda(Expression body, ParameterExpression[] parameters) => ExpressionUnsafe.Lambda(body, parameters);
+        public virtual LambdaExpression Lambda(Expression body, ParameterExpression[] parameters) => ExpressionUnsafe.Lambda(body, parameters);
 
         /// <summary>Creates a LambdaExpression by first constructing a delegate type.</summary>
         /// <param name="body">An <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.LambdaExpression.Body" /> property equal to.</param>
         /// <param name="parameters">An <see cref="T:System.Collections.Generic.IEnumerable`1" /> that contains <see cref="T:System.Linq.Expressions.ParameterExpression" /> objects to use to populate the <see cref="P:System.Linq.Expressions.LambdaExpression.Parameters" /> collection.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.LambdaExpression" /> that has the <see cref="P:System.Linq.Expressions.LambdaExpression.NodeType" /> property equal to Lambda and the <see cref="P:System.Linq.Expressions.LambdaExpression.Body" /> and <see cref="P:System.Linq.Expressions.LambdaExpression.Parameters" /> properties set to the specified values.</returns>
         /// <remarks>This method does not provide any guarantees with regards to argument validation or type checking.</remarks>
-        public LambdaExpression Lambda(Expression body, IEnumerable<ParameterExpression> parameters) => ExpressionUnsafe.Lambda(body, parameters);
+        public virtual LambdaExpression Lambda(Expression body, IEnumerable<ParameterExpression> parameters) => ExpressionUnsafe.Lambda(body, parameters);
 
         /// <summary>Creates an <see cref="T:System.Linq.Expressions.Expression`1" /> where the delegate type is known at compile time.</summary>
         /// <param name="body">An <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.LambdaExpression.Body" /> property equal to.</param>
@@ -1000,7 +1003,7 @@ namespace System.Linq.Expressions
         /// <typeparam name="TDelegate">The delegate type. </typeparam>
         /// <returns>An <see cref="T:System.Linq.Expressions.Expression`1" /> that has the <see cref="P:System.Linq.Expressions.Expression.NodeType" /> property equal to <see cref="F:System.Linq.Expressions.ExpressionType.Lambda" /> and the <see cref="P:System.Linq.Expressions.LambdaExpression.Body" /> and <see cref="P:System.Linq.Expressions.LambdaExpression.Parameters" /> properties set to the specified values.</returns>
         /// <remarks>This method does not provide any guarantees with regards to argument validation or type checking.</remarks>
-        public Expression<TDelegate> Lambda<TDelegate>(Expression body, Boolean tailCall, ParameterExpression[] parameters) => ExpressionUnsafe.Lambda<TDelegate>(body, tailCall, parameters);
+        public virtual Expression<TDelegate> Lambda<TDelegate>(Expression body, Boolean tailCall, ParameterExpression[] parameters) => ExpressionUnsafe.Lambda<TDelegate>(body, tailCall, parameters);
 
         /// <summary>Creates an <see cref="T:System.Linq.Expressions.Expression`1" /> where the delegate type is known at compile time.</summary>
         /// <param name="body">An <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.LambdaExpression.Body" /> property equal to.</param>
@@ -1009,7 +1012,7 @@ namespace System.Linq.Expressions
         /// <typeparam name="TDelegate">The delegate type. </typeparam>
         /// <returns>An <see cref="T:System.Linq.Expressions.Expression`1" /> that has the <see cref="P:System.Linq.Expressions.LambdaExpression.NodeType" /> property equal to <see cref="F:System.Linq.Expressions.ExpressionType.Lambda" /> and the <see cref="P:System.Linq.Expressions.LambdaExpression.Body" /> and <see cref="P:System.Linq.Expressions.LambdaExpression.Parameters" /> properties set to the specified values.</returns>
         /// <remarks>This method does not provide any guarantees with regards to argument validation or type checking.</remarks>
-        public Expression<TDelegate> Lambda<TDelegate>(Expression body, Boolean tailCall, IEnumerable<ParameterExpression> parameters) => ExpressionUnsafe.Lambda<TDelegate>(body, tailCall, parameters);
+        public virtual Expression<TDelegate> Lambda<TDelegate>(Expression body, Boolean tailCall, IEnumerable<ParameterExpression> parameters) => ExpressionUnsafe.Lambda<TDelegate>(body, tailCall, parameters);
 
         /// <summary>Creates an <see cref="T:System.Linq.Expressions.Expression`1" /> where the delegate type is known at compile time.</summary>
         /// <param name="body">An <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.LambdaExpression.Body" /> property equal to.</param>
@@ -1018,7 +1021,7 @@ namespace System.Linq.Expressions
         /// <typeparam name="TDelegate">The delegate type. </typeparam>
         /// <returns>An <see cref="T:System.Linq.Expressions.Expression`1" /> that has the <see cref="P:System.Linq.Expressions.Expression.NodeType" /> property equal to <see cref="F:System.Linq.Expressions.ExpressionType.Lambda" /> and the <see cref="P:System.Linq.Expressions.LambdaExpression.Body" /> and <see cref="P:System.Linq.Expressions.LambdaExpression.Parameters" /> properties set to the specified values.</returns>
         /// <remarks>This method does not provide any guarantees with regards to argument validation or type checking.</remarks>
-        public Expression<TDelegate> Lambda<TDelegate>(Expression body, String name, IEnumerable<ParameterExpression> parameters) => ExpressionUnsafe.Lambda<TDelegate>(body, name, parameters);
+        public virtual Expression<TDelegate> Lambda<TDelegate>(Expression body, String name, IEnumerable<ParameterExpression> parameters) => ExpressionUnsafe.Lambda<TDelegate>(body, name, parameters);
 
         /// <summary>Creates a LambdaExpression by first constructing a delegate type.</summary>
         /// <param name="body">An <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.LambdaExpression.Body" /> property equal to.</param>
@@ -1026,7 +1029,7 @@ namespace System.Linq.Expressions
         /// <param name="parameters">An array that contains <see cref="T:System.Linq.Expressions.ParameterExpression" /> objects to use to populate the <see cref="P:System.Linq.Expressions.LambdaExpression.Parameters" /> collection.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.LambdaExpression" /> that has the <see cref="P:System.Linq.Expressions.LambdaExpression.NodeType" /> property equal to Lambda and the <see cref="P:System.Linq.Expressions.LambdaExpression.Body" /> and <see cref="P:System.Linq.Expressions.LambdaExpression.Parameters" /> properties set to the specified values.</returns>
         /// <remarks>This method does not provide any guarantees with regards to argument validation or type checking.</remarks>
-        public LambdaExpression Lambda(Expression body, Boolean tailCall, ParameterExpression[] parameters) => ExpressionUnsafe.Lambda(body, tailCall, parameters);
+        public virtual LambdaExpression Lambda(Expression body, Boolean tailCall, ParameterExpression[] parameters) => ExpressionUnsafe.Lambda(body, tailCall, parameters);
 
         /// <summary>Creates a LambdaExpression by first constructing a delegate type.</summary>
         /// <param name="body">An <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.LambdaExpression.Body" /> property equal to.</param>
@@ -1034,7 +1037,7 @@ namespace System.Linq.Expressions
         /// <param name="parameters">An <see cref="T:System.Collections.Generic.IEnumerable`1" /> that contains <see cref="T:System.Linq.Expressions.ParameterExpression" /> objects to use to populate the <see cref="P:System.Linq.Expressions.LambdaExpression.Parameters" /> collection.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.LambdaExpression" /> that has the <see cref="P:System.Linq.Expressions.LambdaExpression.NodeType" /> property equal to Lambda and the <see cref="P:System.Linq.Expressions.LambdaExpression.Body" /> and <see cref="P:System.Linq.Expressions.LambdaExpression.Parameters" /> properties set to the specified values.</returns>
         /// <remarks>This method does not provide any guarantees with regards to argument validation or type checking.</remarks>
-        public LambdaExpression Lambda(Expression body, Boolean tailCall, IEnumerable<ParameterExpression> parameters) => ExpressionUnsafe.Lambda(body, tailCall, parameters);
+        public virtual LambdaExpression Lambda(Expression body, Boolean tailCall, IEnumerable<ParameterExpression> parameters) => ExpressionUnsafe.Lambda(body, tailCall, parameters);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.LambdaExpression" /> by first constructing a delegate type. It can be used when the delegate type is not known at compile time.</summary>
         /// <param name="delegateType">A <see cref="T:System.Type" /> that represents a delegate signature for the lambda.</param>
@@ -1042,7 +1045,7 @@ namespace System.Linq.Expressions
         /// <param name="parameters">An array of <see cref="T:System.Linq.Expressions.ParameterExpression" /> objects to use to populate the <see cref="P:System.Linq.Expressions.LambdaExpression.Parameters" /> collection.</param>
         /// <returns>An object that represents a lambda expression which has the <see cref="P:System.Linq.Expressions.Expression.NodeType" /> property equal to <see cref="F:System.Linq.Expressions.ExpressionType.Lambda" /> and the <see cref="P:System.Linq.Expressions.LambdaExpression.Body" /> and <see cref="P:System.Linq.Expressions.LambdaExpression.Parameters" /> properties set to the specified values.</returns>
         /// <remarks>This method does not provide any guarantees with regards to argument validation or type checking.</remarks>
-        public LambdaExpression Lambda(Type delegateType, Expression body, ParameterExpression[] parameters) => ExpressionUnsafe.Lambda(delegateType, body, parameters);
+        public virtual LambdaExpression Lambda(Type delegateType, Expression body, ParameterExpression[] parameters) => ExpressionUnsafe.Lambda(delegateType, body, parameters);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.LambdaExpression" /> by first constructing a delegate type. It can be used when the delegate type is not known at compile time.</summary>
         /// <param name="delegateType">A <see cref="T:System.Type" /> that represents a delegate signature for the lambda.</param>
@@ -1050,7 +1053,7 @@ namespace System.Linq.Expressions
         /// <param name="parameters">An <see cref="T:System.Collections.Generic.IEnumerable`1" /> that contains <see cref="T:System.Linq.Expressions.ParameterExpression" /> objects to use to populate the <see cref="P:System.Linq.Expressions.LambdaExpression.Parameters" /> collection.</param>
         /// <returns>An object that represents a lambda expression which has the <see cref="P:System.Linq.Expressions.Expression.NodeType" /> property equal to <see cref="F:System.Linq.Expressions.ExpressionType.Lambda" /> and the <see cref="P:System.Linq.Expressions.LambdaExpression.Body" /> and <see cref="P:System.Linq.Expressions.LambdaExpression.Parameters" /> properties set to the specified values.</returns>
         /// <remarks>This method does not provide any guarantees with regards to argument validation or type checking.</remarks>
-        public LambdaExpression Lambda(Type delegateType, Expression body, IEnumerable<ParameterExpression> parameters) => ExpressionUnsafe.Lambda(delegateType, body, parameters);
+        public virtual LambdaExpression Lambda(Type delegateType, Expression body, IEnumerable<ParameterExpression> parameters) => ExpressionUnsafe.Lambda(delegateType, body, parameters);
 
         /// <summary>Creates a LambdaExpression by first constructing a delegate type.</summary>
         /// <param name="body">An <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.LambdaExpression.Body" /> property equal to.</param>
@@ -1058,7 +1061,7 @@ namespace System.Linq.Expressions
         /// <param name="parameters">An <see cref="T:System.Collections.Generic.IEnumerable`1" /> that contains <see cref="T:System.Linq.Expressions.ParameterExpression" /> objects to use to populate the <see cref="P:System.Linq.Expressions.LambdaExpression.Parameters" /> collection.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.LambdaExpression" /> that has the <see cref="P:System.Linq.Expressions.LambdaExpression.NodeType" /> property equal to Lambda and the <see cref="P:System.Linq.Expressions.LambdaExpression.Body" /> and <see cref="P:System.Linq.Expressions.LambdaExpression.Parameters" /> properties set to the specified values.</returns>
         /// <remarks>This method does not provide any guarantees with regards to argument validation or type checking.</remarks>
-        public LambdaExpression Lambda(Expression body, String name, IEnumerable<ParameterExpression> parameters) => ExpressionUnsafe.Lambda(body, name, parameters);
+        public virtual LambdaExpression Lambda(Expression body, String name, IEnumerable<ParameterExpression> parameters) => ExpressionUnsafe.Lambda(body, name, parameters);
 
         /// <summary>Creates an <see cref="T:System.Linq.Expressions.Expression`1" /> where the delegate type is known at compile time.</summary>
         /// <param name="body">An <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.LambdaExpression.Body" /> property equal to.</param>
@@ -1068,7 +1071,7 @@ namespace System.Linq.Expressions
         /// <typeparam name="TDelegate">The delegate type. </typeparam>
         /// <returns>An <see cref="T:System.Linq.Expressions.Expression`1" /> that has the <see cref="P:System.Linq.Expressions.LambdaExpression.NodeType" /> property equal to <see cref="F:System.Linq.Expressions.ExpressionType.Lambda" /> and the <see cref="P:System.Linq.Expressions.LambdaExpression.Body" /> and <see cref="P:System.Linq.Expressions.LambdaExpression.Parameters" /> properties set to the specified values.</returns>
         /// <remarks>This method does not provide any guarantees with regards to argument validation or type checking.</remarks>
-        public Expression<TDelegate> Lambda<TDelegate>(Expression body, String name, Boolean tailCall, IEnumerable<ParameterExpression> parameters) => ExpressionUnsafe.Lambda<TDelegate>(body, name, tailCall, parameters);
+        public virtual Expression<TDelegate> Lambda<TDelegate>(Expression body, String name, Boolean tailCall, IEnumerable<ParameterExpression> parameters) => ExpressionUnsafe.Lambda<TDelegate>(body, name, tailCall, parameters);
 
         /// <summary>Creates a LambdaExpression by first constructing a delegate type.</summary>
         /// <param name="delegateType">A <see cref="P:System.Linq.Expressions.Expression.Type" /> representing the delegate signature for the lambda.</param>
@@ -1077,7 +1080,7 @@ namespace System.Linq.Expressions
         /// <param name="parameters">An array that contains <see cref="T:System.Linq.Expressions.ParameterExpression" /> objects to use to populate the <see cref="P:System.Linq.Expressions.LambdaExpression.Parameters" /> collection.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.LambdaExpression" /> that has the <see cref="P:System.Linq.Expressions.LambdaExpression.NodeType" /> property equal to Lambda and the <see cref="P:System.Linq.Expressions.LambdaExpression.Body" /> and <see cref="P:System.Linq.Expressions.LambdaExpression.Parameters" /> properties set to the specified values.</returns>
         /// <remarks>This method does not provide any guarantees with regards to argument validation or type checking.</remarks>
-        public LambdaExpression Lambda(Type delegateType, Expression body, Boolean tailCall, ParameterExpression[] parameters) => ExpressionUnsafe.Lambda(delegateType, body, tailCall, parameters);
+        public virtual LambdaExpression Lambda(Type delegateType, Expression body, Boolean tailCall, ParameterExpression[] parameters) => ExpressionUnsafe.Lambda(delegateType, body, tailCall, parameters);
 
         /// <summary>Creates a LambdaExpression by first constructing a delegate type.</summary>
         /// <param name="delegateType">A <see cref="P:System.Linq.Expressions.Expression.Type" /> representing the delegate signature for the lambda.</param>
@@ -1086,7 +1089,7 @@ namespace System.Linq.Expressions
         /// <param name="parameters">An <see cref="T:System.Collections.Generic.IEnumerable`1" /> that contains <see cref="T:System.Linq.Expressions.ParameterExpression" /> objects to use to populate the <see cref="P:System.Linq.Expressions.LambdaExpression.Parameters" /> collection.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.LambdaExpression" /> that has the <see cref="P:System.Linq.Expressions.LambdaExpression.NodeType" /> property equal to Lambda and the <see cref="P:System.Linq.Expressions.LambdaExpression.Body" /> and <see cref="P:System.Linq.Expressions.LambdaExpression.Parameters" /> properties set to the specified values.</returns>
         /// <remarks>This method does not provide any guarantees with regards to argument validation or type checking.</remarks>
-        public LambdaExpression Lambda(Type delegateType, Expression body, Boolean tailCall, IEnumerable<ParameterExpression> parameters) => ExpressionUnsafe.Lambda(delegateType, body, tailCall, parameters);
+        public virtual LambdaExpression Lambda(Type delegateType, Expression body, Boolean tailCall, IEnumerable<ParameterExpression> parameters) => ExpressionUnsafe.Lambda(delegateType, body, tailCall, parameters);
 
         /// <summary>Creates a LambdaExpression by first constructing a delegate type.</summary>
         /// <param name="body">An <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.LambdaExpression.Body" /> property equal to.</param>
@@ -1095,7 +1098,7 @@ namespace System.Linq.Expressions
         /// <param name="parameters">An <see cref="T:System.Collections.Generic.IEnumerable`1" /> that contains <see cref="T:System.Linq.Expressions.ParameterExpression" /> objects to use to populate the <see cref="P:System.Linq.Expressions.LambdaExpression.Parameters" /> collection.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.LambdaExpression" /> that has the <see cref="P:System.Linq.Expressions.LambdaExpression.NodeType" /> property equal to Lambda and the <see cref="P:System.Linq.Expressions.LambdaExpression.Body" /> and <see cref="P:System.Linq.Expressions.LambdaExpression.Parameters" /> properties set to the specified values.</returns>
         /// <remarks>This method does not provide any guarantees with regards to argument validation or type checking.</remarks>
-        public LambdaExpression Lambda(Expression body, String name, Boolean tailCall, IEnumerable<ParameterExpression> parameters) => ExpressionUnsafe.Lambda(body, name, tailCall, parameters);
+        public virtual LambdaExpression Lambda(Expression body, String name, Boolean tailCall, IEnumerable<ParameterExpression> parameters) => ExpressionUnsafe.Lambda(body, name, tailCall, parameters);
 
         /// <summary>Creates a LambdaExpression by first constructing a delegate type.</summary>
         /// <param name="delegateType">A <see cref="P:System.Linq.Expressions.Expression.Type" /> representing the delegate signature for the lambda.</param>
@@ -1104,7 +1107,7 @@ namespace System.Linq.Expressions
         /// <param name="parameters">An <see cref="T:System.Collections.Generic.IEnumerable`1" /> that contains <see cref="T:System.Linq.Expressions.ParameterExpression" /> objects to use to populate the <see cref="P:System.Linq.Expressions.LambdaExpression.Parameters" /> collection.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.LambdaExpression" /> that has the <see cref="P:System.Linq.Expressions.LambdaExpression.NodeType" /> property equal to Lambda and the <see cref="P:System.Linq.Expressions.LambdaExpression.Body" /> and <see cref="P:System.Linq.Expressions.LambdaExpression.Parameters" /> properties set to the specified values.</returns>
         /// <remarks>This method does not provide any guarantees with regards to argument validation or type checking.</remarks>
-        public LambdaExpression Lambda(Type delegateType, Expression body, String name, IEnumerable<ParameterExpression> parameters) => ExpressionUnsafe.Lambda(delegateType, body, name, parameters);
+        public virtual LambdaExpression Lambda(Type delegateType, Expression body, String name, IEnumerable<ParameterExpression> parameters) => ExpressionUnsafe.Lambda(delegateType, body, name, parameters);
 
         /// <summary>Creates a LambdaExpression by first constructing a delegate type.</summary>
         /// <param name="delegateType">A <see cref="P:System.Linq.Expressions.Expression.Type" /> representing the delegate signature for the lambda.</param>
@@ -1114,14 +1117,14 @@ namespace System.Linq.Expressions
         /// <param name="parameters">An <see cref="T:System.Collections.Generic.IEnumerable`1" /> that contains <see cref="T:System.Linq.Expressions.ParameterExpression" /> objects to use to populate the <see cref="P:System.Linq.Expressions.LambdaExpression.Parameters" /> collection. </param>
         /// <returns>A <see cref="T:System.Linq.Expressions.LambdaExpression" /> that has the <see cref="P:System.Linq.Expressions.LambdaExpression.NodeType" /> property equal to Lambda and the <see cref="P:System.Linq.Expressions.LambdaExpression.Body" /> and <see cref="P:System.Linq.Expressions.LambdaExpression.Parameters" /> properties set to the specified values.</returns>
         /// <remarks>This method does not provide any guarantees with regards to argument validation or type checking.</remarks>
-        public LambdaExpression Lambda(Type delegateType, Expression body, String name, Boolean tailCall, IEnumerable<ParameterExpression> parameters) => ExpressionUnsafe.Lambda(delegateType, body, name, tailCall, parameters);
+        public virtual LambdaExpression Lambda(Type delegateType, Expression body, String name, Boolean tailCall, IEnumerable<ParameterExpression> parameters) => ExpressionUnsafe.Lambda(delegateType, body, name, tailCall, parameters);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.BinaryExpression" /> that represents a bitwise left-shift operation.</summary>
         /// <param name="left">An <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Left" /> property equal to.</param>
         /// <param name="right">An <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Right" /> property equal to.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.BinaryExpression" /> that has the <see cref="P:System.Linq.Expressions.Expression.NodeType" /> property equal to <see cref="F:System.Linq.Expressions.ExpressionType.LeftShift" /> and the <see cref="P:System.Linq.Expressions.BinaryExpression.Left" /> and <see cref="P:System.Linq.Expressions.BinaryExpression.Right" /> properties set to the specified values.</returns>
         /// <remarks>This method does not provide any guarantees with regards to argument validation or type checking.</remarks>
-        public BinaryExpression LeftShift(Expression left, Expression right) => ExpressionUnsafe.LeftShift(left, right);
+        public virtual BinaryExpression LeftShift(Expression left, Expression right) => ExpressionUnsafe.LeftShift(left, right);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.BinaryExpression" /> that represents a bitwise left-shift operation.</summary>
         /// <param name="left">An <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Left" /> property equal to.</param>
@@ -1129,14 +1132,14 @@ namespace System.Linq.Expressions
         /// <param name="method">A <see cref="T:System.Reflection.MethodInfo" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Method" /> property equal to.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.BinaryExpression" /> that has the <see cref="P:System.Linq.Expressions.Expression.NodeType" /> property equal to <see cref="F:System.Linq.Expressions.ExpressionType.LeftShift" /> and the <see cref="P:System.Linq.Expressions.BinaryExpression.Left" />, <see cref="P:System.Linq.Expressions.BinaryExpression.Right" />, and <see cref="P:System.Linq.Expressions.BinaryExpression.Method" /> properties set to the specified values.</returns>
         /// <remarks>This method does not provide any guarantees with regards to argument validation or type checking.</remarks>
-        public BinaryExpression LeftShift(Expression left, Expression right, MethodInfo method) => ExpressionUnsafe.LeftShift(left, right, method);
+        public virtual BinaryExpression LeftShift(Expression left, Expression right, MethodInfo method) => ExpressionUnsafe.LeftShift(left, right, method);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.BinaryExpression" /> that represents a bitwise left-shift assignment operation.</summary>
         /// <param name="left">An <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Left" /> property equal to.</param>
         /// <param name="right">An <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Right" /> property equal to.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.BinaryExpression" /> that has the <see cref="P:System.Linq.Expressions.Expression.NodeType" /> property equal to <see cref="F:System.Linq.Expressions.ExpressionType.LeftShiftAssign" /> and the <see cref="P:System.Linq.Expressions.BinaryExpression.Left" /> and <see cref="P:System.Linq.Expressions.BinaryExpression.Right" /> properties set to the specified values.</returns>
         /// <remarks>This method does not provide any guarantees with regards to argument validation or type checking.</remarks>
-        public BinaryExpression LeftShiftAssign(Expression left, Expression right) => ExpressionUnsafe.LeftShiftAssign(left, right);
+        public virtual BinaryExpression LeftShiftAssign(Expression left, Expression right) => ExpressionUnsafe.LeftShiftAssign(left, right);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.BinaryExpression" /> that represents a bitwise left-shift assignment operation.</summary>
         /// <param name="left">An <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Left" /> property equal to.</param>
@@ -1144,7 +1147,7 @@ namespace System.Linq.Expressions
         /// <param name="method">A <see cref="T:System.Reflection.MethodInfo" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Method" /> property equal to.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.BinaryExpression" /> that has the <see cref="P:System.Linq.Expressions.Expression.NodeType" /> property equal to <see cref="F:System.Linq.Expressions.ExpressionType.LeftShiftAssign" /> and the <see cref="P:System.Linq.Expressions.BinaryExpression.Left" />, <see cref="P:System.Linq.Expressions.BinaryExpression.Right" />, and <see cref="P:System.Linq.Expressions.BinaryExpression.Method" /> properties set to the specified values.</returns>
         /// <remarks>This method does not provide any guarantees with regards to argument validation or type checking.</remarks>
-        public BinaryExpression LeftShiftAssign(Expression left, Expression right, MethodInfo method) => ExpressionUnsafe.LeftShiftAssign(left, right, method);
+        public virtual BinaryExpression LeftShiftAssign(Expression left, Expression right, MethodInfo method) => ExpressionUnsafe.LeftShiftAssign(left, right, method);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.BinaryExpression" /> that represents a bitwise left-shift assignment operation.</summary>
         /// <param name="left">An <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Left" /> property equal to.</param>
@@ -1153,14 +1156,14 @@ namespace System.Linq.Expressions
         /// <param name="conversion">A <see cref="T:System.Linq.Expressions.LambdaExpression" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Conversion" /> property equal to.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.BinaryExpression" /> that has the <see cref="P:System.Linq.Expressions.Expression.NodeType" /> property equal to <see cref="F:System.Linq.Expressions.ExpressionType.LeftShiftAssign" /> and the <see cref="P:System.Linq.Expressions.BinaryExpression.Left" />, <see cref="P:System.Linq.Expressions.BinaryExpression.Right" />, <see cref="P:System.Linq.Expressions.BinaryExpression.Method" />, and <see cref="P:System.Linq.Expressions.BinaryExpression.Conversion" /> properties set to the specified values.</returns>
         /// <remarks>This method does not provide any guarantees with regards to argument validation or type checking.</remarks>
-        public BinaryExpression LeftShiftAssign(Expression left, Expression right, MethodInfo method, LambdaExpression conversion) => ExpressionUnsafe.LeftShiftAssign(left, right, method, conversion);
+        public virtual BinaryExpression LeftShiftAssign(Expression left, Expression right, MethodInfo method, LambdaExpression conversion) => ExpressionUnsafe.LeftShiftAssign(left, right, method, conversion);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.BinaryExpression" /> that represents a "less than" numeric comparison.</summary>
         /// <param name="left">An <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Left" /> property equal to.</param>
         /// <param name="right">An <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Right" /> property equal to.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.BinaryExpression" /> that has the <see cref="P:System.Linq.Expressions.Expression.NodeType" /> property equal to <see cref="F:System.Linq.Expressions.ExpressionType.LessThan" /> and the <see cref="P:System.Linq.Expressions.BinaryExpression.Left" /> and <see cref="P:System.Linq.Expressions.BinaryExpression.Right" /> properties set to the specified values.</returns>
         /// <remarks>This method does not provide any guarantees with regards to argument validation or type checking.</remarks>
-        public BinaryExpression LessThan(Expression left, Expression right) => ExpressionUnsafe.LessThan(left, right);
+        public virtual BinaryExpression LessThan(Expression left, Expression right) => ExpressionUnsafe.LessThan(left, right);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.BinaryExpression" /> that represents a "less than" numeric comparison.</summary>
         /// <param name="left">An <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Left" /> property equal to.</param>
@@ -1170,14 +1173,14 @@ namespace System.Linq.Expressions
         /// <param name="method">A <see cref="T:System.Reflection.MethodInfo" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Method" /> property equal to.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.BinaryExpression" /> that has the <see cref="P:System.Linq.Expressions.Expression.NodeType" /> property equal to <see cref="F:System.Linq.Expressions.ExpressionType.LessThan" /> and the <see cref="P:System.Linq.Expressions.BinaryExpression.Left" />, <see cref="P:System.Linq.Expressions.BinaryExpression.Right" />, <see cref="P:System.Linq.Expressions.BinaryExpression.IsLiftedToNull" />, and <see cref="P:System.Linq.Expressions.BinaryExpression.Method" /> properties set to the specified values.</returns>
         /// <remarks>This method does not provide any guarantees with regards to argument validation or type checking.</remarks>
-        public BinaryExpression LessThan(Expression left, Expression right, Boolean liftToNull, MethodInfo method) => ExpressionUnsafe.LessThan(left, right, liftToNull, method);
+        public virtual BinaryExpression LessThan(Expression left, Expression right, Boolean liftToNull, MethodInfo method) => ExpressionUnsafe.LessThan(left, right, liftToNull, method);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.BinaryExpression" /> that represents a " less than or equal" numeric comparison.</summary>
         /// <param name="left">An <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Left" /> property equal to.</param>
         /// <param name="right">An <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Right" /> property equal to.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.BinaryExpression" /> that has the <see cref="P:System.Linq.Expressions.Expression.NodeType" /> property equal to <see cref="F:System.Linq.Expressions.ExpressionType.LessThanOrEqual" /> and the <see cref="P:System.Linq.Expressions.BinaryExpression.Left" /> and <see cref="P:System.Linq.Expressions.BinaryExpression.Right" /> properties set to the specified values.</returns>
         /// <remarks>This method does not provide any guarantees with regards to argument validation or type checking.</remarks>
-        public BinaryExpression LessThanOrEqual(Expression left, Expression right) => ExpressionUnsafe.LessThanOrEqual(left, right);
+        public virtual BinaryExpression LessThanOrEqual(Expression left, Expression right) => ExpressionUnsafe.LessThanOrEqual(left, right);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.BinaryExpression" /> that represents a "less than or equal" numeric comparison.</summary>
         /// <param name="left">An <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Left" /> property equal to.</param>
@@ -1187,63 +1190,63 @@ namespace System.Linq.Expressions
         /// <param name="method">A <see cref="T:System.Reflection.MethodInfo" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Method" /> property equal to.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.BinaryExpression" /> that has the <see cref="P:System.Linq.Expressions.Expression.NodeType" /> property equal to <see cref="F:System.Linq.Expressions.ExpressionType.LessThanOrEqual" /> and the <see cref="P:System.Linq.Expressions.BinaryExpression.Left" />, <see cref="P:System.Linq.Expressions.BinaryExpression.Right" />, <see cref="P:System.Linq.Expressions.BinaryExpression.IsLiftedToNull" />, and <see cref="P:System.Linq.Expressions.BinaryExpression.Method" /> properties set to the specified values.</returns>
         /// <remarks>This method does not provide any guarantees with regards to argument validation or type checking.</remarks>
-        public BinaryExpression LessThanOrEqual(Expression left, Expression right, Boolean liftToNull, MethodInfo method) => ExpressionUnsafe.LessThanOrEqual(left, right, liftToNull, method);
+        public virtual BinaryExpression LessThanOrEqual(Expression left, Expression right, Boolean liftToNull, MethodInfo method) => ExpressionUnsafe.LessThanOrEqual(left, right, liftToNull, method);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.MemberListBinding" /> where the member is a field or property.</summary>
         /// <param name="member">A <see cref="T:System.Reflection.MemberInfo" /> that represents a field or property to set the <see cref="P:System.Linq.Expressions.MemberBinding.Member" /> property equal to.</param>
         /// <param name="initializers">An array of <see cref="T:System.Linq.Expressions.ElementInit" /> objects to use to populate the <see cref="P:System.Linq.Expressions.MemberListBinding.Initializers" /> collection.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.MemberListBinding" /> that has the <see cref="P:System.Linq.Expressions.MemberBinding.BindingType" /> property equal to <see cref="F:System.Linq.Expressions.MemberBindingType.ListBinding" /> and the <see cref="P:System.Linq.Expressions.MemberBinding.Member" /> and <see cref="P:System.Linq.Expressions.MemberListBinding.Initializers" /> properties set to the specified values.</returns>
         /// <remarks>This method does not provide any guarantees with regards to argument validation or type checking.</remarks>
-        public MemberListBinding ListBind(MemberInfo member, ElementInit[] initializers) => ExpressionUnsafe.ListBind(member, initializers);
+        public virtual MemberListBinding ListBind(MemberInfo member, ElementInit[] initializers) => ExpressionUnsafe.ListBind(member, initializers);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.MemberListBinding" /> where the member is a field or property.</summary>
         /// <param name="member">A <see cref="T:System.Reflection.MemberInfo" /> that represents a field or property to set the <see cref="P:System.Linq.Expressions.MemberBinding.Member" /> property equal to.</param>
         /// <param name="initializers">An <see cref="T:System.Collections.Generic.IEnumerable`1" /> that contains <see cref="T:System.Linq.Expressions.ElementInit" /> objects to use to populate the <see cref="P:System.Linq.Expressions.MemberListBinding.Initializers" /> collection.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.MemberListBinding" /> that has the <see cref="P:System.Linq.Expressions.MemberBinding.BindingType" /> property equal to <see cref="F:System.Linq.Expressions.MemberBindingType.ListBinding" /> and the <see cref="P:System.Linq.Expressions.MemberBinding.Member" /> and <see cref="P:System.Linq.Expressions.MemberListBinding.Initializers" /> properties set to the specified values.</returns>
         /// <remarks>This method does not provide any guarantees with regards to argument validation or type checking.</remarks>
-        public MemberListBinding ListBind(MemberInfo member, IEnumerable<ElementInit> initializers) => ExpressionUnsafe.ListBind(member, initializers);
+        public virtual MemberListBinding ListBind(MemberInfo member, IEnumerable<ElementInit> initializers) => ExpressionUnsafe.ListBind(member, initializers);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.MemberListBinding" /> object based on a specified property accessor method.</summary>
         /// <param name="propertyAccessor">A <see cref="T:System.Reflection.MethodInfo" /> that represents a property accessor method.</param>
         /// <param name="initializers">An array of <see cref="T:System.Linq.Expressions.ElementInit" /> objects to use to populate the <see cref="P:System.Linq.Expressions.MemberListBinding.Initializers" /> collection.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.MemberListBinding" /> that has the <see cref="P:System.Linq.Expressions.MemberBinding.BindingType" /> property equal to <see cref="F:System.Linq.Expressions.MemberBindingType.ListBinding" />, the <see cref="P:System.Linq.Expressions.MemberBinding.Member" /> property set to the <see cref="T:System.Reflection.MemberInfo" /> that represents the property accessed in <paramref name="propertyAccessor" />, and <see cref="P:System.Linq.Expressions.MemberListBinding.Initializers" /> populated with the elements of <paramref name="initializers" />.</returns>
         /// <remarks>This method does not provide any guarantees with regards to argument validation or type checking.</remarks>
-        public MemberListBinding ListBind(MethodInfo propertyAccessor, ElementInit[] initializers) => ExpressionUnsafe.ListBind(propertyAccessor, initializers);
+        public virtual MemberListBinding ListBind(MethodInfo propertyAccessor, ElementInit[] initializers) => ExpressionUnsafe.ListBind(propertyAccessor, initializers);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.MemberListBinding" /> based on a specified property accessor method.</summary>
         /// <param name="propertyAccessor">A <see cref="T:System.Reflection.MethodInfo" /> that represents a property accessor method.</param>
         /// <param name="initializers">An <see cref="T:System.Collections.Generic.IEnumerable`1" /> that contains <see cref="T:System.Linq.Expressions.ElementInit" /> objects to use to populate the <see cref="P:System.Linq.Expressions.MemberListBinding.Initializers" /> collection.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.MemberListBinding" /> that has the <see cref="P:System.Linq.Expressions.MemberBinding.BindingType" /> property equal to <see cref="F:System.Linq.Expressions.MemberBindingType.ListBinding" />, the <see cref="P:System.Linq.Expressions.MemberBinding.Member" /> property set to the <see cref="T:System.Reflection.MemberInfo" /> that represents the property accessed in <paramref name="propertyAccessor" />, and <see cref="P:System.Linq.Expressions.MemberListBinding.Initializers" /> populated with the elements of <paramref name="initializers" />.</returns>
         /// <remarks>This method does not provide any guarantees with regards to argument validation or type checking.</remarks>
-        public MemberListBinding ListBind(MethodInfo propertyAccessor, IEnumerable<ElementInit> initializers) => ExpressionUnsafe.ListBind(propertyAccessor, initializers);
+        public virtual MemberListBinding ListBind(MethodInfo propertyAccessor, IEnumerable<ElementInit> initializers) => ExpressionUnsafe.ListBind(propertyAccessor, initializers);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.ListInitExpression" /> that uses specified <see cref="T:System.Linq.Expressions.ElementInit" /> objects to initialize a collection.</summary>
         /// <param name="newExpression">A <see cref="T:System.Linq.Expressions.NewExpression" /> to set the <see cref="P:System.Linq.Expressions.ListInitExpression.NewExpression" /> property equal to.</param>
         /// <param name="initializers">An array of <see cref="T:System.Linq.Expressions.ElementInit" /> objects to use to populate the <see cref="P:System.Linq.Expressions.ListInitExpression.Initializers" /> collection.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.ListInitExpression" /> that has the <see cref="P:System.Linq.Expressions.Expression.NodeType" /> property equal to <see cref="F:System.Linq.Expressions.ExpressionType.ListInit" /> and the <see cref="P:System.Linq.Expressions.ListInitExpression.NewExpression" /> and <see cref="P:System.Linq.Expressions.ListInitExpression.Initializers" /> properties set to the specified values.</returns>
         /// <remarks>This method does not provide any guarantees with regards to argument validation or type checking.</remarks>
-        public ListInitExpression ListInit(NewExpression newExpression, ElementInit[] initializers) => ExpressionUnsafe.ListInit(newExpression, initializers);
+        public virtual ListInitExpression ListInit(NewExpression newExpression, ElementInit[] initializers) => ExpressionUnsafe.ListInit(newExpression, initializers);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.ListInitExpression" /> that uses specified <see cref="T:System.Linq.Expressions.ElementInit" /> objects to initialize a collection.</summary>
         /// <param name="newExpression">A <see cref="T:System.Linq.Expressions.NewExpression" /> to set the <see cref="P:System.Linq.Expressions.ListInitExpression.NewExpression" /> property equal to.</param>
         /// <param name="initializers">An <see cref="T:System.Collections.Generic.IEnumerable`1" /> that contains <see cref="T:System.Linq.Expressions.ElementInit" /> objects to use to populate the <see cref="P:System.Linq.Expressions.ListInitExpression.Initializers" /> collection.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.ListInitExpression" /> that has the <see cref="P:System.Linq.Expressions.Expression.NodeType" /> property equal to <see cref="F:System.Linq.Expressions.ExpressionType.ListInit" /> and the <see cref="P:System.Linq.Expressions.ListInitExpression.NewExpression" /> and <see cref="P:System.Linq.Expressions.ListInitExpression.Initializers" /> properties set to the specified values.</returns>
         /// <remarks>This method does not provide any guarantees with regards to argument validation or type checking.</remarks>
-        public ListInitExpression ListInit(NewExpression newExpression, IEnumerable<ElementInit> initializers) => ExpressionUnsafe.ListInit(newExpression, initializers);
+        public virtual ListInitExpression ListInit(NewExpression newExpression, IEnumerable<ElementInit> initializers) => ExpressionUnsafe.ListInit(newExpression, initializers);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.ListInitExpression" /> that uses a method named "Add" to add elements to a collection.</summary>
         /// <param name="newExpression">A <see cref="T:System.Linq.Expressions.NewExpression" /> to set the <see cref="P:System.Linq.Expressions.ListInitExpression.NewExpression" /> property equal to.</param>
         /// <param name="initializers">An array of <see cref="T:System.Linq.Expressions.Expression" /> objects to use to populate the <see cref="P:System.Linq.Expressions.ListInitExpression.Initializers" /> collection.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.ListInitExpression" /> that has the <see cref="P:System.Linq.Expressions.Expression.NodeType" /> property equal to <see cref="F:System.Linq.Expressions.ExpressionType.ListInit" /> and the <see cref="P:System.Linq.Expressions.ListInitExpression.NewExpression" /> property set to the specified value.</returns>
         /// <remarks>This method does not provide any guarantees with regards to argument validation or type checking.</remarks>
-        public ListInitExpression ListInit(NewExpression newExpression, Expression[] initializers) => ExpressionUnsafe.ListInit(newExpression, initializers);
+        public virtual ListInitExpression ListInit(NewExpression newExpression, Expression[] initializers) => ExpressionUnsafe.ListInit(newExpression, initializers);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.ListInitExpression" /> that uses a method named "Add" to add elements to a collection.</summary>
         /// <param name="newExpression">A <see cref="T:System.Linq.Expressions.NewExpression" /> to set the <see cref="P:System.Linq.Expressions.ListInitExpression.NewExpression" /> property equal to.</param>
         /// <param name="initializers">An <see cref="T:System.Collections.Generic.IEnumerable`1" /> that contains <see cref="T:System.Linq.Expressions.Expression" /> objects to use to populate the <see cref="P:System.Linq.Expressions.ListInitExpression.Initializers" /> collection.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.ListInitExpression" /> that has the <see cref="P:System.Linq.Expressions.Expression.NodeType" /> property equal to <see cref="F:System.Linq.Expressions.ExpressionType.ListInit" /> and the <see cref="P:System.Linq.Expressions.ListInitExpression.NewExpression" /> property set to the specified value.</returns>
         /// <remarks>This method does not provide any guarantees with regards to argument validation or type checking.</remarks>
-        public ListInitExpression ListInit(NewExpression newExpression, IEnumerable<Expression> initializers) => ExpressionUnsafe.ListInit(newExpression, initializers);
+        public virtual ListInitExpression ListInit(NewExpression newExpression, IEnumerable<Expression> initializers) => ExpressionUnsafe.ListInit(newExpression, initializers);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.ListInitExpression" /> that uses a specified method to add elements to a collection.</summary>
         /// <param name="newExpression">A <see cref="T:System.Linq.Expressions.NewExpression" /> to set the <see cref="P:System.Linq.Expressions.ListInitExpression.NewExpression" /> property equal to.</param>
@@ -1251,7 +1254,7 @@ namespace System.Linq.Expressions
         /// <param name="initializers">An array of <see cref="T:System.Linq.Expressions.Expression" /> objects to use to populate the <see cref="P:System.Linq.Expressions.ListInitExpression.Initializers" /> collection.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.ListInitExpression" /> that has the <see cref="P:System.Linq.Expressions.Expression.NodeType" /> property equal to <see cref="F:System.Linq.Expressions.ExpressionType.ListInit" /> and the <see cref="P:System.Linq.Expressions.ListInitExpression.NewExpression" /> property set to the specified value.</returns>
         /// <remarks>This method does not provide any guarantees with regards to argument validation or type checking.</remarks>
-        public ListInitExpression ListInit(NewExpression newExpression, MethodInfo addMethod, Expression[] initializers) => ExpressionUnsafe.ListInit(newExpression, addMethod, initializers);
+        public virtual ListInitExpression ListInit(NewExpression newExpression, MethodInfo addMethod, Expression[] initializers) => ExpressionUnsafe.ListInit(newExpression, addMethod, initializers);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.ListInitExpression" /> that uses a specified method to add elements to a collection.</summary>
         /// <param name="newExpression">A <see cref="T:System.Linq.Expressions.NewExpression" /> to set the <see cref="P:System.Linq.Expressions.ListInitExpression.NewExpression" /> property equal to.</param>
@@ -1259,20 +1262,20 @@ namespace System.Linq.Expressions
         /// <param name="initializers">An <see cref="T:System.Collections.Generic.IEnumerable`1" /> that contains <see cref="T:System.Linq.Expressions.Expression" /> objects to use to populate the <see cref="P:System.Linq.Expressions.ListInitExpression.Initializers" /> collection.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.ListInitExpression" /> that has the <see cref="P:System.Linq.Expressions.Expression.NodeType" /> property equal to <see cref="F:System.Linq.Expressions.ExpressionType.ListInit" /> and the <see cref="P:System.Linq.Expressions.ListInitExpression.NewExpression" /> property set to the specified value.</returns>
         /// <remarks>This method does not provide any guarantees with regards to argument validation or type checking.</remarks>
-        public ListInitExpression ListInit(NewExpression newExpression, MethodInfo addMethod, IEnumerable<Expression> initializers) => ExpressionUnsafe.ListInit(newExpression, addMethod, initializers);
+        public virtual ListInitExpression ListInit(NewExpression newExpression, MethodInfo addMethod, IEnumerable<Expression> initializers) => ExpressionUnsafe.ListInit(newExpression, addMethod, initializers);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.LoopExpression" /> with the given body.</summary>
         /// <param name="body">The body of the loop.</param>
         /// <returns>The created <see cref="T:System.Linq.Expressions.LoopExpression" />.</returns>
         /// <remarks>This method does not provide any guarantees with regards to argument validation or type checking.</remarks>
-        public LoopExpression Loop(Expression body) => ExpressionUnsafe.Loop(body);
+        public virtual LoopExpression Loop(Expression body) => ExpressionUnsafe.Loop(body);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.LoopExpression" /> with the given body and break target.</summary>
         /// <param name="body">The body of the loop.</param>
         /// <param name="break">The break target used by the loop body.</param>
         /// <returns>The created <see cref="T:System.Linq.Expressions.LoopExpression" />.</returns>
         /// <remarks>This method does not provide any guarantees with regards to argument validation or type checking.</remarks>
-        public LoopExpression Loop(Expression body, LabelTarget @break) => ExpressionUnsafe.Loop(body, @break);
+        public virtual LoopExpression Loop(Expression body, LabelTarget @break) => ExpressionUnsafe.Loop(body, @break);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.LoopExpression" /> with the given body.</summary>
         /// <param name="body">The body of the loop.</param>
@@ -1280,7 +1283,7 @@ namespace System.Linq.Expressions
         /// <param name="continue">The continue target used by the loop body.</param>
         /// <returns>The created <see cref="T:System.Linq.Expressions.LoopExpression" />.</returns>
         /// <remarks>This method does not provide any guarantees with regards to argument validation or type checking.</remarks>
-        public LoopExpression Loop(Expression body, LabelTarget @break, LabelTarget @continue) => ExpressionUnsafe.Loop(body, @break, @continue);
+        public virtual LoopExpression Loop(Expression body, LabelTarget @break, LabelTarget @continue) => ExpressionUnsafe.Loop(body, @break, @continue);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.BinaryExpression" />, given the left and right operands, by calling an appropriate factory method.</summary>
         /// <param name="binaryType">The <see cref="T:System.Linq.Expressions.ExpressionType" /> that specifies the type of binary operation.</param>
@@ -1288,7 +1291,7 @@ namespace System.Linq.Expressions
         /// <param name="right">An <see cref="T:System.Linq.Expressions.Expression" /> that represents the right operand.</param>
         /// <returns>The <see cref="T:System.Linq.Expressions.BinaryExpression" /> that results from calling the appropriate factory method.</returns>
         /// <remarks>This method does not provide any guarantees with regards to argument validation or type checking.</remarks>
-        public BinaryExpression MakeBinary(ExpressionType binaryType, Expression left, Expression right) => ExpressionUnsafe.MakeBinary(binaryType, left, right);
+        public virtual BinaryExpression MakeBinary(ExpressionType binaryType, Expression left, Expression right) => ExpressionUnsafe.MakeBinary(binaryType, left, right);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.BinaryExpression" />, given the left operand, right operand and implementing method, by calling the appropriate factory method.</summary>
         /// <param name="binaryType">The <see cref="T:System.Linq.Expressions.ExpressionType" /> that specifies the type of binary operation.</param>
@@ -1299,7 +1302,7 @@ namespace System.Linq.Expressions
         /// <param name="method">A <see cref="T:System.Reflection.MethodInfo" /> that specifies the implementing method.</param>
         /// <returns>The <see cref="T:System.Linq.Expressions.BinaryExpression" /> that results from calling the appropriate factory method.</returns>
         /// <remarks>This method does not provide any guarantees with regards to argument validation or type checking.</remarks>
-        public BinaryExpression MakeBinary(ExpressionType binaryType, Expression left, Expression right, Boolean liftToNull, MethodInfo method) => ExpressionUnsafe.MakeBinary(binaryType, left, right, liftToNull, method);
+        public virtual BinaryExpression MakeBinary(ExpressionType binaryType, Expression left, Expression right, Boolean liftToNull, MethodInfo method) => ExpressionUnsafe.MakeBinary(binaryType, left, right, liftToNull, method);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.BinaryExpression" />, given the left operand, right operand, implementing method and type conversion function, by calling the appropriate factory method.</summary>
         /// <param name="binaryType">The <see cref="T:System.Linq.Expressions.ExpressionType" /> that specifies the type of binary operation.</param>
@@ -1311,7 +1314,7 @@ namespace System.Linq.Expressions
         /// <param name="conversion">A <see cref="T:System.Linq.Expressions.LambdaExpression" /> that represents a type conversion function. This parameter is used only if <paramref name="binaryType" /> is <see cref="F:System.Linq.Expressions.ExpressionType.Coalesce" /> or compound assignment..</param>
         /// <returns>The <see cref="T:System.Linq.Expressions.BinaryExpression" /> that results from calling the appropriate factory method.</returns>
         /// <remarks>This method does not provide any guarantees with regards to argument validation or type checking.</remarks>
-        public BinaryExpression MakeBinary(ExpressionType binaryType, Expression left, Expression right, Boolean liftToNull, MethodInfo method, LambdaExpression conversion) => ExpressionUnsafe.MakeBinary(binaryType, left, right, liftToNull, method, conversion);
+        public virtual BinaryExpression MakeBinary(ExpressionType binaryType, Expression left, Expression right, Boolean liftToNull, MethodInfo method, LambdaExpression conversion) => ExpressionUnsafe.MakeBinary(binaryType, left, right, liftToNull, method, conversion);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.CatchBlock" /> representing a catch statement with the specified elements.</summary>
         /// <param name="type">The <see cref="P:System.Linq.Expressions.Expression.Type" /> of <see cref="T:System.Exception" /> this <see cref="T:System.Linq.Expressions.CatchBlock" /> will handle.</param>
@@ -1320,7 +1323,7 @@ namespace System.Linq.Expressions
         /// <param name="filter">The body of the <see cref="T:System.Exception" /> filter.</param>
         /// <returns>The created <see cref="T:System.Linq.Expressions.CatchBlock" />.</returns>
         /// <remarks>This method does not provide any guarantees with regards to argument validation or type checking.</remarks>
-        public CatchBlock MakeCatchBlock(Type type, ParameterExpression variable, Expression body, Expression filter) => ExpressionUnsafe.MakeCatchBlock(type, variable, body, filter);
+        public virtual CatchBlock MakeCatchBlock(Type type, ParameterExpression variable, Expression body, Expression filter) => ExpressionUnsafe.MakeCatchBlock(type, variable, body, filter);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.DynamicExpression" /> that represents a dynamic operation bound by the provided <see cref="T:System.Runtime.CompilerServices.CallSiteBinder" />.</summary>
         /// <param name="delegateType">The type of the delegate used by the <see cref="T:System.Runtime.CompilerServices.CallSite" />.</param>
@@ -1328,7 +1331,7 @@ namespace System.Linq.Expressions
         /// <param name="arguments">The arguments to the dynamic operation.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.DynamicExpression" /> that has <see cref="P:System.Linq.Expressions.Expression.NodeType" /> equal to <see cref="F:System.Linq.Expressions.ExpressionType.Dynamic" /> and has the <see cref="P:System.Linq.Expressions.DynamicExpression.DelegateType" />, <see cref="P:System.Linq.Expressions.DynamicExpression.Binder" />, and <see cref="P:System.Linq.Expressions.DynamicExpression.Arguments" /> set to the specified values.</returns>
         /// <remarks>This method does not provide any guarantees with regards to argument validation or type checking.</remarks>
-        public DynamicExpression MakeDynamic(Type delegateType, CallSiteBinder binder, Expression[] arguments) => ExpressionUnsafe.MakeDynamic(delegateType, binder, arguments);
+        public virtual DynamicExpression MakeDynamic(Type delegateType, CallSiteBinder binder, Expression[] arguments) => ExpressionUnsafe.MakeDynamic(delegateType, binder, arguments);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.DynamicExpression" /> that represents a dynamic operation bound by the provided <see cref="T:System.Runtime.CompilerServices.CallSiteBinder" />.</summary>
         /// <param name="delegateType">The type of the delegate used by the <see cref="T:System.Runtime.CompilerServices.CallSite" />.</param>
@@ -1336,7 +1339,7 @@ namespace System.Linq.Expressions
         /// <param name="arguments">The arguments to the dynamic operation.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.DynamicExpression" /> that has <see cref="P:System.Linq.Expressions.Expression.NodeType" /> equal to <see cref="F:System.Linq.Expressions.ExpressionType.Dynamic" /> and has the <see cref="P:System.Linq.Expressions.DynamicExpression.DelegateType" />, <see cref="P:System.Linq.Expressions.DynamicExpression.Binder" />, and <see cref="P:System.Linq.Expressions.DynamicExpression.Arguments" /> set to the specified values.</returns>
         /// <remarks>This method does not provide any guarantees with regards to argument validation or type checking.</remarks>
-        public DynamicExpression MakeDynamic(Type delegateType, CallSiteBinder binder, IEnumerable<Expression> arguments) => ExpressionUnsafe.MakeDynamic(delegateType, binder, arguments);
+        public virtual DynamicExpression MakeDynamic(Type delegateType, CallSiteBinder binder, IEnumerable<Expression> arguments) => ExpressionUnsafe.MakeDynamic(delegateType, binder, arguments);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.DynamicExpression" /> that represents a dynamic operation bound by the provided <see cref="T:System.Runtime.CompilerServices.CallSiteBinder" /> and one argument.</summary>
         /// <param name="delegateType">The type of the delegate used by the <see cref="T:System.Runtime.CompilerServices.CallSite" />.</param>
@@ -1344,7 +1347,7 @@ namespace System.Linq.Expressions
         /// <param name="arg0">The argument to the dynamic operation.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.DynamicExpression" /> that has <see cref="P:System.Linq.Expressions.Expression.NodeType" /> equal to <see cref="F:System.Linq.Expressions.ExpressionType.Dynamic" /> and has the <see cref="P:System.Linq.Expressions.DynamicExpression.DelegateType" />, <see cref="P:System.Linq.Expressions.DynamicExpression.Binder" />, and <see cref="P:System.Linq.Expressions.DynamicExpression.Arguments" /> set to the specified values.</returns>
         /// <remarks>This method does not provide any guarantees with regards to argument validation or type checking.</remarks>
-        public DynamicExpression MakeDynamic(Type delegateType, CallSiteBinder binder, Expression arg0) => ExpressionUnsafe.MakeDynamic(delegateType, binder, arg0);
+        public virtual DynamicExpression MakeDynamic(Type delegateType, CallSiteBinder binder, Expression arg0) => ExpressionUnsafe.MakeDynamic(delegateType, binder, arg0);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.DynamicExpression" /> that represents a dynamic operation bound by the provided <see cref="T:System.Runtime.CompilerServices.CallSiteBinder" /> and two arguments.</summary>
         /// <param name="delegateType">The type of the delegate used by the <see cref="T:System.Runtime.CompilerServices.CallSite" />.</param>
@@ -1353,7 +1356,7 @@ namespace System.Linq.Expressions
         /// <param name="arg1">The second argument to the dynamic operation.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.DynamicExpression" /> that has <see cref="P:System.Linq.Expressions.Expression.NodeType" /> equal to <see cref="F:System.Linq.Expressions.ExpressionType.Dynamic" /> and has the <see cref="P:System.Linq.Expressions.DynamicExpression.DelegateType" />, <see cref="P:System.Linq.Expressions.DynamicExpression.Binder" />, and <see cref="P:System.Linq.Expressions.DynamicExpression.Arguments" /> set to the specified values.</returns>
         /// <remarks>This method does not provide any guarantees with regards to argument validation or type checking.</remarks>
-        public DynamicExpression MakeDynamic(Type delegateType, CallSiteBinder binder, Expression arg0, Expression arg1) => ExpressionUnsafe.MakeDynamic(delegateType, binder, arg0, arg1);
+        public virtual DynamicExpression MakeDynamic(Type delegateType, CallSiteBinder binder, Expression arg0, Expression arg1) => ExpressionUnsafe.MakeDynamic(delegateType, binder, arg0, arg1);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.DynamicExpression" /> that represents a dynamic operation bound by the provided <see cref="T:System.Runtime.CompilerServices.CallSiteBinder" /> and three arguments.</summary>
         /// <param name="delegateType">The type of the delegate used by the <see cref="T:System.Runtime.CompilerServices.CallSite" />.</param>
@@ -1363,7 +1366,7 @@ namespace System.Linq.Expressions
         /// <param name="arg2">The third argument to the dynamic operation.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.DynamicExpression" /> that has <see cref="P:System.Linq.Expressions.Expression.NodeType" /> equal to <see cref="F:System.Linq.Expressions.ExpressionType.Dynamic" /> and has the <see cref="P:System.Linq.Expressions.DynamicExpression.DelegateType" />, <see cref="P:System.Linq.Expressions.DynamicExpression.Binder" />, and <see cref="P:System.Linq.Expressions.DynamicExpression.Arguments" /> set to the specified values.</returns>
         /// <remarks>This method does not provide any guarantees with regards to argument validation or type checking.</remarks>
-        public DynamicExpression MakeDynamic(Type delegateType, CallSiteBinder binder, Expression arg0, Expression arg1, Expression arg2) => ExpressionUnsafe.MakeDynamic(delegateType, binder, arg0, arg1, arg2);
+        public virtual DynamicExpression MakeDynamic(Type delegateType, CallSiteBinder binder, Expression arg0, Expression arg1, Expression arg2) => ExpressionUnsafe.MakeDynamic(delegateType, binder, arg0, arg1, arg2);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.DynamicExpression" /> that represents a dynamic operation bound by the provided <see cref="T:System.Runtime.CompilerServices.CallSiteBinder" /> and four arguments.</summary>
         /// <param name="delegateType">The type of the delegate used by the <see cref="T:System.Runtime.CompilerServices.CallSite" />.</param>
@@ -1374,7 +1377,7 @@ namespace System.Linq.Expressions
         /// <param name="arg3">The fourth argument to the dynamic operation.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.DynamicExpression" /> that has <see cref="P:System.Linq.Expressions.Expression.NodeType" /> equal to <see cref="F:System.Linq.Expressions.ExpressionType.Dynamic" /> and has the <see cref="P:System.Linq.Expressions.DynamicExpression.DelegateType" />, <see cref="P:System.Linq.Expressions.DynamicExpression.Binder" />, and <see cref="P:System.Linq.Expressions.DynamicExpression.Arguments" /> set to the specified values.</returns>
         /// <remarks>This method does not provide any guarantees with regards to argument validation or type checking.</remarks>
-        public DynamicExpression MakeDynamic(Type delegateType, CallSiteBinder binder, Expression arg0, Expression arg1, Expression arg2, Expression arg3) => ExpressionUnsafe.MakeDynamic(delegateType, binder, arg0, arg1, arg2, arg3);
+        public virtual DynamicExpression MakeDynamic(Type delegateType, CallSiteBinder binder, Expression arg0, Expression arg1, Expression arg2, Expression arg3) => ExpressionUnsafe.MakeDynamic(delegateType, binder, arg0, arg1, arg2, arg3);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.GotoExpression" /> representing a jump of the specified <see cref="T:System.Linq.Expressions.GotoExpressionKind" />. The value passed to the label upon jumping can also be specified.</summary>
         /// <param name="kind">The <see cref="T:System.Linq.Expressions.GotoExpressionKind" /> of the <see cref="T:System.Linq.Expressions.GotoExpression" />.</param>
@@ -1383,7 +1386,7 @@ namespace System.Linq.Expressions
         /// <param name="type">An <see cref="T:System.Type" /> to set the <see cref="P:System.Linq.Expressions.Expression.Type" /> property equal to.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.GotoExpression" /> with <see cref="P:System.Linq.Expressions.GotoExpression.Kind" /> equal to <paramref name="kind" />, the <see cref="P:System.Linq.Expressions.GotoExpression.Target" /> property set to <paramref name="target" />, the <see cref="P:System.Linq.Expressions.Expression.Type" /> property set to <paramref name="type" />, and <paramref name="value" /> to be passed to the target label upon jumping.</returns>
         /// <remarks>This method does not provide any guarantees with regards to argument validation or type checking.</remarks>
-        public GotoExpression MakeGoto(GotoExpressionKind kind, LabelTarget target, Expression value, Type type) => ExpressionUnsafe.MakeGoto(kind, target, value, type);
+        public virtual GotoExpression MakeGoto(GotoExpressionKind kind, LabelTarget target, Expression value, Type type) => ExpressionUnsafe.MakeGoto(kind, target, value, type);
 
         /// <summary>Creates an <see cref="T:System.Linq.Expressions.IndexExpression" /> that represents accessing an indexed property in an object.</summary>
         /// <param name="instance">The object to which the property belongs. It should be null if the property is <see langword="static" /> (<see langword="shared" /> in Visual Basic).</param>
@@ -1391,14 +1394,14 @@ namespace System.Linq.Expressions
         /// <param name="arguments">An IEnumerable&lt;Expression&gt; (IEnumerable (Of Expression) in Visual Basic) that contains the arguments that will be used to index the property.</param>
         /// <returns>The created <see cref="T:System.Linq.Expressions.IndexExpression" />.</returns>
         /// <remarks>This method does not provide any guarantees with regards to argument validation or type checking.</remarks>
-        public IndexExpression MakeIndex(Expression instance, PropertyInfo indexer, IEnumerable<Expression> arguments) => ExpressionUnsafe.MakeIndex(instance, indexer, arguments);
+        public virtual IndexExpression MakeIndex(Expression instance, PropertyInfo indexer, IEnumerable<Expression> arguments) => ExpressionUnsafe.MakeIndex(instance, indexer, arguments);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.MemberExpression" /> that represents accessing either a field or a property.</summary>
         /// <param name="expression">An <see cref="T:System.Linq.Expressions.Expression" /> that represents the object that the member belongs to. This can be null for static members.</param>
         /// <param name="member">The <see cref="T:System.Reflection.MemberInfo" /> that describes the field or property to be accessed.</param>
         /// <returns>The <see cref="T:System.Linq.Expressions.MemberExpression" /> that results from calling the appropriate factory method.</returns>
         /// <remarks>This method does not provide any guarantees with regards to argument validation or type checking.</remarks>
-        public MemberExpression MakeMemberAccess(Expression expression, MemberInfo member) => ExpressionUnsafe.MakeMemberAccess(expression, member);
+        public virtual MemberExpression MakeMemberAccess(Expression expression, MemberInfo member) => ExpressionUnsafe.MakeMemberAccess(expression, member);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.TryExpression" /> representing a try block with the specified elements.</summary>
         /// <param name="type">The result type of the try expression. If null, bodh and all handlers must have identical type.</param>
@@ -1408,7 +1411,7 @@ namespace System.Linq.Expressions
         /// <param name="handlers">A collection of <see cref="T:System.Linq.Expressions.CatchBlock" />s representing the catch statements to be associated with the try block.</param>
         /// <returns>The created <see cref="T:System.Linq.Expressions.TryExpression" />.</returns>
         /// <remarks>This method does not provide any guarantees with regards to argument validation or type checking.</remarks>
-        public TryExpression MakeTry(Type type, Expression body, Expression @finally, Expression fault, IEnumerable<CatchBlock> handlers) => ExpressionUnsafe.MakeTry(type, body, @finally, fault, handlers);
+        public virtual TryExpression MakeTry(Type type, Expression body, Expression @finally, Expression fault, IEnumerable<CatchBlock> handlers) => ExpressionUnsafe.MakeTry(type, body, @finally, fault, handlers);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.UnaryExpression" />, given an operand, by calling the appropriate factory method.</summary>
         /// <param name="unaryType">The <see cref="T:System.Linq.Expressions.ExpressionType" /> that specifies the type of unary operation.</param>
@@ -1416,7 +1419,7 @@ namespace System.Linq.Expressions
         /// <param name="type">The <see cref="T:System.Type" /> that specifies the type to be converted to (pass <see langword="null" /> if not applicable).</param>
         /// <returns>The <see cref="T:System.Linq.Expressions.UnaryExpression" /> that results from calling the appropriate factory method.</returns>
         /// <remarks>This method does not provide any guarantees with regards to argument validation or type checking.</remarks>
-        public UnaryExpression MakeUnary(ExpressionType unaryType, Expression operand, Type type) => ExpressionUnsafe.MakeUnary(unaryType, operand, type);
+        public virtual UnaryExpression MakeUnary(ExpressionType unaryType, Expression operand, Type type) => ExpressionUnsafe.MakeUnary(unaryType, operand, type);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.UnaryExpression" />, given an operand and implementing method, by calling the appropriate factory method.</summary>
         /// <param name="unaryType">The <see cref="T:System.Linq.Expressions.ExpressionType" /> that specifies the type of unary operation.</param>
@@ -1425,56 +1428,56 @@ namespace System.Linq.Expressions
         /// <param name="method">The <see cref="T:System.Reflection.MethodInfo" /> that represents the implementing method.</param>
         /// <returns>The <see cref="T:System.Linq.Expressions.UnaryExpression" /> that results from calling the appropriate factory method.</returns>
         /// <remarks>This method does not provide any guarantees with regards to argument validation or type checking.</remarks>
-        public UnaryExpression MakeUnary(ExpressionType unaryType, Expression operand, Type type, MethodInfo method) => ExpressionUnsafe.MakeUnary(unaryType, operand, type, method);
+        public virtual UnaryExpression MakeUnary(ExpressionType unaryType, Expression operand, Type type, MethodInfo method) => ExpressionUnsafe.MakeUnary(unaryType, operand, type, method);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.MemberMemberBinding" /> that represents the recursive initialization of members of a field or property.</summary>
         /// <param name="member">The <see cref="T:System.Reflection.MemberInfo" /> to set the <see cref="P:System.Linq.Expressions.MemberBinding.Member" /> property equal to.</param>
         /// <param name="bindings">An array of <see cref="T:System.Linq.Expressions.MemberBinding" /> objects to use to populate the <see cref="P:System.Linq.Expressions.MemberMemberBinding.Bindings" /> collection.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.MemberMemberBinding" /> that has the <see cref="P:System.Linq.Expressions.MemberBinding.BindingType" /> property equal to <see cref="F:System.Linq.Expressions.MemberBindingType.MemberBinding" /> and the <see cref="P:System.Linq.Expressions.MemberBinding.Member" /> and <see cref="P:System.Linq.Expressions.MemberMemberBinding.Bindings" /> properties set to the specified values.</returns>
         /// <remarks>This method does not provide any guarantees with regards to argument validation or type checking.</remarks>
-        public MemberMemberBinding MemberBind(MemberInfo member, MemberBinding[] bindings) => ExpressionUnsafe.MemberBind(member, bindings);
+        public virtual MemberMemberBinding MemberBind(MemberInfo member, MemberBinding[] bindings) => ExpressionUnsafe.MemberBind(member, bindings);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.MemberMemberBinding" /> that represents the recursive initialization of members of a field or property.</summary>
         /// <param name="member">The <see cref="T:System.Reflection.MemberInfo" /> to set the <see cref="P:System.Linq.Expressions.MemberBinding.Member" /> property equal to.</param>
         /// <param name="bindings">An <see cref="T:System.Collections.Generic.IEnumerable`1" /> that contains <see cref="T:System.Linq.Expressions.MemberBinding" /> objects to use to populate the <see cref="P:System.Linq.Expressions.MemberMemberBinding.Bindings" /> collection.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.MemberMemberBinding" /> that has the <see cref="P:System.Linq.Expressions.MemberBinding.BindingType" /> property equal to <see cref="F:System.Linq.Expressions.MemberBindingType.MemberBinding" /> and the <see cref="P:System.Linq.Expressions.MemberBinding.Member" /> and <see cref="P:System.Linq.Expressions.MemberMemberBinding.Bindings" /> properties set to the specified values.</returns>
         /// <remarks>This method does not provide any guarantees with regards to argument validation or type checking.</remarks>
-        public MemberMemberBinding MemberBind(MemberInfo member, IEnumerable<MemberBinding> bindings) => ExpressionUnsafe.MemberBind(member, bindings);
+        public virtual MemberMemberBinding MemberBind(MemberInfo member, IEnumerable<MemberBinding> bindings) => ExpressionUnsafe.MemberBind(member, bindings);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.MemberMemberBinding" /> that represents the recursive initialization of members of a member that is accessed by using a property accessor method.</summary>
         /// <param name="propertyAccessor">The <see cref="T:System.Reflection.MethodInfo" /> that represents a property accessor method.</param>
         /// <param name="bindings">An array of <see cref="T:System.Linq.Expressions.MemberBinding" /> objects to use to populate the <see cref="P:System.Linq.Expressions.MemberMemberBinding.Bindings" /> collection.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.MemberMemberBinding" /> that has the <see cref="P:System.Linq.Expressions.MemberBinding.BindingType" /> property equal to <see cref="F:System.Linq.Expressions.MemberBindingType.MemberBinding" />, the <see cref="P:System.Linq.Expressions.MemberBinding.Member" /> property set to the <see cref="T:System.Reflection.PropertyInfo" /> that represents the property accessed in <paramref name="propertyAccessor" />, and <see cref="P:System.Linq.Expressions.MemberMemberBinding.Bindings" /> properties set to the specified values.</returns>
         /// <remarks>This method does not provide any guarantees with regards to argument validation or type checking.</remarks>
-        public MemberMemberBinding MemberBind(MethodInfo propertyAccessor, MemberBinding[] bindings) => ExpressionUnsafe.MemberBind(propertyAccessor, bindings);
+        public virtual MemberMemberBinding MemberBind(MethodInfo propertyAccessor, MemberBinding[] bindings) => ExpressionUnsafe.MemberBind(propertyAccessor, bindings);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.MemberMemberBinding" /> that represents the recursive initialization of members of a member that is accessed by using a property accessor method.</summary>
         /// <param name="propertyAccessor">The <see cref="T:System.Reflection.MethodInfo" /> that represents a property accessor method.</param>
         /// <param name="bindings">An <see cref="T:System.Collections.Generic.IEnumerable`1" /> that contains <see cref="T:System.Linq.Expressions.MemberBinding" /> objects to use to populate the <see cref="P:System.Linq.Expressions.MemberMemberBinding.Bindings" /> collection.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.MemberMemberBinding" /> that has the <see cref="P:System.Linq.Expressions.MemberBinding.BindingType" /> property equal to <see cref="F:System.Linq.Expressions.MemberBindingType.MemberBinding" />, the <see cref="P:System.Linq.Expressions.MemberBinding.Member" /> property set to the <see cref="T:System.Reflection.PropertyInfo" /> that represents the property accessed in <paramref name="propertyAccessor" />, and <see cref="P:System.Linq.Expressions.MemberMemberBinding.Bindings" /> properties set to the specified values.</returns>
         /// <remarks>This method does not provide any guarantees with regards to argument validation or type checking.</remarks>
-        public MemberMemberBinding MemberBind(MethodInfo propertyAccessor, IEnumerable<MemberBinding> bindings) => ExpressionUnsafe.MemberBind(propertyAccessor, bindings);
+        public virtual MemberMemberBinding MemberBind(MethodInfo propertyAccessor, IEnumerable<MemberBinding> bindings) => ExpressionUnsafe.MemberBind(propertyAccessor, bindings);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.MemberInitExpression" />.</summary>
         /// <param name="newExpression">A <see cref="T:System.Linq.Expressions.NewExpression" /> to set the <see cref="P:System.Linq.Expressions.MemberInitExpression.NewExpression" /> property equal to.</param>
         /// <param name="bindings">An array of <see cref="T:System.Linq.Expressions.MemberBinding" /> objects to use to populate the <see cref="P:System.Linq.Expressions.MemberInitExpression.Bindings" /> collection.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.MemberInitExpression" /> that has the <see cref="P:System.Linq.Expressions.Expression.NodeType" /> property equal to <see cref="F:System.Linq.Expressions.ExpressionType.MemberInit" /> and the <see cref="P:System.Linq.Expressions.MemberInitExpression.NewExpression" /> and <see cref="P:System.Linq.Expressions.MemberInitExpression.Bindings" /> properties set to the specified values.</returns>
         /// <remarks>This method does not provide any guarantees with regards to argument validation or type checking.</remarks>
-        public MemberInitExpression MemberInit(NewExpression newExpression, MemberBinding[] bindings) => ExpressionUnsafe.MemberInit(newExpression, bindings);
+        public virtual MemberInitExpression MemberInit(NewExpression newExpression, MemberBinding[] bindings) => ExpressionUnsafe.MemberInit(newExpression, bindings);
 
         /// <summary>Represents an expression that creates a new object and initializes a property of the object.</summary>
         /// <param name="newExpression">A <see cref="T:System.Linq.Expressions.NewExpression" /> to set the <see cref="P:System.Linq.Expressions.MemberInitExpression.NewExpression" /> property equal to.</param>
         /// <param name="bindings">An <see cref="T:System.Collections.Generic.IEnumerable`1" /> that contains <see cref="T:System.Linq.Expressions.MemberBinding" /> objects to use to populate the <see cref="P:System.Linq.Expressions.MemberInitExpression.Bindings" /> collection.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.MemberInitExpression" /> that has the <see cref="P:System.Linq.Expressions.Expression.NodeType" /> property equal to <see cref="F:System.Linq.Expressions.ExpressionType.MemberInit" /> and the <see cref="P:System.Linq.Expressions.MemberInitExpression.NewExpression" /> and <see cref="P:System.Linq.Expressions.MemberInitExpression.Bindings" /> properties set to the specified values.</returns>
         /// <remarks>This method does not provide any guarantees with regards to argument validation or type checking.</remarks>
-        public MemberInitExpression MemberInit(NewExpression newExpression, IEnumerable<MemberBinding> bindings) => ExpressionUnsafe.MemberInit(newExpression, bindings);
+        public virtual MemberInitExpression MemberInit(NewExpression newExpression, IEnumerable<MemberBinding> bindings) => ExpressionUnsafe.MemberInit(newExpression, bindings);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.BinaryExpression" /> that represents an arithmetic remainder operation.</summary>
         /// <param name="left">An <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Left" /> property equal to.</param>
         /// <param name="right">An <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Right" /> property equal to.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.BinaryExpression" /> that has the <see cref="P:System.Linq.Expressions.Expression.NodeType" /> property equal to <see cref="F:System.Linq.Expressions.ExpressionType.Modulo" /> and the <see cref="P:System.Linq.Expressions.BinaryExpression.Left" /> and <see cref="P:System.Linq.Expressions.BinaryExpression.Right" /> properties set to the specified values.</returns>
         /// <remarks>This method does not provide any guarantees with regards to argument validation or type checking.</remarks>
-        public BinaryExpression Modulo(Expression left, Expression right) => ExpressionUnsafe.Modulo(left, right);
+        public virtual BinaryExpression Modulo(Expression left, Expression right) => ExpressionUnsafe.Modulo(left, right);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.BinaryExpression" /> that represents an arithmetic remainder operation.</summary>
         /// <param name="left">An <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Left" /> property equal to.</param>
@@ -1482,14 +1485,14 @@ namespace System.Linq.Expressions
         /// <param name="method">A <see cref="T:System.Reflection.MethodInfo" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Method" /> property equal to.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.BinaryExpression" /> that has the <see cref="P:System.Linq.Expressions.Expression.NodeType" /> property equal to <see cref="F:System.Linq.Expressions.ExpressionType.Modulo" /> and the <see cref="P:System.Linq.Expressions.BinaryExpression.Left" />, <see cref="P:System.Linq.Expressions.BinaryExpression.Right" />, and <see cref="P:System.Linq.Expressions.BinaryExpression.Method" /> properties set to the specified values.</returns>
         /// <remarks>This method does not provide any guarantees with regards to argument validation or type checking.</remarks>
-        public BinaryExpression Modulo(Expression left, Expression right, MethodInfo method) => ExpressionUnsafe.Modulo(left, right, method);
+        public virtual BinaryExpression Modulo(Expression left, Expression right, MethodInfo method) => ExpressionUnsafe.Modulo(left, right, method);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.BinaryExpression" /> that represents a remainder assignment operation.</summary>
         /// <param name="left">An <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Left" /> property equal to.</param>
         /// <param name="right">An <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Right" /> property equal to.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.BinaryExpression" /> that has the <see cref="P:System.Linq.Expressions.Expression.NodeType" /> property equal to <see cref="F:System.Linq.Expressions.ExpressionType.ModuloAssign" /> and the <see cref="P:System.Linq.Expressions.BinaryExpression.Left" /> and <see cref="P:System.Linq.Expressions.BinaryExpression.Right" /> properties set to the specified values.</returns>
         /// <remarks>This method does not provide any guarantees with regards to argument validation or type checking.</remarks>
-        public BinaryExpression ModuloAssign(Expression left, Expression right) => ExpressionUnsafe.ModuloAssign(left, right);
+        public virtual BinaryExpression ModuloAssign(Expression left, Expression right) => ExpressionUnsafe.ModuloAssign(left, right);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.BinaryExpression" /> that represents a remainder assignment operation.</summary>
         /// <param name="left">An <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Left" /> property equal to.</param>
@@ -1497,7 +1500,7 @@ namespace System.Linq.Expressions
         /// <param name="method">A <see cref="T:System.Reflection.MethodInfo" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Method" /> property equal to.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.BinaryExpression" /> that has the <see cref="P:System.Linq.Expressions.Expression.NodeType" /> property equal to <see cref="F:System.Linq.Expressions.ExpressionType.ModuloAssign" /> and the <see cref="P:System.Linq.Expressions.BinaryExpression.Left" />, <see cref="P:System.Linq.Expressions.BinaryExpression.Right" />, and <see cref="P:System.Linq.Expressions.BinaryExpression.Method" /> properties set to the specified values.</returns>
         /// <remarks>This method does not provide any guarantees with regards to argument validation or type checking.</remarks>
-        public BinaryExpression ModuloAssign(Expression left, Expression right, MethodInfo method) => ExpressionUnsafe.ModuloAssign(left, right, method);
+        public virtual BinaryExpression ModuloAssign(Expression left, Expression right, MethodInfo method) => ExpressionUnsafe.ModuloAssign(left, right, method);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.BinaryExpression" /> that represents a remainder assignment operation.</summary>
         /// <param name="left">An <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Left" /> property equal to.</param>
@@ -1506,14 +1509,14 @@ namespace System.Linq.Expressions
         /// <param name="conversion">A <see cref="T:System.Linq.Expressions.LambdaExpression" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Conversion" /> property equal to.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.BinaryExpression" /> that has the <see cref="P:System.Linq.Expressions.Expression.NodeType" /> property equal to <see cref="F:System.Linq.Expressions.ExpressionType.ModuloAssign" /> and the <see cref="P:System.Linq.Expressions.BinaryExpression.Left" />, <see cref="P:System.Linq.Expressions.BinaryExpression.Right" />, <see cref="P:System.Linq.Expressions.BinaryExpression.Method" />, and <see cref="P:System.Linq.Expressions.BinaryExpression.Conversion" /> properties set to the specified values.</returns>
         /// <remarks>This method does not provide any guarantees with regards to argument validation or type checking.</remarks>
-        public BinaryExpression ModuloAssign(Expression left, Expression right, MethodInfo method, LambdaExpression conversion) => ExpressionUnsafe.ModuloAssign(left, right, method, conversion);
+        public virtual BinaryExpression ModuloAssign(Expression left, Expression right, MethodInfo method, LambdaExpression conversion) => ExpressionUnsafe.ModuloAssign(left, right, method, conversion);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.BinaryExpression" /> that represents an arithmetic multiplication operation that does not have overflow checking.</summary>
         /// <param name="left">An <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Left" /> property equal to.</param>
         /// <param name="right">An <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Right" /> property equal to.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.BinaryExpression" /> that has the <see cref="P:System.Linq.Expressions.Expression.NodeType" /> property equal to <see cref="F:System.Linq.Expressions.ExpressionType.Multiply" /> and the <see cref="P:System.Linq.Expressions.BinaryExpression.Left" /> and <see cref="P:System.Linq.Expressions.BinaryExpression.Right" /> properties set to the specified values.</returns>
         /// <remarks>This method does not provide any guarantees with regards to argument validation or type checking.</remarks>
-        public BinaryExpression Multiply(Expression left, Expression right) => ExpressionUnsafe.Multiply(left, right);
+        public virtual BinaryExpression Multiply(Expression left, Expression right) => ExpressionUnsafe.Multiply(left, right);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.BinaryExpression" /> that represents an arithmetic multiplication operation that does not have overflow checking.</summary>
         /// <param name="left">An <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Left" /> property equal to.</param>
@@ -1521,14 +1524,14 @@ namespace System.Linq.Expressions
         /// <param name="method">A <see cref="T:System.Reflection.MethodInfo" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Method" /> property equal to.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.BinaryExpression" /> that has the <see cref="P:System.Linq.Expressions.Expression.NodeType" /> property equal to <see cref="F:System.Linq.Expressions.ExpressionType.Multiply" /> and the <see cref="P:System.Linq.Expressions.BinaryExpression.Left" />, <see cref="P:System.Linq.Expressions.BinaryExpression.Right" />, and <see cref="P:System.Linq.Expressions.BinaryExpression.Method" /> properties set to the specified values.</returns>
         /// <remarks>This method does not provide any guarantees with regards to argument validation or type checking.</remarks>
-        public BinaryExpression Multiply(Expression left, Expression right, MethodInfo method) => ExpressionUnsafe.Multiply(left, right, method);
+        public virtual BinaryExpression Multiply(Expression left, Expression right, MethodInfo method) => ExpressionUnsafe.Multiply(left, right, method);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.BinaryExpression" /> that represents a multiplication assignment operation that does not have overflow checking.</summary>
         /// <param name="left">An <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Left" /> property equal to.</param>
         /// <param name="right">An <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Right" /> property equal to.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.BinaryExpression" /> that has the <see cref="P:System.Linq.Expressions.Expression.NodeType" /> property equal to <see cref="F:System.Linq.Expressions.ExpressionType.MultiplyAssign" /> and the <see cref="P:System.Linq.Expressions.BinaryExpression.Left" /> and <see cref="P:System.Linq.Expressions.BinaryExpression.Right" /> properties set to the specified values.</returns>
         /// <remarks>This method does not provide any guarantees with regards to argument validation or type checking.</remarks>
-        public BinaryExpression MultiplyAssign(Expression left, Expression right) => ExpressionUnsafe.MultiplyAssign(left, right);
+        public virtual BinaryExpression MultiplyAssign(Expression left, Expression right) => ExpressionUnsafe.MultiplyAssign(left, right);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.BinaryExpression" /> that represents a multiplication assignment operation that does not have overflow checking.</summary>
         /// <param name="left">An <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Left" /> property equal to.</param>
@@ -1536,7 +1539,7 @@ namespace System.Linq.Expressions
         /// <param name="method">A <see cref="T:System.Reflection.MethodInfo" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Method" /> property equal to.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.BinaryExpression" /> that has the <see cref="P:System.Linq.Expressions.Expression.NodeType" /> property equal to <see cref="F:System.Linq.Expressions.ExpressionType.MultiplyAssign" /> and the <see cref="P:System.Linq.Expressions.BinaryExpression.Left" />, <see cref="P:System.Linq.Expressions.BinaryExpression.Right" />, and <see cref="P:System.Linq.Expressions.BinaryExpression.Method" /> properties set to the specified values.</returns>
         /// <remarks>This method does not provide any guarantees with regards to argument validation or type checking.</remarks>
-        public BinaryExpression MultiplyAssign(Expression left, Expression right, MethodInfo method) => ExpressionUnsafe.MultiplyAssign(left, right, method);
+        public virtual BinaryExpression MultiplyAssign(Expression left, Expression right, MethodInfo method) => ExpressionUnsafe.MultiplyAssign(left, right, method);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.BinaryExpression" /> that represents a multiplication assignment operation that does not have overflow checking.</summary>
         /// <param name="left">An <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Left" /> property equal to.</param>
@@ -1545,14 +1548,14 @@ namespace System.Linq.Expressions
         /// <param name="conversion">A <see cref="T:System.Linq.Expressions.LambdaExpression" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Conversion" /> property equal to.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.BinaryExpression" /> that has the <see cref="P:System.Linq.Expressions.Expression.NodeType" /> property equal to <see cref="F:System.Linq.Expressions.ExpressionType.MultiplyAssign" /> and the <see cref="P:System.Linq.Expressions.BinaryExpression.Left" />, <see cref="P:System.Linq.Expressions.BinaryExpression.Right" />, <see cref="P:System.Linq.Expressions.BinaryExpression.Method" />, and <see cref="P:System.Linq.Expressions.BinaryExpression.Conversion" /> properties set to the specified values.</returns>
         /// <remarks>This method does not provide any guarantees with regards to argument validation or type checking.</remarks>
-        public BinaryExpression MultiplyAssign(Expression left, Expression right, MethodInfo method, LambdaExpression conversion) => ExpressionUnsafe.MultiplyAssign(left, right, method, conversion);
+        public virtual BinaryExpression MultiplyAssign(Expression left, Expression right, MethodInfo method, LambdaExpression conversion) => ExpressionUnsafe.MultiplyAssign(left, right, method, conversion);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.BinaryExpression" /> that represents a multiplication assignment operation that has overflow checking.</summary>
         /// <param name="left">An <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Left" /> property equal to.</param>
         /// <param name="right">An <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Right" /> property equal to.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.BinaryExpression" /> that has the <see cref="P:System.Linq.Expressions.Expression.NodeType" /> property equal to <see cref="F:System.Linq.Expressions.ExpressionType.MultiplyAssignChecked" /> and the <see cref="P:System.Linq.Expressions.BinaryExpression.Left" /> and <see cref="P:System.Linq.Expressions.BinaryExpression.Right" /> properties set to the specified values.</returns>
         /// <remarks>This method does not provide any guarantees with regards to argument validation or type checking.</remarks>
-        public BinaryExpression MultiplyAssignChecked(Expression left, Expression right) => ExpressionUnsafe.MultiplyAssignChecked(left, right);
+        public virtual BinaryExpression MultiplyAssignChecked(Expression left, Expression right) => ExpressionUnsafe.MultiplyAssignChecked(left, right);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.BinaryExpression" /> that represents a multiplication assignment operation that has overflow checking.</summary>
         /// <param name="left">An <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Left" /> property equal to.</param>
@@ -1560,7 +1563,7 @@ namespace System.Linq.Expressions
         /// <param name="method">A <see cref="T:System.Reflection.MethodInfo" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Method" /> property equal to.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.BinaryExpression" /> that has the <see cref="P:System.Linq.Expressions.Expression.NodeType" /> property equal to <see cref="F:System.Linq.Expressions.ExpressionType.MultiplyAssignChecked" /> and the <see cref="P:System.Linq.Expressions.BinaryExpression.Left" />, <see cref="P:System.Linq.Expressions.BinaryExpression.Right" />, and <see cref="P:System.Linq.Expressions.BinaryExpression.Method" /> properties set to the specified values.</returns>
         /// <remarks>This method does not provide any guarantees with regards to argument validation or type checking.</remarks>
-        public BinaryExpression MultiplyAssignChecked(Expression left, Expression right, MethodInfo method) => ExpressionUnsafe.MultiplyAssignChecked(left, right, method);
+        public virtual BinaryExpression MultiplyAssignChecked(Expression left, Expression right, MethodInfo method) => ExpressionUnsafe.MultiplyAssignChecked(left, right, method);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.BinaryExpression" /> that represents a multiplication assignment operation that has overflow checking.</summary>
         /// <param name="left">An <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Left" /> property equal to.</param>
@@ -1569,14 +1572,14 @@ namespace System.Linq.Expressions
         /// <param name="conversion">A <see cref="T:System.Linq.Expressions.LambdaExpression" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Conversion" /> property equal to.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.BinaryExpression" /> that has the <see cref="P:System.Linq.Expressions.Expression.NodeType" /> property equal to <see cref="F:System.Linq.Expressions.ExpressionType.MultiplyAssignChecked" /> and the <see cref="P:System.Linq.Expressions.BinaryExpression.Left" />, <see cref="P:System.Linq.Expressions.BinaryExpression.Right" />, <see cref="P:System.Linq.Expressions.BinaryExpression.Method" />, and <see cref="P:System.Linq.Expressions.BinaryExpression.Conversion" /> properties set to the specified values.</returns>
         /// <remarks>This method does not provide any guarantees with regards to argument validation or type checking.</remarks>
-        public BinaryExpression MultiplyAssignChecked(Expression left, Expression right, MethodInfo method, LambdaExpression conversion) => ExpressionUnsafe.MultiplyAssignChecked(left, right, method, conversion);
+        public virtual BinaryExpression MultiplyAssignChecked(Expression left, Expression right, MethodInfo method, LambdaExpression conversion) => ExpressionUnsafe.MultiplyAssignChecked(left, right, method, conversion);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.BinaryExpression" /> that represents an arithmetic multiplication operation that has overflow checking.</summary>
         /// <param name="left">An <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Left" /> property equal to.</param>
         /// <param name="right">An <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Right" /> property equal to.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.BinaryExpression" /> that has the <see cref="P:System.Linq.Expressions.Expression.NodeType" /> property equal to <see cref="F:System.Linq.Expressions.ExpressionType.MultiplyChecked" /> and the <see cref="P:System.Linq.Expressions.BinaryExpression.Left" /> and <see cref="P:System.Linq.Expressions.BinaryExpression.Right" /> properties set to the specified values.</returns>
         /// <remarks>This method does not provide any guarantees with regards to argument validation or type checking.</remarks>
-        public BinaryExpression MultiplyChecked(Expression left, Expression right) => ExpressionUnsafe.MultiplyChecked(left, right);
+        public virtual BinaryExpression MultiplyChecked(Expression left, Expression right) => ExpressionUnsafe.MultiplyChecked(left, right);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.BinaryExpression" /> that represents an arithmetic multiplication operation that has overflow checking.</summary>
         /// <param name="left">An <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Left" /> property equal to.</param>
@@ -1584,59 +1587,59 @@ namespace System.Linq.Expressions
         /// <param name="method">A <see cref="T:System.Reflection.MethodInfo" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Method" /> property equal to.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.BinaryExpression" /> that has the <see cref="P:System.Linq.Expressions.Expression.NodeType" /> property equal to <see cref="F:System.Linq.Expressions.ExpressionType.MultiplyChecked" /> and the <see cref="P:System.Linq.Expressions.BinaryExpression.Left" />, <see cref="P:System.Linq.Expressions.BinaryExpression.Right" />, and <see cref="P:System.Linq.Expressions.BinaryExpression.Method" /> properties set to the specified values.</returns>
         /// <remarks>This method does not provide any guarantees with regards to argument validation or type checking.</remarks>
-        public BinaryExpression MultiplyChecked(Expression left, Expression right, MethodInfo method) => ExpressionUnsafe.MultiplyChecked(left, right, method);
+        public virtual BinaryExpression MultiplyChecked(Expression left, Expression right, MethodInfo method) => ExpressionUnsafe.MultiplyChecked(left, right, method);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.UnaryExpression" /> that represents an arithmetic negation operation.</summary>
         /// <param name="expression">An <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.UnaryExpression.Operand" /> property equal to.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.UnaryExpression" /> that has the <see cref="P:System.Linq.Expressions.Expression.NodeType" /> property equal to <see cref="F:System.Linq.Expressions.ExpressionType.Negate" /> and the <see cref="P:System.Linq.Expressions.UnaryExpression.Operand" /> property set to the specified value.</returns>
         /// <remarks>This method does not provide any guarantees with regards to argument validation or type checking.</remarks>
-        public UnaryExpression Negate(Expression expression) => ExpressionUnsafe.Negate(expression);
+        public virtual UnaryExpression Negate(Expression expression) => ExpressionUnsafe.Negate(expression);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.UnaryExpression" /> that represents an arithmetic negation operation.</summary>
         /// <param name="expression">An <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.UnaryExpression.Operand" /> property equal to.</param>
         /// <param name="method">A <see cref="T:System.Reflection.MethodInfo" /> to set the <see cref="P:System.Linq.Expressions.UnaryExpression.Method" /> property equal to.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.UnaryExpression" /> that has the <see cref="P:System.Linq.Expressions.Expression.NodeType" /> property equal to <see cref="F:System.Linq.Expressions.ExpressionType.Negate" /> and the <see cref="P:System.Linq.Expressions.UnaryExpression.Operand" /> and <see cref="P:System.Linq.Expressions.UnaryExpression.Method" /> properties set to the specified values.</returns>
         /// <remarks>This method does not provide any guarantees with regards to argument validation or type checking.</remarks>
-        public UnaryExpression Negate(Expression expression, MethodInfo method) => ExpressionUnsafe.Negate(expression, method);
+        public virtual UnaryExpression Negate(Expression expression, MethodInfo method) => ExpressionUnsafe.Negate(expression, method);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.UnaryExpression" /> that represents an arithmetic negation operation that has overflow checking.</summary>
         /// <param name="expression">An <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.UnaryExpression.Operand" /> property equal to.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.UnaryExpression" /> that has the <see cref="P:System.Linq.Expressions.Expression.NodeType" /> property equal to <see cref="F:System.Linq.Expressions.ExpressionType.NegateChecked" /> and the <see cref="P:System.Linq.Expressions.UnaryExpression.Operand" /> property set to the specified value.</returns>
         /// <remarks>This method does not provide any guarantees with regards to argument validation or type checking.</remarks>
-        public UnaryExpression NegateChecked(Expression expression) => ExpressionUnsafe.NegateChecked(expression);
+        public virtual UnaryExpression NegateChecked(Expression expression) => ExpressionUnsafe.NegateChecked(expression);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.UnaryExpression" /> that represents an arithmetic negation operation that has overflow checking. The implementing method can be specified.</summary>
         /// <param name="expression">An <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.UnaryExpression.Operand" /> property equal to.</param>
         /// <param name="method">A <see cref="T:System.Reflection.MethodInfo" /> to set the <see cref="P:System.Linq.Expressions.UnaryExpression.Method" /> property equal to.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.UnaryExpression" /> that has the <see cref="P:System.Linq.Expressions.Expression.NodeType" /> property equal to <see cref="F:System.Linq.Expressions.ExpressionType.NegateChecked" /> and the <see cref="P:System.Linq.Expressions.UnaryExpression.Operand" /> and <see cref="P:System.Linq.Expressions.UnaryExpression.Method" /> properties set to the specified values.</returns>
         /// <remarks>This method does not provide any guarantees with regards to argument validation or type checking.</remarks>
-        public UnaryExpression NegateChecked(Expression expression, MethodInfo method) => ExpressionUnsafe.NegateChecked(expression, method);
+        public virtual UnaryExpression NegateChecked(Expression expression, MethodInfo method) => ExpressionUnsafe.NegateChecked(expression, method);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.NewExpression" /> that represents calling the specified constructor that takes no arguments.</summary>
         /// <param name="constructor">The <see cref="T:System.Reflection.ConstructorInfo" /> to set the <see cref="P:System.Linq.Expressions.NewExpression.Constructor" /> property equal to.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.NewExpression" /> that has the <see cref="P:System.Linq.Expressions.Expression.NodeType" /> property equal to <see cref="F:System.Linq.Expressions.ExpressionType.New" /> and the <see cref="P:System.Linq.Expressions.NewExpression.Constructor" /> property set to the specified value.</returns>
         /// <remarks>This method does not provide any guarantees with regards to argument validation or type checking.</remarks>
-        public NewExpression New(ConstructorInfo constructor) => ExpressionUnsafe.New(constructor);
+        public virtual NewExpression New(ConstructorInfo constructor) => ExpressionUnsafe.New(constructor);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.NewExpression" /> that represents calling the parameterless constructor of the specified type.</summary>
         /// <param name="type">A <see cref="T:System.Type" /> that has a constructor that takes no arguments.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.NewExpression" /> that has the <see cref="P:System.Linq.Expressions.Expression.NodeType" /> property equal to <see cref="F:System.Linq.Expressions.ExpressionType.New" /> and the <see cref="P:System.Linq.Expressions.NewExpression.Constructor" /> property set to the <see cref="T:System.Reflection.ConstructorInfo" /> that represents the constructor without parameters for the specified type.</returns>
         /// <remarks>This method does not provide any guarantees with regards to argument validation or type checking.</remarks>
-        public NewExpression New(Type type) => ExpressionUnsafe.New(type);
+        public virtual NewExpression New(Type type) => ExpressionUnsafe.New(type);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.NewExpression" /> that represents calling the specified constructor with the specified arguments.</summary>
         /// <param name="constructor">The <see cref="T:System.Reflection.ConstructorInfo" /> to set the <see cref="P:System.Linq.Expressions.NewExpression.Constructor" /> property equal to.</param>
         /// <param name="arguments">An array of <see cref="T:System.Linq.Expressions.Expression" /> objects to use to populate the <see cref="P:System.Linq.Expressions.NewExpression.Arguments" /> collection.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.NewExpression" /> that has the <see cref="P:System.Linq.Expressions.Expression.NodeType" /> property equal to <see cref="F:System.Linq.Expressions.ExpressionType.New" /> and the <see cref="P:System.Linq.Expressions.NewExpression.Constructor" /> and <see cref="P:System.Linq.Expressions.NewExpression.Arguments" /> properties set to the specified values.</returns>
         /// <remarks>This method does not provide any guarantees with regards to argument validation or type checking.</remarks>
-        public NewExpression New(ConstructorInfo constructor, Expression[] arguments) => ExpressionUnsafe.New(constructor, arguments);
+        public virtual NewExpression New(ConstructorInfo constructor, Expression[] arguments) => ExpressionUnsafe.New(constructor, arguments);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.NewExpression" /> that represents calling the specified constructor with the specified arguments.</summary>
         /// <param name="constructor">The <see cref="T:System.Reflection.ConstructorInfo" /> to set the <see cref="P:System.Linq.Expressions.NewExpression.Constructor" /> property equal to.</param>
         /// <param name="arguments">An <see cref="T:System.Collections.Generic.IEnumerable`1" /> that contains <see cref="T:System.Linq.Expressions.Expression" /> objects to use to populate the <see cref="P:System.Linq.Expressions.NewExpression.Arguments" /> collection.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.NewExpression" /> that has the <see cref="P:System.Linq.Expressions.Expression.NodeType" /> property equal to <see cref="F:System.Linq.Expressions.ExpressionType.New" /> and the <see cref="P:System.Linq.Expressions.NewExpression.Constructor" /> and <see cref="P:System.Linq.Expressions.NewExpression.Arguments" /> properties set to the specified values.</returns>
         /// <remarks>This method does not provide any guarantees with regards to argument validation or type checking.</remarks>
-        public NewExpression New(ConstructorInfo constructor, IEnumerable<Expression> arguments) => ExpressionUnsafe.New(constructor, arguments);
+        public virtual NewExpression New(ConstructorInfo constructor, IEnumerable<Expression> arguments) => ExpressionUnsafe.New(constructor, arguments);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.NewExpression" /> that represents calling the specified constructor with the specified arguments. The members that access the constructor initialized fields are specified.</summary>
         /// <param name="constructor">The <see cref="T:System.Reflection.ConstructorInfo" /> to set the <see cref="P:System.Linq.Expressions.NewExpression.Constructor" /> property equal to.</param>
@@ -1644,7 +1647,7 @@ namespace System.Linq.Expressions
         /// <param name="members">An <see cref="T:System.Collections.Generic.IEnumerable`1" /> that contains <see cref="T:System.Reflection.MemberInfo" /> objects to use to populate the <see cref="P:System.Linq.Expressions.NewExpression.Members" /> collection.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.NewExpression" /> that has the <see cref="P:System.Linq.Expressions.Expression.NodeType" /> property equal to <see cref="F:System.Linq.Expressions.ExpressionType.New" /> and the <see cref="P:System.Linq.Expressions.NewExpression.Constructor" />, <see cref="P:System.Linq.Expressions.NewExpression.Arguments" /> and <see cref="P:System.Linq.Expressions.NewExpression.Members" /> properties set to the specified values.</returns>
         /// <remarks>This method does not provide any guarantees with regards to argument validation or type checking.</remarks>
-        public NewExpression New(ConstructorInfo constructor, IEnumerable<Expression> arguments, IEnumerable<MemberInfo> members) => ExpressionUnsafe.New(constructor, arguments, members);
+        public virtual NewExpression New(ConstructorInfo constructor, IEnumerable<Expression> arguments, IEnumerable<MemberInfo> members) => ExpressionUnsafe.New(constructor, arguments, members);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.NewExpression" /> that represents calling the specified constructor with the specified arguments. The members that access the constructor initialized fields are specified as an array.</summary>
         /// <param name="constructor">The <see cref="T:System.Reflection.ConstructorInfo" /> to set the <see cref="P:System.Linq.Expressions.NewExpression.Constructor" /> property equal to.</param>
@@ -1652,55 +1655,55 @@ namespace System.Linq.Expressions
         /// <param name="members">An array of <see cref="T:System.Reflection.MemberInfo" /> objects to use to populate the <see cref="P:System.Linq.Expressions.NewExpression.Members" /> collection.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.NewExpression" /> that has the <see cref="P:System.Linq.Expressions.Expression.NodeType" /> property equal to <see cref="F:System.Linq.Expressions.ExpressionType.New" /> and the <see cref="P:System.Linq.Expressions.NewExpression.Constructor" />, <see cref="P:System.Linq.Expressions.NewExpression.Arguments" /> and <see cref="P:System.Linq.Expressions.NewExpression.Members" /> properties set to the specified values.</returns>
         /// <remarks>This method does not provide any guarantees with regards to argument validation or type checking.</remarks>
-        public NewExpression New(ConstructorInfo constructor, IEnumerable<Expression> arguments, MemberInfo[] members) => ExpressionUnsafe.New(constructor, arguments, members);
+        public virtual NewExpression New(ConstructorInfo constructor, IEnumerable<Expression> arguments, MemberInfo[] members) => ExpressionUnsafe.New(constructor, arguments, members);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.NewArrayExpression" /> that represents creating an array that has a specified rank.</summary>
         /// <param name="type">A <see cref="T:System.Type" /> that represents the element type of the array.</param>
         /// <param name="bounds">An array of <see cref="T:System.Linq.Expressions.Expression" /> objects to use to populate the <see cref="P:System.Linq.Expressions.NewArrayExpression.Expressions" /> collection.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.NewArrayExpression" /> that has the <see cref="P:System.Linq.Expressions.Expression.NodeType" /> property equal to <see cref="F:System.Linq.Expressions.ExpressionType.NewArrayBounds" /> and the <see cref="P:System.Linq.Expressions.NewArrayExpression.Expressions" /> property set to the specified value.</returns>
         /// <remarks>This method does not provide any guarantees with regards to argument validation or type checking.</remarks>
-        public NewArrayExpression NewArrayBounds(Type type, Expression[] bounds) => ExpressionUnsafe.NewArrayBounds(type, bounds);
+        public virtual NewArrayExpression NewArrayBounds(Type type, Expression[] bounds) => ExpressionUnsafe.NewArrayBounds(type, bounds);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.NewArrayExpression" /> that represents creating an array that has a specified rank.</summary>
         /// <param name="type">A <see cref="T:System.Type" /> that represents the element type of the array.</param>
         /// <param name="bounds">An <see cref="T:System.Collections.Generic.IEnumerable`1" /> that contains <see cref="T:System.Linq.Expressions.Expression" /> objects to use to populate the <see cref="P:System.Linq.Expressions.NewArrayExpression.Expressions" /> collection.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.NewArrayExpression" /> that has the <see cref="P:System.Linq.Expressions.Expression.NodeType" /> property equal to <see cref="F:System.Linq.Expressions.ExpressionType.NewArrayBounds" /> and the <see cref="P:System.Linq.Expressions.NewArrayExpression.Expressions" /> property set to the specified value.</returns>
         /// <remarks>This method does not provide any guarantees with regards to argument validation or type checking.</remarks>
-        public NewArrayExpression NewArrayBounds(Type type, IEnumerable<Expression> bounds) => ExpressionUnsafe.NewArrayBounds(type, bounds);
+        public virtual NewArrayExpression NewArrayBounds(Type type, IEnumerable<Expression> bounds) => ExpressionUnsafe.NewArrayBounds(type, bounds);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.NewArrayExpression" /> that represents creating a one-dimensional array and initializing it from a list of elements.</summary>
         /// <param name="type">A <see cref="T:System.Type" /> that represents the element type of the array.</param>
         /// <param name="initializers">An array of <see cref="T:System.Linq.Expressions.Expression" /> objects to use to populate the <see cref="P:System.Linq.Expressions.NewArrayExpression.Expressions" /> collection.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.NewArrayExpression" /> that has the <see cref="P:System.Linq.Expressions.Expression.NodeType" /> property equal to <see cref="F:System.Linq.Expressions.ExpressionType.NewArrayInit" /> and the <see cref="P:System.Linq.Expressions.NewArrayExpression.Expressions" /> property set to the specified value.</returns>
         /// <remarks>This method does not provide any guarantees with regards to argument validation or type checking.</remarks>
-        public NewArrayExpression NewArrayInit(Type type, Expression[] initializers) => ExpressionUnsafe.NewArrayInit(type, initializers);
+        public virtual NewArrayExpression NewArrayInit(Type type, Expression[] initializers) => ExpressionUnsafe.NewArrayInit(type, initializers);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.NewArrayExpression" /> that represents creating a one-dimensional array and initializing it from a list of elements.</summary>
         /// <param name="type">A <see cref="T:System.Type" /> that represents the element type of the array.</param>
         /// <param name="initializers">An <see cref="T:System.Collections.Generic.IEnumerable`1" /> that contains <see cref="T:System.Linq.Expressions.Expression" /> objects to use to populate the <see cref="P:System.Linq.Expressions.NewArrayExpression.Expressions" /> collection.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.NewArrayExpression" /> that has the <see cref="P:System.Linq.Expressions.Expression.NodeType" /> property equal to <see cref="F:System.Linq.Expressions.ExpressionType.NewArrayInit" /> and the <see cref="P:System.Linq.Expressions.NewArrayExpression.Expressions" /> property set to the specified value.</returns>
         /// <remarks>This method does not provide any guarantees with regards to argument validation or type checking.</remarks>
-        public NewArrayExpression NewArrayInit(Type type, IEnumerable<Expression> initializers) => ExpressionUnsafe.NewArrayInit(type, initializers);
+        public virtual NewArrayExpression NewArrayInit(Type type, IEnumerable<Expression> initializers) => ExpressionUnsafe.NewArrayInit(type, initializers);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.UnaryExpression" /> that represents a bitwise complement operation.</summary>
         /// <param name="expression">An <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.UnaryExpression.Operand" /> property equal to.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.UnaryExpression" /> that has the <see cref="P:System.Linq.Expressions.Expression.NodeType" /> property equal to <see cref="F:System.Linq.Expressions.ExpressionType.Not" /> and the <see cref="P:System.Linq.Expressions.UnaryExpression.Operand" /> property set to the specified value.</returns>
         /// <remarks>This method does not provide any guarantees with regards to argument validation or type checking.</remarks>
-        public UnaryExpression Not(Expression expression) => ExpressionUnsafe.Not(expression);
+        public virtual UnaryExpression Not(Expression expression) => ExpressionUnsafe.Not(expression);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.UnaryExpression" /> that represents a bitwise complement operation. The implementing method can be specified.</summary>
         /// <param name="expression">An <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.UnaryExpression.Operand" /> property equal to.</param>
         /// <param name="method">A <see cref="T:System.Reflection.MethodInfo" /> to set the <see cref="P:System.Linq.Expressions.UnaryExpression.Method" /> property equal to.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.UnaryExpression" /> that has the <see cref="P:System.Linq.Expressions.Expression.NodeType" /> property equal to <see cref="F:System.Linq.Expressions.ExpressionType.Not" /> and the <see cref="P:System.Linq.Expressions.UnaryExpression.Operand" /> and <see cref="P:System.Linq.Expressions.UnaryExpression.Method" /> properties set to the specified values.</returns>
         /// <remarks>This method does not provide any guarantees with regards to argument validation or type checking.</remarks>
-        public UnaryExpression Not(Expression expression, MethodInfo method) => ExpressionUnsafe.Not(expression, method);
+        public virtual UnaryExpression Not(Expression expression, MethodInfo method) => ExpressionUnsafe.Not(expression, method);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.BinaryExpression" /> that represents an inequality comparison.</summary>
         /// <param name="left">An <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Left" /> property equal to.</param>
         /// <param name="right">An <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Right" /> property equal to.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.BinaryExpression" /> that has the <see cref="P:System.Linq.Expressions.Expression.NodeType" /> property equal to <see cref="F:System.Linq.Expressions.ExpressionType.NotEqual" /> and the <see cref="P:System.Linq.Expressions.BinaryExpression.Left" /> and <see cref="P:System.Linq.Expressions.BinaryExpression.Right" /> properties set to the specified values.</returns>
         /// <remarks>This method does not provide any guarantees with regards to argument validation or type checking.</remarks>
-        public BinaryExpression NotEqual(Expression left, Expression right) => ExpressionUnsafe.NotEqual(left, right);
+        public virtual BinaryExpression NotEqual(Expression left, Expression right) => ExpressionUnsafe.NotEqual(left, right);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.BinaryExpression" /> that represents an inequality comparison.</summary>
         /// <param name="left">An <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Left" /> property equal to.</param>
@@ -1710,27 +1713,27 @@ namespace System.Linq.Expressions
         /// <param name="method">A <see cref="T:System.Reflection.MethodInfo" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Method" /> property equal to.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.BinaryExpression" /> that has the <see cref="P:System.Linq.Expressions.Expression.NodeType" /> property equal to <see cref="F:System.Linq.Expressions.ExpressionType.NotEqual" /> and the <see cref="P:System.Linq.Expressions.BinaryExpression.Left" />, <see cref="P:System.Linq.Expressions.BinaryExpression.Right" />, <see cref="P:System.Linq.Expressions.BinaryExpression.IsLiftedToNull" />, and <see cref="P:System.Linq.Expressions.BinaryExpression.Method" /> properties set to the specified values.</returns>
         /// <remarks>This method does not provide any guarantees with regards to argument validation or type checking.</remarks>
-        public BinaryExpression NotEqual(Expression left, Expression right, Boolean liftToNull, MethodInfo method) => ExpressionUnsafe.NotEqual(left, right, liftToNull, method);
+        public virtual BinaryExpression NotEqual(Expression left, Expression right, Boolean liftToNull, MethodInfo method) => ExpressionUnsafe.NotEqual(left, right, liftToNull, method);
 
         /// <summary>Returns the expression representing the ones complement.</summary>
         /// <param name="expression">An <see cref="T:System.Linq.Expressions.Expression" />.</param>
         /// <returns>An instance of <see cref="T:System.Linq.Expressions.UnaryExpression" />.</returns>
         /// <remarks>This method does not provide any guarantees with regards to argument validation or type checking.</remarks>
-        public UnaryExpression OnesComplement(Expression expression) => ExpressionUnsafe.OnesComplement(expression);
+        public virtual UnaryExpression OnesComplement(Expression expression) => ExpressionUnsafe.OnesComplement(expression);
 
         /// <summary>Returns the expression representing the ones complement.</summary>
         /// <param name="expression">An <see cref="T:System.Linq.Expressions.Expression" />.</param>
         /// <param name="method">A <see cref="T:System.Reflection.MethodInfo" /> that represents the implementing method.</param>
         /// <returns>An instance of <see cref="T:System.Linq.Expressions.UnaryExpression" />.</returns>
         /// <remarks>This method does not provide any guarantees with regards to argument validation or type checking.</remarks>
-        public UnaryExpression OnesComplement(Expression expression, MethodInfo method) => ExpressionUnsafe.OnesComplement(expression, method);
+        public virtual UnaryExpression OnesComplement(Expression expression, MethodInfo method) => ExpressionUnsafe.OnesComplement(expression, method);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.BinaryExpression" /> that represents a bitwise <see langword="OR" /> operation.</summary>
         /// <param name="left">An <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Left" /> property equal to.</param>
         /// <param name="right">An <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Right" /> property equal to.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.BinaryExpression" /> that has the <see cref="P:System.Linq.Expressions.Expression.NodeType" /> property equal to <see cref="F:System.Linq.Expressions.ExpressionType.Or" /> and the <see cref="P:System.Linq.Expressions.BinaryExpression.Left" /> and <see cref="P:System.Linq.Expressions.BinaryExpression.Right" /> properties set to the specified values.</returns>
         /// <remarks>This method does not provide any guarantees with regards to argument validation or type checking.</remarks>
-        public BinaryExpression Or(Expression left, Expression right) => ExpressionUnsafe.Or(left, right);
+        public virtual BinaryExpression Or(Expression left, Expression right) => ExpressionUnsafe.Or(left, right);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.BinaryExpression" /> that represents a bitwise <see langword="OR" /> operation.</summary>
         /// <param name="left">An <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Left" /> property equal to.</param>
@@ -1738,14 +1741,14 @@ namespace System.Linq.Expressions
         /// <param name="method">A <see cref="T:System.Reflection.MethodInfo" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Method" /> property equal to.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.BinaryExpression" /> that has the <see cref="P:System.Linq.Expressions.Expression.NodeType" /> property equal to <see cref="F:System.Linq.Expressions.ExpressionType.Or" /> and the <see cref="P:System.Linq.Expressions.BinaryExpression.Left" />, <see cref="P:System.Linq.Expressions.BinaryExpression.Right" />, and <see cref="P:System.Linq.Expressions.BinaryExpression.Method" /> properties set to the specified values.</returns>
         /// <remarks>This method does not provide any guarantees with regards to argument validation or type checking.</remarks>
-        public BinaryExpression Or(Expression left, Expression right, MethodInfo method) => ExpressionUnsafe.Or(left, right, method);
+        public virtual BinaryExpression Or(Expression left, Expression right, MethodInfo method) => ExpressionUnsafe.Or(left, right, method);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.BinaryExpression" /> that represents a bitwise OR assignment operation.</summary>
         /// <param name="left">An <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Left" /> property equal to.</param>
         /// <param name="right">An <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Right" /> property equal to.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.BinaryExpression" /> that has the <see cref="P:System.Linq.Expressions.Expression.NodeType" /> property equal to <see cref="F:System.Linq.Expressions.ExpressionType.OrAssign" /> and the <see cref="P:System.Linq.Expressions.BinaryExpression.Left" /> and <see cref="P:System.Linq.Expressions.BinaryExpression.Right" /> properties set to the specified values.</returns>
         /// <remarks>This method does not provide any guarantees with regards to argument validation or type checking.</remarks>
-        public BinaryExpression OrAssign(Expression left, Expression right) => ExpressionUnsafe.OrAssign(left, right);
+        public virtual BinaryExpression OrAssign(Expression left, Expression right) => ExpressionUnsafe.OrAssign(left, right);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.BinaryExpression" /> that represents a bitwise OR assignment operation.</summary>
         /// <param name="left">An <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Left" /> property equal to.</param>
@@ -1753,7 +1756,7 @@ namespace System.Linq.Expressions
         /// <param name="method">A <see cref="T:System.Reflection.MethodInfo" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Method" /> property equal to.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.BinaryExpression" /> that has the <see cref="P:System.Linq.Expressions.Expression.NodeType" /> property equal to <see cref="F:System.Linq.Expressions.ExpressionType.OrAssign" /> and the <see cref="P:System.Linq.Expressions.BinaryExpression.Left" />, <see cref="P:System.Linq.Expressions.BinaryExpression.Right" />, and <see cref="P:System.Linq.Expressions.BinaryExpression.Method" /> properties set to the specified values.</returns>
         /// <remarks>This method does not provide any guarantees with regards to argument validation or type checking.</remarks>
-        public BinaryExpression OrAssign(Expression left, Expression right, MethodInfo method) => ExpressionUnsafe.OrAssign(left, right, method);
+        public virtual BinaryExpression OrAssign(Expression left, Expression right, MethodInfo method) => ExpressionUnsafe.OrAssign(left, right, method);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.BinaryExpression" /> that represents a bitwise OR assignment operation.</summary>
         /// <param name="left">An <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Left" /> property equal to.</param>
@@ -1762,14 +1765,14 @@ namespace System.Linq.Expressions
         /// <param name="conversion">A <see cref="T:System.Linq.Expressions.LambdaExpression" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Conversion" /> property equal to.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.BinaryExpression" /> that has the <see cref="P:System.Linq.Expressions.Expression.NodeType" /> property equal to <see cref="F:System.Linq.Expressions.ExpressionType.OrAssign" /> and the <see cref="P:System.Linq.Expressions.BinaryExpression.Left" />, <see cref="P:System.Linq.Expressions.BinaryExpression.Right" />, <see cref="P:System.Linq.Expressions.BinaryExpression.Method" />, and <see cref="P:System.Linq.Expressions.BinaryExpression.Conversion" /> properties set to the specified values.</returns>
         /// <remarks>This method does not provide any guarantees with regards to argument validation or type checking.</remarks>
-        public BinaryExpression OrAssign(Expression left, Expression right, MethodInfo method, LambdaExpression conversion) => ExpressionUnsafe.OrAssign(left, right, method, conversion);
+        public virtual BinaryExpression OrAssign(Expression left, Expression right, MethodInfo method, LambdaExpression conversion) => ExpressionUnsafe.OrAssign(left, right, method, conversion);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.BinaryExpression" /> that represents a conditional <see langword="OR" /> operation that evaluates the second operand only if the first operand evaluates to <see langword="false" />.</summary>
         /// <param name="left">An <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Left" /> property equal to.</param>
         /// <param name="right">An <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Right" /> property equal to.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.BinaryExpression" /> that has the <see cref="P:System.Linq.Expressions.Expression.NodeType" /> property equal to <see cref="F:System.Linq.Expressions.ExpressionType.OrElse" /> and the <see cref="P:System.Linq.Expressions.BinaryExpression.Left" /> and <see cref="P:System.Linq.Expressions.BinaryExpression.Right" /> properties set to the specified values.</returns>
         /// <remarks>This method does not provide any guarantees with regards to argument validation or type checking.</remarks>
-        public BinaryExpression OrElse(Expression left, Expression right) => ExpressionUnsafe.OrElse(left, right);
+        public virtual BinaryExpression OrElse(Expression left, Expression right) => ExpressionUnsafe.OrElse(left, right);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.BinaryExpression" /> that represents a conditional <see langword="OR" /> operation that evaluates the second operand only if the first operand evaluates to <see langword="false" />.</summary>
         /// <param name="left">An <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Left" /> property equal to.</param>
@@ -1777,53 +1780,53 @@ namespace System.Linq.Expressions
         /// <param name="method">A <see cref="T:System.Reflection.MethodInfo" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Method" /> property equal to.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.BinaryExpression" /> that has the <see cref="P:System.Linq.Expressions.Expression.NodeType" /> property equal to <see cref="F:System.Linq.Expressions.ExpressionType.OrElse" /> and the <see cref="P:System.Linq.Expressions.BinaryExpression.Left" />, <see cref="P:System.Linq.Expressions.BinaryExpression.Right" />, and <see cref="P:System.Linq.Expressions.BinaryExpression.Method" /> properties set to the specified values.</returns>
         /// <remarks>This method does not provide any guarantees with regards to argument validation or type checking.</remarks>
-        public BinaryExpression OrElse(Expression left, Expression right, MethodInfo method) => ExpressionUnsafe.OrElse(left, right, method);
+        public virtual BinaryExpression OrElse(Expression left, Expression right, MethodInfo method) => ExpressionUnsafe.OrElse(left, right, method);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.ParameterExpression" /> node that can be used to identify a parameter or a variable in an expression tree.</summary>
         /// <param name="type">The type of the parameter or variable.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.ParameterExpression" /> node with the specified name and type.</returns>
         /// <remarks>This method does not provide any guarantees with regards to argument validation or type checking.</remarks>
-        public ParameterExpression Parameter(Type type) => ExpressionUnsafe.Parameter(type);
+        public virtual ParameterExpression Parameter(Type type) => ExpressionUnsafe.Parameter(type);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.ParameterExpression" /> node that can be used to identify a parameter or a variable in an expression tree.</summary>
         /// <param name="type">The type of the parameter or variable.</param>
         /// <param name="name">The name of the parameter or variable, used for debugging or printing purpose only.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.ParameterExpression" /> that has the <see cref="P:System.Linq.Expressions.Expression.NodeType" /> property equal to <see cref="F:System.Linq.Expressions.ExpressionType.Parameter" /> and the <see cref="P:System.Linq.Expressions.Expression.Type" /> and <see cref="P:System.Linq.Expressions.ParameterExpression.Name" /> properties set to the specified values.</returns>
         /// <remarks>This method does not provide any guarantees with regards to argument validation or type checking.</remarks>
-        public ParameterExpression Parameter(Type type, String name) => ExpressionUnsafe.Parameter(type, name);
+        public virtual ParameterExpression Parameter(Type type, String name) => ExpressionUnsafe.Parameter(type, name);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.UnaryExpression" /> that represents the assignment of the expression followed by a subsequent decrement by 1 of the original expression.</summary>
         /// <param name="expression">An <see cref="T:System.Linq.Expressions.Expression" /> to apply the operations on.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.UnaryExpression" /> that represents the resultant expression.</returns>
         /// <remarks>This method does not provide any guarantees with regards to argument validation or type checking.</remarks>
-        public UnaryExpression PostDecrementAssign(Expression expression) => ExpressionUnsafe.PostDecrementAssign(expression);
+        public virtual UnaryExpression PostDecrementAssign(Expression expression) => ExpressionUnsafe.PostDecrementAssign(expression);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.UnaryExpression" /> that represents the assignment of the expression followed by a subsequent decrement by 1 of the original expression.</summary>
         /// <param name="expression">An <see cref="T:System.Linq.Expressions.Expression" /> to apply the operations on.</param>
         /// <param name="method">A <see cref="T:System.Reflection.MethodInfo" /> that represents the implementing method.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.UnaryExpression" /> that represents the resultant expression.</returns>
         /// <remarks>This method does not provide any guarantees with regards to argument validation or type checking.</remarks>
-        public UnaryExpression PostDecrementAssign(Expression expression, MethodInfo method) => ExpressionUnsafe.PostDecrementAssign(expression, method);
+        public virtual UnaryExpression PostDecrementAssign(Expression expression, MethodInfo method) => ExpressionUnsafe.PostDecrementAssign(expression, method);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.UnaryExpression" /> that represents the assignment of the expression followed by a subsequent increment by 1 of the original expression.</summary>
         /// <param name="expression">An <see cref="T:System.Linq.Expressions.Expression" /> to apply the operations on.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.UnaryExpression" /> that represents the resultant expression.</returns>
         /// <remarks>This method does not provide any guarantees with regards to argument validation or type checking.</remarks>
-        public UnaryExpression PostIncrementAssign(Expression expression) => ExpressionUnsafe.PostIncrementAssign(expression);
+        public virtual UnaryExpression PostIncrementAssign(Expression expression) => ExpressionUnsafe.PostIncrementAssign(expression);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.UnaryExpression" /> that represents the assignment of the expression followed by a subsequent increment by 1 of the original expression.</summary>
         /// <param name="expression">An <see cref="T:System.Linq.Expressions.Expression" /> to apply the operations on.</param>
         /// <param name="method">A <see cref="T:System.Reflection.MethodInfo" /> that represents the implementing method.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.UnaryExpression" /> that represents the resultant expression.</returns>
         /// <remarks>This method does not provide any guarantees with regards to argument validation or type checking.</remarks>
-        public UnaryExpression PostIncrementAssign(Expression expression, MethodInfo method) => ExpressionUnsafe.PostIncrementAssign(expression, method);
+        public virtual UnaryExpression PostIncrementAssign(Expression expression, MethodInfo method) => ExpressionUnsafe.PostIncrementAssign(expression, method);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.BinaryExpression" /> that represents raising a number to a power.</summary>
         /// <param name="left">An <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Left" /> property equal to.</param>
         /// <param name="right">An <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Right" /> property equal to.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.BinaryExpression" /> that has the <see cref="P:System.Linq.Expressions.Expression.NodeType" /> property equal to <see cref="F:System.Linq.Expressions.ExpressionType.Power" /> and the <see cref="P:System.Linq.Expressions.BinaryExpression.Left" /> and <see cref="P:System.Linq.Expressions.BinaryExpression.Right" /> properties set to the specified values.</returns>
         /// <remarks>This method does not provide any guarantees with regards to argument validation or type checking.</remarks>
-        public BinaryExpression Power(Expression left, Expression right) => ExpressionUnsafe.Power(left, right);
+        public virtual BinaryExpression Power(Expression left, Expression right) => ExpressionUnsafe.Power(left, right);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.BinaryExpression" /> that represents raising a number to a power.</summary>
         /// <param name="left">An <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Left" /> property equal to.</param>
@@ -1831,14 +1834,14 @@ namespace System.Linq.Expressions
         /// <param name="method">A <see cref="T:System.Reflection.MethodInfo" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Method" /> property equal to.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.BinaryExpression" /> that has the <see cref="P:System.Linq.Expressions.Expression.NodeType" /> property equal to <see cref="F:System.Linq.Expressions.ExpressionType.Power" /> and the <see cref="P:System.Linq.Expressions.BinaryExpression.Left" />, <see cref="P:System.Linq.Expressions.BinaryExpression.Right" />, and <see cref="P:System.Linq.Expressions.BinaryExpression.Method" /> properties set to the specified values.</returns>
         /// <remarks>This method does not provide any guarantees with regards to argument validation or type checking.</remarks>
-        public BinaryExpression Power(Expression left, Expression right, MethodInfo method) => ExpressionUnsafe.Power(left, right, method);
+        public virtual BinaryExpression Power(Expression left, Expression right, MethodInfo method) => ExpressionUnsafe.Power(left, right, method);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.BinaryExpression" /> that represents raising an expression to a power and assigning the result back to the expression.</summary>
         /// <param name="left">An <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Left" /> property equal to.</param>
         /// <param name="right">An <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Right" /> property equal to.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.BinaryExpression" /> that has the <see cref="P:System.Linq.Expressions.Expression.NodeType" /> property equal to <see cref="F:System.Linq.Expressions.ExpressionType.PowerAssign" /> and the <see cref="P:System.Linq.Expressions.BinaryExpression.Left" /> and <see cref="P:System.Linq.Expressions.BinaryExpression.Right" /> properties set to the specified values.</returns>
         /// <remarks>This method does not provide any guarantees with regards to argument validation or type checking.</remarks>
-        public BinaryExpression PowerAssign(Expression left, Expression right) => ExpressionUnsafe.PowerAssign(left, right);
+        public virtual BinaryExpression PowerAssign(Expression left, Expression right) => ExpressionUnsafe.PowerAssign(left, right);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.BinaryExpression" /> that represents raising an expression to a power and assigning the result back to the expression.</summary>
         /// <param name="left">An <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Left" /> property equal to.</param>
@@ -1846,7 +1849,7 @@ namespace System.Linq.Expressions
         /// <param name="method">A <see cref="T:System.Reflection.MethodInfo" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Method" /> property equal to.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.BinaryExpression" /> that has the <see cref="P:System.Linq.Expressions.Expression.NodeType" /> property equal to <see cref="F:System.Linq.Expressions.ExpressionType.PowerAssign" /> and the <see cref="P:System.Linq.Expressions.BinaryExpression.Left" />, <see cref="P:System.Linq.Expressions.BinaryExpression.Right" />, and <see cref="P:System.Linq.Expressions.BinaryExpression.Method" /> properties set to the specified values.</returns>
         /// <remarks>This method does not provide any guarantees with regards to argument validation or type checking.</remarks>
-        public BinaryExpression PowerAssign(Expression left, Expression right, MethodInfo method) => ExpressionUnsafe.PowerAssign(left, right, method);
+        public virtual BinaryExpression PowerAssign(Expression left, Expression right, MethodInfo method) => ExpressionUnsafe.PowerAssign(left, right, method);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.BinaryExpression" /> that represents raising an expression to a power and assigning the result back to the expression.</summary>
         /// <param name="left">An <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Left" /> property equal to.</param>
@@ -1855,54 +1858,54 @@ namespace System.Linq.Expressions
         /// <param name="conversion">A <see cref="T:System.Linq.Expressions.LambdaExpression" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Conversion" /> property equal to.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.BinaryExpression" /> that has the <see cref="P:System.Linq.Expressions.Expression.NodeType" /> property equal to <see cref="F:System.Linq.Expressions.ExpressionType.PowerAssign" /> and the <see cref="P:System.Linq.Expressions.BinaryExpression.Left" />, <see cref="P:System.Linq.Expressions.BinaryExpression.Right" />, <see cref="P:System.Linq.Expressions.BinaryExpression.Method" />, and <see cref="P:System.Linq.Expressions.BinaryExpression.Conversion" /> properties set to the specified values.</returns>
         /// <remarks>This method does not provide any guarantees with regards to argument validation or type checking.</remarks>
-        public BinaryExpression PowerAssign(Expression left, Expression right, MethodInfo method, LambdaExpression conversion) => ExpressionUnsafe.PowerAssign(left, right, method, conversion);
+        public virtual BinaryExpression PowerAssign(Expression left, Expression right, MethodInfo method, LambdaExpression conversion) => ExpressionUnsafe.PowerAssign(left, right, method, conversion);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.UnaryExpression" /> that decrements the expression by 1 and assigns the result back to the expression.</summary>
         /// <param name="expression">An <see cref="T:System.Linq.Expressions.Expression" /> to apply the operations on.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.UnaryExpression" /> that represents the resultant expression.</returns>
         /// <remarks>This method does not provide any guarantees with regards to argument validation or type checking.</remarks>
-        public UnaryExpression PreDecrementAssign(Expression expression) => ExpressionUnsafe.PreDecrementAssign(expression);
+        public virtual UnaryExpression PreDecrementAssign(Expression expression) => ExpressionUnsafe.PreDecrementAssign(expression);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.UnaryExpression" /> that decrements the expression by 1 and assigns the result back to the expression.</summary>
         /// <param name="expression">An <see cref="T:System.Linq.Expressions.Expression" /> to apply the operations on.</param>
         /// <param name="method">A <see cref="T:System.Reflection.MethodInfo" /> that represents the implementing method.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.UnaryExpression" /> that represents the resultant expression.</returns>
         /// <remarks>This method does not provide any guarantees with regards to argument validation or type checking.</remarks>
-        public UnaryExpression PreDecrementAssign(Expression expression, MethodInfo method) => ExpressionUnsafe.PreDecrementAssign(expression, method);
+        public virtual UnaryExpression PreDecrementAssign(Expression expression, MethodInfo method) => ExpressionUnsafe.PreDecrementAssign(expression, method);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.UnaryExpression" /> that increments the expression by 1 and assigns the result back to the expression.</summary>
         /// <param name="expression">An <see cref="T:System.Linq.Expressions.Expression" /> to apply the operations on.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.UnaryExpression" /> that represents the resultant expression.</returns>
         /// <remarks>This method does not provide any guarantees with regards to argument validation or type checking.</remarks>
-        public UnaryExpression PreIncrementAssign(Expression expression) => ExpressionUnsafe.PreIncrementAssign(expression);
+        public virtual UnaryExpression PreIncrementAssign(Expression expression) => ExpressionUnsafe.PreIncrementAssign(expression);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.UnaryExpression" /> that increments the expression by 1 and assigns the result back to the expression.</summary>
         /// <param name="expression">An <see cref="T:System.Linq.Expressions.Expression" /> to apply the operations on.</param>
         /// <param name="method">A <see cref="T:System.Reflection.MethodInfo" /> that represents the implementing method.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.UnaryExpression" /> that represents the resultant expression.</returns>
         /// <remarks>This method does not provide any guarantees with regards to argument validation or type checking.</remarks>
-        public UnaryExpression PreIncrementAssign(Expression expression, MethodInfo method) => ExpressionUnsafe.PreIncrementAssign(expression, method);
+        public virtual UnaryExpression PreIncrementAssign(Expression expression, MethodInfo method) => ExpressionUnsafe.PreIncrementAssign(expression, method);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.MemberExpression" /> that represents accessing a property.</summary>
         /// <param name="expression">An <see cref="T:System.Linq.Expressions.Expression" /> whose <see cref="P:System.Linq.Expressions.Expression.Type" /> contains a property named <paramref name="propertyName" />. This can be <see langword="null" /> for static properties.</param>
         /// <param name="propertyName">The name of a property to be accessed.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.MemberExpression" /> that has the <see cref="P:System.Linq.Expressions.Expression.NodeType" /> property equal to <see cref="F:System.Linq.Expressions.ExpressionType.MemberAccess" />, the <see cref="P:System.Linq.Expressions.MemberExpression.Expression" /> property set to <paramref name="expression" />, and the <see cref="P:System.Linq.Expressions.MemberExpression.Member" /> property set to the <see cref="T:System.Reflection.PropertyInfo" /> that represents the property denoted by <paramref name="propertyName" />.</returns>
         /// <remarks>This method does not provide any guarantees with regards to argument validation or type checking.</remarks>
-        public MemberExpression Property(Expression expression, String propertyName) => ExpressionUnsafe.Property(expression, propertyName);
+        public virtual MemberExpression Property(Expression expression, String propertyName) => ExpressionUnsafe.Property(expression, propertyName);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.MemberExpression" /> that represents accessing a property.</summary>
         /// <param name="expression">An <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.MemberExpression.Expression" /> property equal to. This can be null for static properties.</param>
         /// <param name="property">The <see cref="T:System.Reflection.PropertyInfo" /> to set the <see cref="P:System.Linq.Expressions.MemberExpression.Member" /> property equal to.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.MemberExpression" /> that has the <see cref="P:System.Linq.Expressions.Expression.NodeType" /> property equal to <see cref="F:System.Linq.Expressions.ExpressionType.MemberAccess" /> and the <see cref="P:System.Linq.Expressions.MemberExpression.Expression" /> and <see cref="P:System.Linq.Expressions.MemberExpression.Member" /> properties set to the specified values.</returns>
         /// <remarks>This method does not provide any guarantees with regards to argument validation or type checking.</remarks>
-        public MemberExpression Property(Expression expression, PropertyInfo property) => ExpressionUnsafe.Property(expression, property);
+        public virtual MemberExpression Property(Expression expression, PropertyInfo property) => ExpressionUnsafe.Property(expression, property);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.MemberExpression" /> that represents accessing a property by using a property accessor method.</summary>
         /// <param name="expression">An <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.MemberExpression.Expression" /> property equal to. This can be null for static properties.</param>
         /// <param name="propertyAccessor">The <see cref="T:System.Reflection.MethodInfo" /> that represents a property accessor method.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.MemberExpression" /> that has the <see cref="P:System.Linq.Expressions.Expression.NodeType" /> property equal to <see cref="F:System.Linq.Expressions.ExpressionType.MemberAccess" />, the <see cref="P:System.Linq.Expressions.MemberExpression.Expression" /> property set to <paramref name="expression" /> and the <see cref="P:System.Linq.Expressions.MemberExpression.Member" /> property set to the <see cref="T:System.Reflection.PropertyInfo" /> that represents the property accessed in <paramref name="propertyAccessor" />.</returns>
         /// <remarks>This method does not provide any guarantees with regards to argument validation or type checking.</remarks>
-        public MemberExpression Property(Expression expression, MethodInfo propertyAccessor) => ExpressionUnsafe.Property(expression, propertyAccessor);
+        public virtual MemberExpression Property(Expression expression, MethodInfo propertyAccessor) => ExpressionUnsafe.Property(expression, propertyAccessor);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.MemberExpression" /> accessing a property.</summary>
         /// <param name="expression">The containing object of the property. This can be null for static properties.</param>
@@ -1910,7 +1913,7 @@ namespace System.Linq.Expressions
         /// <param name="propertyName">The property to be accessed.</param>
         /// <returns>The created <see cref="T:System.Linq.Expressions.MemberExpression" />.</returns>
         /// <remarks>This method does not provide any guarantees with regards to argument validation or type checking.</remarks>
-        public MemberExpression Property(Expression expression, Type type, String propertyName) => ExpressionUnsafe.Property(expression, type, propertyName);
+        public virtual MemberExpression Property(Expression expression, Type type, String propertyName) => ExpressionUnsafe.Property(expression, type, propertyName);
 
         /// <summary>Creates an <see cref="T:System.Linq.Expressions.IndexExpression" /> representing the access to an indexed property.</summary>
         /// <param name="instance">The object to which the property belongs. If the property is static/shared, it must be null.</param>
@@ -1918,7 +1921,7 @@ namespace System.Linq.Expressions
         /// <param name="arguments">An array of <see cref="T:System.Linq.Expressions.Expression" /> objects that are used to index the property.</param>
         /// <returns>The created <see cref="T:System.Linq.Expressions.IndexExpression" />.</returns>
         /// <remarks>This method does not provide any guarantees with regards to argument validation or type checking.</remarks>
-        public IndexExpression Property(Expression instance, String propertyName, Expression[] arguments) => ExpressionUnsafe.Property(instance, propertyName, arguments);
+        public virtual IndexExpression Property(Expression instance, String propertyName, Expression[] arguments) => ExpressionUnsafe.Property(instance, propertyName, arguments);
 
         /// <summary>Creates an <see cref="T:System.Linq.Expressions.IndexExpression" /> representing the access to an indexed property.</summary>
         /// <param name="instance">The object to which the property belongs. If the property is static/shared, it must be null.</param>
@@ -1926,7 +1929,7 @@ namespace System.Linq.Expressions
         /// <param name="arguments">An array of <see cref="T:System.Linq.Expressions.Expression" /> objects that are used to index the property.</param>
         /// <returns>The created <see cref="T:System.Linq.Expressions.IndexExpression" />.</returns>
         /// <remarks>This method does not provide any guarantees with regards to argument validation or type checking.</remarks>
-        public IndexExpression Property(Expression instance, PropertyInfo indexer, Expression[] arguments) => ExpressionUnsafe.Property(instance, indexer, arguments);
+        public virtual IndexExpression Property(Expression instance, PropertyInfo indexer, Expression[] arguments) => ExpressionUnsafe.Property(instance, indexer, arguments);
 
         /// <summary>Creates an <see cref="T:System.Linq.Expressions.IndexExpression" /> representing the access to an indexed property.</summary>
         /// <param name="instance">The object to which the property belongs. If the property is static/shared, it must be null.</param>
@@ -1934,65 +1937,65 @@ namespace System.Linq.Expressions
         /// <param name="arguments">An <see cref="T:System.Collections.Generic.IEnumerable`1" /> of <see cref="T:System.Linq.Expressions.Expression" /> objects that are used to index the property.</param>
         /// <returns>The created <see cref="T:System.Linq.Expressions.IndexExpression" />.</returns>
         /// <remarks>This method does not provide any guarantees with regards to argument validation or type checking.</remarks>
-        public IndexExpression Property(Expression instance, PropertyInfo indexer, IEnumerable<Expression> arguments) => ExpressionUnsafe.Property(instance, indexer, arguments);
+        public virtual IndexExpression Property(Expression instance, PropertyInfo indexer, IEnumerable<Expression> arguments) => ExpressionUnsafe.Property(instance, indexer, arguments);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.MemberExpression" /> that represents accessing a property or field.</summary>
         /// <param name="expression">An <see cref="T:System.Linq.Expressions.Expression" /> whose <see cref="P:System.Linq.Expressions.Expression.Type" /> contains a property or field named <paramref name="propertyOrFieldName" />. This can be null for static members.</param>
         /// <param name="propertyOrFieldName">The name of a property or field to be accessed.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.MemberExpression" /> that has the <see cref="P:System.Linq.Expressions.Expression.NodeType" /> property equal to <see cref="F:System.Linq.Expressions.ExpressionType.MemberAccess" />, the <see cref="P:System.Linq.Expressions.MemberExpression.Expression" /> property set to <paramref name="expression" />, and the <see cref="P:System.Linq.Expressions.MemberExpression.Member" /> property set to the <see cref="T:System.Reflection.PropertyInfo" /> or <see cref="T:System.Reflection.FieldInfo" /> that represents the property or field denoted by <paramref name="propertyOrFieldName" />.</returns>
         /// <remarks>This method does not provide any guarantees with regards to argument validation or type checking.</remarks>
-        public MemberExpression PropertyOrField(Expression expression, String propertyOrFieldName) => ExpressionUnsafe.PropertyOrField(expression, propertyOrFieldName);
+        public virtual MemberExpression PropertyOrField(Expression expression, String propertyOrFieldName) => ExpressionUnsafe.PropertyOrField(expression, propertyOrFieldName);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.UnaryExpression" /> that represents an expression that has a constant value of type <see cref="T:System.Linq.Expressions.Expression" />.</summary>
         /// <param name="expression">An <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.UnaryExpression.Operand" /> property equal to.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.UnaryExpression" /> that has the <see cref="P:System.Linq.Expressions.Expression.NodeType" /> property equal to <see cref="F:System.Linq.Expressions.ExpressionType.Quote" /> and the <see cref="P:System.Linq.Expressions.UnaryExpression.Operand" /> property set to the specified value.</returns>
         /// <remarks>This method does not provide any guarantees with regards to argument validation or type checking.</remarks>
-        public UnaryExpression Quote(Expression expression) => ExpressionUnsafe.Quote(expression);
+        public virtual UnaryExpression Quote(Expression expression) => ExpressionUnsafe.Quote(expression);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.BinaryExpression" /> that represents a reference equality comparison.</summary>
         /// <param name="left">An <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Left" /> property equal to.</param>
         /// <param name="right">An <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Right" /> property equal to.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.BinaryExpression" /> that has the <see cref="P:System.Linq.Expressions.Expression.NodeType" /> property equal to <see cref="F:System.Linq.Expressions.ExpressionType.Equal" /> and the <see cref="P:System.Linq.Expressions.BinaryExpression.Left" /> and <see cref="P:System.Linq.Expressions.BinaryExpression.Right" /> properties set to the specified values.</returns>
         /// <remarks>This method does not provide any guarantees with regards to argument validation or type checking.</remarks>
-        public BinaryExpression ReferenceEqual(Expression left, Expression right) => ExpressionUnsafe.ReferenceEqual(left, right);
+        public virtual BinaryExpression ReferenceEqual(Expression left, Expression right) => ExpressionUnsafe.ReferenceEqual(left, right);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.BinaryExpression" /> that represents a reference inequality comparison.</summary>
         /// <param name="left">An <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Left" /> property equal to.</param>
         /// <param name="right">An <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Right" /> property equal to.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.BinaryExpression" /> that has the <see cref="P:System.Linq.Expressions.Expression.NodeType" /> property equal to <see cref="F:System.Linq.Expressions.ExpressionType.NotEqual" /> and the <see cref="P:System.Linq.Expressions.BinaryExpression.Left" /> and <see cref="P:System.Linq.Expressions.BinaryExpression.Right" /> properties set to the specified values.</returns>
         /// <remarks>This method does not provide any guarantees with regards to argument validation or type checking.</remarks>
-        public BinaryExpression ReferenceNotEqual(Expression left, Expression right) => ExpressionUnsafe.ReferenceNotEqual(left, right);
+        public virtual BinaryExpression ReferenceNotEqual(Expression left, Expression right) => ExpressionUnsafe.ReferenceNotEqual(left, right);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.UnaryExpression" /> that represents a rethrowing of an exception.</summary>
         /// <returns>A <see cref="T:System.Linq.Expressions.UnaryExpression" /> that represents a rethrowing of an exception.</returns>
         /// <remarks>This method does not provide any guarantees with regards to argument validation or type checking.</remarks>
-        public UnaryExpression Rethrow() => ExpressionUnsafe.Rethrow();
+        public virtual UnaryExpression Rethrow() => ExpressionUnsafe.Rethrow();
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.UnaryExpression" /> that represents a rethrowing of an exception with a given type.</summary>
         /// <param name="type">The new <see cref="T:System.Type" /> of the expression.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.UnaryExpression" /> that represents a rethrowing of an exception.</returns>
         /// <remarks>This method does not provide any guarantees with regards to argument validation or type checking.</remarks>
-        public UnaryExpression Rethrow(Type type) => ExpressionUnsafe.Rethrow(type);
+        public virtual UnaryExpression Rethrow(Type type) => ExpressionUnsafe.Rethrow(type);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.GotoExpression" /> representing a return statement.</summary>
         /// <param name="target">The <see cref="T:System.Linq.Expressions.LabelTarget" /> that the <see cref="T:System.Linq.Expressions.GotoExpression" /> will jump to.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.GotoExpression" /> with <see cref="P:System.Linq.Expressions.GotoExpression.Kind" /> equal to Return, the <see cref="P:System.Linq.Expressions.GotoExpression.Target" /> property set to <paramref name="target" />, and a null value to be passed to the target label upon jumping.</returns>
         /// <remarks>This method does not provide any guarantees with regards to argument validation or type checking.</remarks>
-        public GotoExpression Return(LabelTarget target) => ExpressionUnsafe.Return(target);
+        public virtual GotoExpression Return(LabelTarget target) => ExpressionUnsafe.Return(target);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.GotoExpression" /> representing a return statement with the specified type.</summary>
         /// <param name="target">The <see cref="T:System.Linq.Expressions.LabelTarget" /> that the <see cref="T:System.Linq.Expressions.GotoExpression" /> will jump to.</param>
         /// <param name="type">An <see cref="T:System.Type" /> to set the <see cref="P:System.Linq.Expressions.Expression.Type" /> property equal to.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.GotoExpression" /> with <see cref="P:System.Linq.Expressions.GotoExpression.Kind" /> equal to Return, the <see cref="P:System.Linq.Expressions.GotoExpression.Target" /> property set to <paramref name="target" />, the <see cref="P:System.Linq.Expressions.Expression.Type" /> property set to <paramref name="type" />, and a null value to be passed to the target label upon jumping.</returns>
         /// <remarks>This method does not provide any guarantees with regards to argument validation or type checking.</remarks>
-        public GotoExpression Return(LabelTarget target, Type type) => ExpressionUnsafe.Return(target, type);
+        public virtual GotoExpression Return(LabelTarget target, Type type) => ExpressionUnsafe.Return(target, type);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.GotoExpression" /> representing a return statement. The value passed to the label upon jumping can be specified.</summary>
         /// <param name="target">The <see cref="T:System.Linq.Expressions.LabelTarget" /> that the <see cref="T:System.Linq.Expressions.GotoExpression" /> will jump to.</param>
         /// <param name="value">The value that will be passed to the associated label upon jumping.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.GotoExpression" /> with <see cref="P:System.Linq.Expressions.GotoExpression.Kind" /> equal to Continue, the <see cref="P:System.Linq.Expressions.GotoExpression.Target" /> property set to <paramref name="target" />, and <paramref name="value" /> to be passed to the target label upon jumping.</returns>
         /// <remarks>This method does not provide any guarantees with regards to argument validation or type checking.</remarks>
-        public GotoExpression Return(LabelTarget target, Expression value) => ExpressionUnsafe.Return(target, value);
+        public virtual GotoExpression Return(LabelTarget target, Expression value) => ExpressionUnsafe.Return(target, value);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.GotoExpression" /> representing a return statement with the specified type. The value passed to the label upon jumping can be specified.</summary>
         /// <param name="target">The <see cref="T:System.Linq.Expressions.LabelTarget" /> that the <see cref="T:System.Linq.Expressions.GotoExpression" /> will jump to.</param>
@@ -2000,14 +2003,14 @@ namespace System.Linq.Expressions
         /// <param name="type">An <see cref="T:System.Type" /> to set the <see cref="P:System.Linq.Expressions.Expression.Type" /> property equal to.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.GotoExpression" /> with <see cref="P:System.Linq.Expressions.GotoExpression.Kind" /> equal to Continue, the <see cref="P:System.Linq.Expressions.GotoExpression.Target" /> property set to <paramref name="target" />, the <see cref="P:System.Linq.Expressions.Expression.Type" /> property set to <paramref name="type" />, and <paramref name="value" /> to be passed to the target label upon jumping.</returns>
         /// <remarks>This method does not provide any guarantees with regards to argument validation or type checking.</remarks>
-        public GotoExpression Return(LabelTarget target, Expression value, Type type) => ExpressionUnsafe.Return(target, value, type);
+        public virtual GotoExpression Return(LabelTarget target, Expression value, Type type) => ExpressionUnsafe.Return(target, value, type);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.BinaryExpression" /> that represents a bitwise right-shift operation.</summary>
         /// <param name="left">An <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Left" /> property equal to.</param>
         /// <param name="right">An <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Right" /> property equal to.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.BinaryExpression" /> that has the <see cref="P:System.Linq.Expressions.Expression.NodeType" /> property equal to <see cref="F:System.Linq.Expressions.ExpressionType.RightShift" /> and the <see cref="P:System.Linq.Expressions.BinaryExpression.Left" /> and <see cref="P:System.Linq.Expressions.BinaryExpression.Right" /> properties set to the specified values.</returns>
         /// <remarks>This method does not provide any guarantees with regards to argument validation or type checking.</remarks>
-        public BinaryExpression RightShift(Expression left, Expression right) => ExpressionUnsafe.RightShift(left, right);
+        public virtual BinaryExpression RightShift(Expression left, Expression right) => ExpressionUnsafe.RightShift(left, right);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.BinaryExpression" /> that represents a bitwise right-shift operation.</summary>
         /// <param name="left">An <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Left" /> property equal to.</param>
@@ -2015,14 +2018,14 @@ namespace System.Linq.Expressions
         /// <param name="method">A <see cref="T:System.Reflection.MethodInfo" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Method" /> property equal to.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.BinaryExpression" /> that has the <see cref="P:System.Linq.Expressions.Expression.NodeType" /> property equal to <see cref="F:System.Linq.Expressions.ExpressionType.RightShift" /> and the <see cref="P:System.Linq.Expressions.BinaryExpression.Left" />, <see cref="P:System.Linq.Expressions.BinaryExpression.Right" />, and <see cref="P:System.Linq.Expressions.BinaryExpression.Method" /> properties set to the specified values.</returns>
         /// <remarks>This method does not provide any guarantees with regards to argument validation or type checking.</remarks>
-        public BinaryExpression RightShift(Expression left, Expression right, MethodInfo method) => ExpressionUnsafe.RightShift(left, right, method);
+        public virtual BinaryExpression RightShift(Expression left, Expression right, MethodInfo method) => ExpressionUnsafe.RightShift(left, right, method);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.BinaryExpression" /> that represents a bitwise right-shift assignment operation.</summary>
         /// <param name="left">An <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Left" /> property equal to.</param>
         /// <param name="right">An <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Right" /> property equal to.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.BinaryExpression" /> that has the <see cref="P:System.Linq.Expressions.Expression.NodeType" /> property equal to <see cref="F:System.Linq.Expressions.ExpressionType.RightShiftAssign" /> and the <see cref="P:System.Linq.Expressions.BinaryExpression.Left" /> and <see cref="P:System.Linq.Expressions.BinaryExpression.Right" /> properties set to the specified values.</returns>
         /// <remarks>This method does not provide any guarantees with regards to argument validation or type checking.</remarks>
-        public BinaryExpression RightShiftAssign(Expression left, Expression right) => ExpressionUnsafe.RightShiftAssign(left, right);
+        public virtual BinaryExpression RightShiftAssign(Expression left, Expression right) => ExpressionUnsafe.RightShiftAssign(left, right);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.BinaryExpression" /> that represents a bitwise right-shift assignment operation.</summary>
         /// <param name="left">An <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Left" /> property equal to.</param>
@@ -2030,7 +2033,7 @@ namespace System.Linq.Expressions
         /// <param name="method">A <see cref="T:System.Reflection.MethodInfo" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Method" /> property equal to.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.BinaryExpression" /> that has the <see cref="P:System.Linq.Expressions.Expression.NodeType" /> property equal to <see cref="F:System.Linq.Expressions.ExpressionType.RightShiftAssign" /> and the <see cref="P:System.Linq.Expressions.BinaryExpression.Left" />, <see cref="P:System.Linq.Expressions.BinaryExpression.Right" />, and <see cref="P:System.Linq.Expressions.BinaryExpression.Method" /> properties set to the specified values.</returns>
         /// <remarks>This method does not provide any guarantees with regards to argument validation or type checking.</remarks>
-        public BinaryExpression RightShiftAssign(Expression left, Expression right, MethodInfo method) => ExpressionUnsafe.RightShiftAssign(left, right, method);
+        public virtual BinaryExpression RightShiftAssign(Expression left, Expression right, MethodInfo method) => ExpressionUnsafe.RightShiftAssign(left, right, method);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.BinaryExpression" /> that represents a bitwise right-shift assignment operation.</summary>
         /// <param name="left">An <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Left" /> property equal to.</param>
@@ -2039,26 +2042,26 @@ namespace System.Linq.Expressions
         /// <param name="conversion">A <see cref="T:System.Linq.Expressions.LambdaExpression" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Conversion" /> property equal to.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.BinaryExpression" /> that has the <see cref="P:System.Linq.Expressions.Expression.NodeType" /> property equal to <see cref="F:System.Linq.Expressions.ExpressionType.RightShiftAssign" /> and the <see cref="P:System.Linq.Expressions.BinaryExpression.Left" />, <see cref="P:System.Linq.Expressions.BinaryExpression.Right" />, <see cref="P:System.Linq.Expressions.BinaryExpression.Method" />, and <see cref="P:System.Linq.Expressions.BinaryExpression.Conversion" /> properties set to the specified values.</returns>
         /// <remarks>This method does not provide any guarantees with regards to argument validation or type checking.</remarks>
-        public BinaryExpression RightShiftAssign(Expression left, Expression right, MethodInfo method, LambdaExpression conversion) => ExpressionUnsafe.RightShiftAssign(left, right, method, conversion);
+        public virtual BinaryExpression RightShiftAssign(Expression left, Expression right, MethodInfo method, LambdaExpression conversion) => ExpressionUnsafe.RightShiftAssign(left, right, method, conversion);
 
         /// <summary>Creates an instance of <see cref="T:System.Linq.Expressions.RuntimeVariablesExpression" />.</summary>
         /// <param name="variables">An array of <see cref="T:System.Linq.Expressions.ParameterExpression" /> objects to use to populate the <see cref="P:System.Linq.Expressions.RuntimeVariablesExpression.Variables" /> collection.</param>
         /// <returns>An instance of <see cref="T:System.Linq.Expressions.RuntimeVariablesExpression" /> that has the <see cref="P:System.Linq.Expressions.Expression.NodeType" /> property equal to <see cref="F:System.Linq.Expressions.ExpressionType.RuntimeVariables" /> and the <see cref="P:System.Linq.Expressions.RuntimeVariablesExpression.Variables" /> property set to the specified value.</returns>
         /// <remarks>This method does not provide any guarantees with regards to argument validation or type checking.</remarks>
-        public RuntimeVariablesExpression RuntimeVariables(ParameterExpression[] variables) => ExpressionUnsafe.RuntimeVariables(variables);
+        public virtual RuntimeVariablesExpression RuntimeVariables(ParameterExpression[] variables) => ExpressionUnsafe.RuntimeVariables(variables);
 
         /// <summary>Creates an instance of <see cref="T:System.Linq.Expressions.RuntimeVariablesExpression" />.</summary>
         /// <param name="variables">A collection of <see cref="T:System.Linq.Expressions.ParameterExpression" /> objects to use to populate the <see cref="P:System.Linq.Expressions.RuntimeVariablesExpression.Variables" /> collection.</param>
         /// <returns>An instance of <see cref="T:System.Linq.Expressions.RuntimeVariablesExpression" /> that has the <see cref="P:System.Linq.Expressions.Expression.NodeType" /> property equal to <see cref="F:System.Linq.Expressions.ExpressionType.RuntimeVariables" /> and the <see cref="P:System.Linq.Expressions.RuntimeVariablesExpression.Variables" /> property set to the specified value.</returns>
         /// <remarks>This method does not provide any guarantees with regards to argument validation or type checking.</remarks>
-        public RuntimeVariablesExpression RuntimeVariables(IEnumerable<ParameterExpression> variables) => ExpressionUnsafe.RuntimeVariables(variables);
+        public virtual RuntimeVariablesExpression RuntimeVariables(IEnumerable<ParameterExpression> variables) => ExpressionUnsafe.RuntimeVariables(variables);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.BinaryExpression" /> that represents an arithmetic subtraction operation that does not have overflow checking.</summary>
         /// <param name="left">An <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Left" /> property equal to.</param>
         /// <param name="right">A <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Right" /> property equal to.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.BinaryExpression" /> that has the <see cref="P:System.Linq.Expressions.Expression.NodeType" /> property equal to <see cref="F:System.Linq.Expressions.ExpressionType.Subtract" /> and the <see cref="P:System.Linq.Expressions.BinaryExpression.Left" /> and <see cref="P:System.Linq.Expressions.BinaryExpression.Right" /> properties set to the specified values.</returns>
         /// <remarks>This method does not provide any guarantees with regards to argument validation or type checking.</remarks>
-        public BinaryExpression Subtract(Expression left, Expression right) => ExpressionUnsafe.Subtract(left, right);
+        public virtual BinaryExpression Subtract(Expression left, Expression right) => ExpressionUnsafe.Subtract(left, right);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.BinaryExpression" /> that represents an arithmetic subtraction operation that does not have overflow checking.</summary>
         /// <param name="left">A <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Left" /> property equal to.</param>
@@ -2066,14 +2069,14 @@ namespace System.Linq.Expressions
         /// <param name="method">A <see cref="T:System.Reflection.MethodInfo" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Method" /> property equal to.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.BinaryExpression" /> that has the <see cref="P:System.Linq.Expressions.Expression.NodeType" /> property equal to <see cref="F:System.Linq.Expressions.ExpressionType.Subtract" /> and the <see cref="P:System.Linq.Expressions.BinaryExpression.Left" />, <see cref="P:System.Linq.Expressions.BinaryExpression.Right" />, and <see cref="P:System.Linq.Expressions.BinaryExpression.Method" /> properties set to the specified values.</returns>
         /// <remarks>This method does not provide any guarantees with regards to argument validation or type checking.</remarks>
-        public BinaryExpression Subtract(Expression left, Expression right, MethodInfo method) => ExpressionUnsafe.Subtract(left, right, method);
+        public virtual BinaryExpression Subtract(Expression left, Expression right, MethodInfo method) => ExpressionUnsafe.Subtract(left, right, method);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.BinaryExpression" /> that represents a subtraction assignment operation that does not have overflow checking.</summary>
         /// <param name="left">An <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Left" /> property equal to.</param>
         /// <param name="right">An <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Right" /> property equal to.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.BinaryExpression" /> that has the <see cref="P:System.Linq.Expressions.Expression.NodeType" /> property equal to <see cref="F:System.Linq.Expressions.ExpressionType.SubtractAssign" /> and the <see cref="P:System.Linq.Expressions.BinaryExpression.Left" /> and <see cref="P:System.Linq.Expressions.BinaryExpression.Right" /> properties set to the specified values.</returns>
         /// <remarks>This method does not provide any guarantees with regards to argument validation or type checking.</remarks>
-        public BinaryExpression SubtractAssign(Expression left, Expression right) => ExpressionUnsafe.SubtractAssign(left, right);
+        public virtual BinaryExpression SubtractAssign(Expression left, Expression right) => ExpressionUnsafe.SubtractAssign(left, right);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.BinaryExpression" /> that represents a subtraction assignment operation that does not have overflow checking.</summary>
         /// <param name="left">An <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Left" /> property equal to.</param>
@@ -2081,7 +2084,7 @@ namespace System.Linq.Expressions
         /// <param name="method">A <see cref="T:System.Reflection.MethodInfo" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Method" /> property equal to.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.BinaryExpression" /> that has the <see cref="P:System.Linq.Expressions.Expression.NodeType" /> property equal to <see cref="F:System.Linq.Expressions.ExpressionType.SubtractAssign" /> and the <see cref="P:System.Linq.Expressions.BinaryExpression.Left" />, <see cref="P:System.Linq.Expressions.BinaryExpression.Right" />, and <see cref="P:System.Linq.Expressions.BinaryExpression.Method" /> properties set to the specified values.</returns>
         /// <remarks>This method does not provide any guarantees with regards to argument validation or type checking.</remarks>
-        public BinaryExpression SubtractAssign(Expression left, Expression right, MethodInfo method) => ExpressionUnsafe.SubtractAssign(left, right, method);
+        public virtual BinaryExpression SubtractAssign(Expression left, Expression right, MethodInfo method) => ExpressionUnsafe.SubtractAssign(left, right, method);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.BinaryExpression" /> that represents a subtraction assignment operation that does not have overflow checking.</summary>
         /// <param name="left">An <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Left" /> property equal to.</param>
@@ -2090,14 +2093,14 @@ namespace System.Linq.Expressions
         /// <param name="conversion">A <see cref="T:System.Linq.Expressions.LambdaExpression" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Conversion" /> property equal to.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.BinaryExpression" /> that has the <see cref="P:System.Linq.Expressions.Expression.NodeType" /> property equal to <see cref="F:System.Linq.Expressions.ExpressionType.SubtractAssign" /> and the <see cref="P:System.Linq.Expressions.BinaryExpression.Left" />, <see cref="P:System.Linq.Expressions.BinaryExpression.Right" />, <see cref="P:System.Linq.Expressions.BinaryExpression.Method" />, and <see cref="P:System.Linq.Expressions.BinaryExpression.Conversion" /> properties set to the specified values.</returns>
         /// <remarks>This method does not provide any guarantees with regards to argument validation or type checking.</remarks>
-        public BinaryExpression SubtractAssign(Expression left, Expression right, MethodInfo method, LambdaExpression conversion) => ExpressionUnsafe.SubtractAssign(left, right, method, conversion);
+        public virtual BinaryExpression SubtractAssign(Expression left, Expression right, MethodInfo method, LambdaExpression conversion) => ExpressionUnsafe.SubtractAssign(left, right, method, conversion);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.BinaryExpression" /> that represents a subtraction assignment operation that has overflow checking.</summary>
         /// <param name="left">An <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Left" /> property equal to.</param>
         /// <param name="right">An <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Right" /> property equal to.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.BinaryExpression" /> that has the <see cref="P:System.Linq.Expressions.Expression.NodeType" /> property equal to <see cref="F:System.Linq.Expressions.ExpressionType.SubtractAssignChecked" /> and the <see cref="P:System.Linq.Expressions.BinaryExpression.Left" /> and <see cref="P:System.Linq.Expressions.BinaryExpression.Right" /> properties set to the specified values.</returns>
         /// <remarks>This method does not provide any guarantees with regards to argument validation or type checking.</remarks>
-        public BinaryExpression SubtractAssignChecked(Expression left, Expression right) => ExpressionUnsafe.SubtractAssignChecked(left, right);
+        public virtual BinaryExpression SubtractAssignChecked(Expression left, Expression right) => ExpressionUnsafe.SubtractAssignChecked(left, right);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.BinaryExpression" /> that represents a subtraction assignment operation that has overflow checking.</summary>
         /// <param name="left">An <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Left" /> property equal to.</param>
@@ -2105,7 +2108,7 @@ namespace System.Linq.Expressions
         /// <param name="method">A <see cref="T:System.Reflection.MethodInfo" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Method" /> property equal to.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.BinaryExpression" /> that has the <see cref="P:System.Linq.Expressions.Expression.NodeType" /> property equal to <see cref="F:System.Linq.Expressions.ExpressionType.SubtractAssignChecked" /> and the <see cref="P:System.Linq.Expressions.BinaryExpression.Left" />, <see cref="P:System.Linq.Expressions.BinaryExpression.Right" />, and <see cref="P:System.Linq.Expressions.BinaryExpression.Method" /> properties set to the specified values.</returns>
         /// <remarks>This method does not provide any guarantees with regards to argument validation or type checking.</remarks>
-        public BinaryExpression SubtractAssignChecked(Expression left, Expression right, MethodInfo method) => ExpressionUnsafe.SubtractAssignChecked(left, right, method);
+        public virtual BinaryExpression SubtractAssignChecked(Expression left, Expression right, MethodInfo method) => ExpressionUnsafe.SubtractAssignChecked(left, right, method);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.BinaryExpression" /> that represents a subtraction assignment operation that has overflow checking.</summary>
         /// <param name="left">An <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Left" /> property equal to.</param>
@@ -2114,14 +2117,14 @@ namespace System.Linq.Expressions
         /// <param name="conversion">A <see cref="T:System.Linq.Expressions.LambdaExpression" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Conversion" /> property equal to.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.BinaryExpression" /> that has the <see cref="P:System.Linq.Expressions.Expression.NodeType" /> property equal to <see cref="F:System.Linq.Expressions.ExpressionType.SubtractAssignChecked" /> and the <see cref="P:System.Linq.Expressions.BinaryExpression.Left" />, <see cref="P:System.Linq.Expressions.BinaryExpression.Right" />, <see cref="P:System.Linq.Expressions.BinaryExpression.Method" />, and <see cref="P:System.Linq.Expressions.BinaryExpression.Conversion" /> properties set to the specified values.</returns>
         /// <remarks>This method does not provide any guarantees with regards to argument validation or type checking.</remarks>
-        public BinaryExpression SubtractAssignChecked(Expression left, Expression right, MethodInfo method, LambdaExpression conversion) => ExpressionUnsafe.SubtractAssignChecked(left, right, method, conversion);
+        public virtual BinaryExpression SubtractAssignChecked(Expression left, Expression right, MethodInfo method, LambdaExpression conversion) => ExpressionUnsafe.SubtractAssignChecked(left, right, method, conversion);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.BinaryExpression" /> that represents an arithmetic subtraction operation that has overflow checking.</summary>
         /// <param name="left">A <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Left" /> property equal to.</param>
         /// <param name="right">A <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Right" /> property equal to.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.BinaryExpression" /> that has the <see cref="P:System.Linq.Expressions.Expression.NodeType" /> property equal to <see cref="F:System.Linq.Expressions.ExpressionType.SubtractChecked" /> and the <see cref="P:System.Linq.Expressions.BinaryExpression.Left" /> and <see cref="P:System.Linq.Expressions.BinaryExpression.Right" /> properties set to the specified values.</returns>
         /// <remarks>This method does not provide any guarantees with regards to argument validation or type checking.</remarks>
-        public BinaryExpression SubtractChecked(Expression left, Expression right) => ExpressionUnsafe.SubtractChecked(left, right);
+        public virtual BinaryExpression SubtractChecked(Expression left, Expression right) => ExpressionUnsafe.SubtractChecked(left, right);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.BinaryExpression" /> that represents an arithmetic subtraction operation that has overflow checking.</summary>
         /// <param name="left">A <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Left" /> property equal to.</param>
@@ -2129,14 +2132,14 @@ namespace System.Linq.Expressions
         /// <param name="method">A <see cref="T:System.Reflection.MethodInfo" /> to set the <see cref="P:System.Linq.Expressions.BinaryExpression.Method" /> property equal to.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.BinaryExpression" /> that has the <see cref="P:System.Linq.Expressions.Expression.NodeType" /> property equal to <see cref="F:System.Linq.Expressions.ExpressionType.SubtractChecked" /> and the <see cref="P:System.Linq.Expressions.BinaryExpression.Left" />, <see cref="P:System.Linq.Expressions.BinaryExpression.Right" />, and <see cref="P:System.Linq.Expressions.BinaryExpression.Method" /> properties set to the specified values.</returns>
         /// <remarks>This method does not provide any guarantees with regards to argument validation or type checking.</remarks>
-        public BinaryExpression SubtractChecked(Expression left, Expression right, MethodInfo method) => ExpressionUnsafe.SubtractChecked(left, right, method);
+        public virtual BinaryExpression SubtractChecked(Expression left, Expression right, MethodInfo method) => ExpressionUnsafe.SubtractChecked(left, right, method);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.SwitchExpression" /> that represents a <see langword="switch" /> statement without a default case.</summary>
         /// <param name="switchValue">The value to be tested against each case.</param>
         /// <param name="cases">The set of cases for this switch expression.</param>
         /// <returns>The created <see cref="T:System.Linq.Expressions.SwitchExpression" />.</returns>
         /// <remarks>This method does not provide any guarantees with regards to argument validation or type checking.</remarks>
-        public SwitchExpression Switch(Expression switchValue, SwitchCase[] cases) => ExpressionUnsafe.Switch(switchValue, cases);
+        public virtual SwitchExpression Switch(Expression switchValue, SwitchCase[] cases) => ExpressionUnsafe.Switch(switchValue, cases);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.SwitchExpression" /> that represents a <see langword="switch" /> statement that has a default case.</summary>
         /// <param name="switchValue">The value to be tested against each case.</param>
@@ -2144,16 +2147,7 @@ namespace System.Linq.Expressions
         /// <param name="cases">The set of cases for this switch expression.</param>
         /// <returns>The created <see cref="T:System.Linq.Expressions.SwitchExpression" />.</returns>
         /// <remarks>This method does not provide any guarantees with regards to argument validation or type checking.</remarks>
-        public SwitchExpression Switch(Expression switchValue, Expression defaultBody, SwitchCase[] cases) => ExpressionUnsafe.Switch(switchValue, defaultBody, cases);
-
-        /// <summary>Creates a <see cref="T:System.Linq.Expressions.SwitchExpression" /> that represents a <see langword="switch" /> statement that has a default case.</summary>
-        /// <param name="switchValue">The value to be tested against each case.</param>
-        /// <param name="defaultBody">The result of the switch if <paramref name="switchValue" /> does not match any of the cases.</param>
-        /// <param name="comparison">The equality comparison method to use.</param>
-        /// <param name="cases">The set of cases for this switch expression.</param>
-        /// <returns>The created <see cref="T:System.Linq.Expressions.SwitchExpression" />.</returns>
-        /// <remarks>This method does not provide any guarantees with regards to argument validation or type checking.</remarks>
-        public SwitchExpression Switch(Expression switchValue, Expression defaultBody, MethodInfo comparison, SwitchCase[] cases) => ExpressionUnsafe.Switch(switchValue, defaultBody, comparison, cases);
+        public virtual SwitchExpression Switch(Expression switchValue, Expression defaultBody, SwitchCase[] cases) => ExpressionUnsafe.Switch(switchValue, defaultBody, cases);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.SwitchExpression" /> that represents a <see langword="switch" /> statement that has a default case.</summary>
         /// <param name="switchValue">The value to be tested against each case.</param>
@@ -2162,7 +2156,16 @@ namespace System.Linq.Expressions
         /// <param name="cases">The set of cases for this switch expression.</param>
         /// <returns>The created <see cref="T:System.Linq.Expressions.SwitchExpression" />.</returns>
         /// <remarks>This method does not provide any guarantees with regards to argument validation or type checking.</remarks>
-        public SwitchExpression Switch(Expression switchValue, Expression defaultBody, MethodInfo comparison, IEnumerable<SwitchCase> cases) => ExpressionUnsafe.Switch(switchValue, defaultBody, comparison, cases);
+        public virtual SwitchExpression Switch(Expression switchValue, Expression defaultBody, MethodInfo comparison, SwitchCase[] cases) => ExpressionUnsafe.Switch(switchValue, defaultBody, comparison, cases);
+
+        /// <summary>Creates a <see cref="T:System.Linq.Expressions.SwitchExpression" /> that represents a <see langword="switch" /> statement that has a default case.</summary>
+        /// <param name="switchValue">The value to be tested against each case.</param>
+        /// <param name="defaultBody">The result of the switch if <paramref name="switchValue" /> does not match any of the cases.</param>
+        /// <param name="comparison">The equality comparison method to use.</param>
+        /// <param name="cases">The set of cases for this switch expression.</param>
+        /// <returns>The created <see cref="T:System.Linq.Expressions.SwitchExpression" />.</returns>
+        /// <remarks>This method does not provide any guarantees with regards to argument validation or type checking.</remarks>
+        public virtual SwitchExpression Switch(Expression switchValue, Expression defaultBody, MethodInfo comparison, IEnumerable<SwitchCase> cases) => ExpressionUnsafe.Switch(switchValue, defaultBody, comparison, cases);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.SwitchExpression" /> that represents a <see langword="switch" /> statement that has a default case.</summary>
         /// <param name="type">The result type of the switch.</param>
@@ -2172,7 +2175,7 @@ namespace System.Linq.Expressions
         /// <param name="cases">The set of cases for this switch expression.</param>
         /// <returns>The created <see cref="T:System.Linq.Expressions.SwitchExpression" />.</returns>
         /// <remarks>This method does not provide any guarantees with regards to argument validation or type checking.</remarks>
-        public SwitchExpression Switch(Type type, Expression switchValue, Expression defaultBody, MethodInfo comparison, IEnumerable<SwitchCase> cases) => ExpressionUnsafe.Switch(type, switchValue, defaultBody, comparison, cases);
+        public virtual SwitchExpression Switch(Type type, Expression switchValue, Expression defaultBody, MethodInfo comparison, IEnumerable<SwitchCase> cases) => ExpressionUnsafe.Switch(type, switchValue, defaultBody, comparison, cases);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.SwitchExpression" /> that represents a <see langword="switch" /> statement that has a default case..</summary>
         /// <param name="type">The result type of the switch.</param>
@@ -2182,34 +2185,34 @@ namespace System.Linq.Expressions
         /// <param name="cases">The set of cases for this switch expression.</param>
         /// <returns>The created <see cref="T:System.Linq.Expressions.SwitchExpression" />.</returns>
         /// <remarks>This method does not provide any guarantees with regards to argument validation or type checking.</remarks>
-        public SwitchExpression Switch(Type type, Expression switchValue, Expression defaultBody, MethodInfo comparison, SwitchCase[] cases) => ExpressionUnsafe.Switch(type, switchValue, defaultBody, comparison, cases);
+        public virtual SwitchExpression Switch(Type type, Expression switchValue, Expression defaultBody, MethodInfo comparison, SwitchCase[] cases) => ExpressionUnsafe.Switch(type, switchValue, defaultBody, comparison, cases);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.SwitchCase" /> for use in a <see cref="T:System.Linq.Expressions.SwitchExpression" />.</summary>
         /// <param name="body">The body of the case.</param>
         /// <param name="testValues">The test values of the case.</param>
         /// <returns>The created <see cref="T:System.Linq.Expressions.SwitchCase" />.</returns>
         /// <remarks>This method does not provide any guarantees with regards to argument validation or type checking.</remarks>
-        public SwitchCase SwitchCase(Expression body, Expression[] testValues) => ExpressionUnsafe.SwitchCase(body, testValues);
+        public virtual SwitchCase SwitchCase(Expression body, Expression[] testValues) => ExpressionUnsafe.SwitchCase(body, testValues);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.SwitchCase" /> object to be used in a <see cref="T:System.Linq.Expressions.SwitchExpression" /> object.</summary>
         /// <param name="body">The body of the case.</param>
         /// <param name="testValues">The test values of the case.</param>
         /// <returns>The created <see cref="T:System.Linq.Expressions.SwitchCase" />.</returns>
         /// <remarks>This method does not provide any guarantees with regards to argument validation or type checking.</remarks>
-        public SwitchCase SwitchCase(Expression body, IEnumerable<Expression> testValues) => ExpressionUnsafe.SwitchCase(body, testValues);
+        public virtual SwitchCase SwitchCase(Expression body, IEnumerable<Expression> testValues) => ExpressionUnsafe.SwitchCase(body, testValues);
 
         /// <summary>Creates an instance of <see cref="T:System.Linq.Expressions.SymbolDocumentInfo" />.</summary>
         /// <param name="fileName">A <see cref="T:System.String" /> to set the <see cref="P:System.Linq.Expressions.SymbolDocumentInfo.FileName" /> equal to.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.SymbolDocumentInfo" /> that has the <see cref="P:System.Linq.Expressions.SymbolDocumentInfo.FileName" /> property set to the specified value.</returns>
         /// <remarks>This method does not provide any guarantees with regards to argument validation or type checking.</remarks>
-        public SymbolDocumentInfo SymbolDocument(String fileName) => ExpressionUnsafe.SymbolDocument(fileName);
+        public virtual SymbolDocumentInfo SymbolDocument(String fileName) => ExpressionUnsafe.SymbolDocument(fileName);
 
         /// <summary>Creates an instance of <see cref="T:System.Linq.Expressions.SymbolDocumentInfo" />.</summary>
         /// <param name="fileName">A <see cref="T:System.String" /> to set the <see cref="P:System.Linq.Expressions.SymbolDocumentInfo.FileName" /> equal to.</param>
         /// <param name="language">A <see cref="T:System.Guid" /> to set the <see cref="P:System.Linq.Expressions.SymbolDocumentInfo.Language" /> equal to.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.SymbolDocumentInfo" /> that has the <see cref="P:System.Linq.Expressions.SymbolDocumentInfo.FileName" /> and <see cref="P:System.Linq.Expressions.SymbolDocumentInfo.Language" /> properties set to the specified value.</returns>
         /// <remarks>This method does not provide any guarantees with regards to argument validation or type checking.</remarks>
-        public SymbolDocumentInfo SymbolDocument(String fileName, Guid language) => ExpressionUnsafe.SymbolDocument(fileName, language);
+        public virtual SymbolDocumentInfo SymbolDocument(String fileName, Guid language) => ExpressionUnsafe.SymbolDocument(fileName, language);
 
         /// <summary>Creates an instance of <see cref="T:System.Linq.Expressions.SymbolDocumentInfo" />.</summary>
         /// <param name="fileName">A <see cref="T:System.String" /> to set the <see cref="P:System.Linq.Expressions.SymbolDocumentInfo.FileName" /> equal to.</param>
@@ -2217,7 +2220,7 @@ namespace System.Linq.Expressions
         /// <param name="languageVendor">A <see cref="T:System.Guid" /> to set the <see cref="P:System.Linq.Expressions.SymbolDocumentInfo.LanguageVendor" /> equal to.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.SymbolDocumentInfo" /> that has the <see cref="P:System.Linq.Expressions.SymbolDocumentInfo.FileName" /> and <see cref="P:System.Linq.Expressions.SymbolDocumentInfo.Language" /> and <see cref="P:System.Linq.Expressions.SymbolDocumentInfo.LanguageVendor" /> properties set to the specified value.</returns>
         /// <remarks>This method does not provide any guarantees with regards to argument validation or type checking.</remarks>
-        public SymbolDocumentInfo SymbolDocument(String fileName, Guid language, Guid languageVendor) => ExpressionUnsafe.SymbolDocument(fileName, language, languageVendor);
+        public virtual SymbolDocumentInfo SymbolDocument(String fileName, Guid language, Guid languageVendor) => ExpressionUnsafe.SymbolDocument(fileName, language, languageVendor);
 
         /// <summary>Creates an instance of <see cref="T:System.Linq.Expressions.SymbolDocumentInfo" />.</summary>
         /// <param name="fileName">A <see cref="T:System.String" /> to set the <see cref="P:System.Linq.Expressions.SymbolDocumentInfo.FileName" /> equal to.</param>
@@ -2226,27 +2229,27 @@ namespace System.Linq.Expressions
         /// <param name="documentType">A <see cref="T:System.Guid" /> to set the <see cref="P:System.Linq.Expressions.SymbolDocumentInfo.DocumentType" /> equal to.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.SymbolDocumentInfo" /> that has the <see cref="P:System.Linq.Expressions.SymbolDocumentInfo.FileName" /> and <see cref="P:System.Linq.Expressions.SymbolDocumentInfo.Language" /> and <see cref="P:System.Linq.Expressions.SymbolDocumentInfo.LanguageVendor" /> and <see cref="P:System.Linq.Expressions.SymbolDocumentInfo.DocumentType" /> properties set to the specified value.</returns>
         /// <remarks>This method does not provide any guarantees with regards to argument validation or type checking.</remarks>
-        public SymbolDocumentInfo SymbolDocument(String fileName, Guid language, Guid languageVendor, Guid documentType) => ExpressionUnsafe.SymbolDocument(fileName, language, languageVendor, documentType);
+        public virtual SymbolDocumentInfo SymbolDocument(String fileName, Guid language, Guid languageVendor, Guid documentType) => ExpressionUnsafe.SymbolDocument(fileName, language, languageVendor, documentType);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.UnaryExpression" /> that represents a throwing of an exception.</summary>
         /// <param name="value">An <see cref="T:System.Linq.Expressions.Expression" />.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.UnaryExpression" /> that represents the exception.</returns>
         /// <remarks>This method does not provide any guarantees with regards to argument validation or type checking.</remarks>
-        public UnaryExpression Throw(Expression value) => ExpressionUnsafe.Throw(value);
+        public virtual UnaryExpression Throw(Expression value) => ExpressionUnsafe.Throw(value);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.UnaryExpression" /> that represents a throwing of an exception with a given type.</summary>
         /// <param name="value">An <see cref="T:System.Linq.Expressions.Expression" />.</param>
         /// <param name="type">The new <see cref="T:System.Type" /> of the expression.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.UnaryExpression" /> that represents the exception.</returns>
         /// <remarks>This method does not provide any guarantees with regards to argument validation or type checking.</remarks>
-        public UnaryExpression Throw(Expression value, Type type) => ExpressionUnsafe.Throw(value, type);
+        public virtual UnaryExpression Throw(Expression value, Type type) => ExpressionUnsafe.Throw(value, type);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.TryExpression" /> representing a try block with any number of catch statements and neither a fault nor finally block.</summary>
         /// <param name="body">The body of the try block.</param>
         /// <param name="handlers">The array of zero or more <see cref="T:System.Linq.Expressions.CatchBlock" /> expressions representing the catch statements to be associated with the try block.</param>
         /// <returns>The created <see cref="T:System.Linq.Expressions.TryExpression" />.</returns>
         /// <remarks>This method does not provide any guarantees with regards to argument validation or type checking.</remarks>
-        public TryExpression TryCatch(Expression body, CatchBlock[] handlers) => ExpressionUnsafe.TryCatch(body, handlers);
+        public virtual TryExpression TryCatch(Expression body, CatchBlock[] handlers) => ExpressionUnsafe.TryCatch(body, handlers);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.TryExpression" /> representing a try block with any number of catch statements and a finally block.</summary>
         /// <param name="body">The body of the try block.</param>
@@ -2254,75 +2257,75 @@ namespace System.Linq.Expressions
         /// <param name="handlers">The array of zero or more <see cref="T:System.Linq.Expressions.CatchBlock" /> expressions representing the catch statements to be associated with the try block.</param>
         /// <returns>The created <see cref="T:System.Linq.Expressions.TryExpression" />.</returns>
         /// <remarks>This method does not provide any guarantees with regards to argument validation or type checking.</remarks>
-        public TryExpression TryCatchFinally(Expression body, Expression @finally, CatchBlock[] handlers) => ExpressionUnsafe.TryCatchFinally(body, @finally, handlers);
+        public virtual TryExpression TryCatchFinally(Expression body, Expression @finally, CatchBlock[] handlers) => ExpressionUnsafe.TryCatchFinally(body, @finally, handlers);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.TryExpression" /> representing a try block with a fault block and no catch statements.</summary>
         /// <param name="body">The body of the try block.</param>
         /// <param name="fault">The body of the fault block.</param>
         /// <returns>The created <see cref="T:System.Linq.Expressions.TryExpression" />.</returns>
         /// <remarks>This method does not provide any guarantees with regards to argument validation or type checking.</remarks>
-        public TryExpression TryFault(Expression body, Expression fault) => ExpressionUnsafe.TryFault(body, fault);
+        public virtual TryExpression TryFault(Expression body, Expression fault) => ExpressionUnsafe.TryFault(body, fault);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.TryExpression" /> representing a try block with a finally block and no catch statements.</summary>
         /// <param name="body">The body of the try block.</param>
         /// <param name="finally">The body of the finally block.</param>
         /// <returns>The created <see cref="T:System.Linq.Expressions.TryExpression" />.</returns>
         /// <remarks>This method does not provide any guarantees with regards to argument validation or type checking.</remarks>
-        public TryExpression TryFinally(Expression body, Expression @finally) => ExpressionUnsafe.TryFinally(body, @finally);
+        public virtual TryExpression TryFinally(Expression body, Expression @finally) => ExpressionUnsafe.TryFinally(body, @finally);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.UnaryExpression" /> that represents an explicit reference or boxing conversion where <see langword="null" /> is supplied if the conversion fails.</summary>
         /// <param name="expression">An <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.UnaryExpression.Operand" /> property equal to.</param>
         /// <param name="type">A <see cref="T:System.Type" /> to set the <see cref="P:System.Linq.Expressions.Expression.Type" /> property equal to.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.UnaryExpression" /> that has the <see cref="P:System.Linq.Expressions.Expression.NodeType" /> property equal to <see cref="F:System.Linq.Expressions.ExpressionType.TypeAs" /> and the <see cref="P:System.Linq.Expressions.UnaryExpression.Operand" /> and <see cref="P:System.Linq.Expressions.Expression.Type" /> properties set to the specified values.</returns>
         /// <remarks>This method does not provide any guarantees with regards to argument validation or type checking.</remarks>
-        public UnaryExpression TypeAs(Expression expression, Type type) => ExpressionUnsafe.TypeAs(expression, type);
+        public virtual UnaryExpression TypeAs(Expression expression, Type type) => ExpressionUnsafe.TypeAs(expression, type);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.TypeBinaryExpression" /> that compares run-time type identity.</summary>
         /// <param name="expression">An <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="T:System.Linq.Expressions.Expression" /> property equal to.</param>
         /// <param name="type">A <see cref="P:System.Linq.Expressions.Expression.Type" /> to set the <see cref="P:System.Linq.Expressions.TypeBinaryExpression.TypeOperand" /> property equal to.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.TypeBinaryExpression" /> for which the <see cref="P:System.Linq.Expressions.Expression.NodeType" /> property is equal to <see cref="M:System.Linq.Expressions.Expression.TypeEqual(System.Linq.Expressions.Expression,System.Type)" /> and for which the <see cref="T:System.Linq.Expressions.Expression" /> and <see cref="P:System.Linq.Expressions.TypeBinaryExpression.TypeOperand" /> properties are set to the specified values.</returns>
         /// <remarks>This method does not provide any guarantees with regards to argument validation or type checking.</remarks>
-        public TypeBinaryExpression TypeEqual(Expression expression, Type type) => ExpressionUnsafe.TypeEqual(expression, type);
+        public virtual TypeBinaryExpression TypeEqual(Expression expression, Type type) => ExpressionUnsafe.TypeEqual(expression, type);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.TypeBinaryExpression" />.</summary>
         /// <param name="expression">An <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.TypeBinaryExpression.Expression" /> property equal to.</param>
         /// <param name="type">A <see cref="P:System.Linq.Expressions.Expression.Type" /> to set the <see cref="P:System.Linq.Expressions.TypeBinaryExpression.TypeOperand" /> property equal to.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.TypeBinaryExpression" /> for which the <see cref="P:System.Linq.Expressions.Expression.NodeType" /> property is equal to <see cref="F:System.Linq.Expressions.ExpressionType.TypeIs" /> and for which the <see cref="P:System.Linq.Expressions.TypeBinaryExpression.Expression" /> and <see cref="P:System.Linq.Expressions.TypeBinaryExpression.TypeOperand" /> properties are set to the specified values.</returns>
         /// <remarks>This method does not provide any guarantees with regards to argument validation or type checking.</remarks>
-        public TypeBinaryExpression TypeIs(Expression expression, Type type) => ExpressionUnsafe.TypeIs(expression, type);
+        public virtual TypeBinaryExpression TypeIs(Expression expression, Type type) => ExpressionUnsafe.TypeIs(expression, type);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.UnaryExpression" /> that represents a unary plus operation.</summary>
         /// <param name="expression">An <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.UnaryExpression.Operand" /> property equal to.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.UnaryExpression" /> that has the <see cref="P:System.Linq.Expressions.Expression.NodeType" /> property equal to <see cref="F:System.Linq.Expressions.ExpressionType.UnaryPlus" /> and the <see cref="P:System.Linq.Expressions.UnaryExpression.Operand" /> property set to the specified value.</returns>
         /// <remarks>This method does not provide any guarantees with regards to argument validation or type checking.</remarks>
-        public UnaryExpression UnaryPlus(Expression expression) => ExpressionUnsafe.UnaryPlus(expression);
+        public virtual UnaryExpression UnaryPlus(Expression expression) => ExpressionUnsafe.UnaryPlus(expression);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.UnaryExpression" /> that represents a unary plus operation.</summary>
         /// <param name="expression">An <see cref="T:System.Linq.Expressions.Expression" /> to set the <see cref="P:System.Linq.Expressions.UnaryExpression.Operand" /> property equal to.</param>
         /// <param name="method">A <see cref="T:System.Reflection.MethodInfo" /> to set the <see cref="P:System.Linq.Expressions.UnaryExpression.Method" /> property equal to.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.UnaryExpression" /> that has the <see cref="P:System.Linq.Expressions.Expression.NodeType" /> property equal to <see cref="F:System.Linq.Expressions.ExpressionType.UnaryPlus" /> and the <see cref="P:System.Linq.Expressions.UnaryExpression.Operand" /> and <see cref="P:System.Linq.Expressions.UnaryExpression.Method" /> properties set to the specified values.</returns>
         /// <remarks>This method does not provide any guarantees with regards to argument validation or type checking.</remarks>
-        public UnaryExpression UnaryPlus(Expression expression, MethodInfo method) => ExpressionUnsafe.UnaryPlus(expression, method);
+        public virtual UnaryExpression UnaryPlus(Expression expression, MethodInfo method) => ExpressionUnsafe.UnaryPlus(expression, method);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.UnaryExpression" /> that represents an explicit unboxing.</summary>
         /// <param name="expression">An <see cref="T:System.Linq.Expressions.Expression" /> to unbox.</param>
         /// <param name="type">The new <see cref="T:System.Type" /> of the expression.</param>
         /// <returns>An instance of <see cref="T:System.Linq.Expressions.UnaryExpression" />.</returns>
         /// <remarks>This method does not provide any guarantees with regards to argument validation or type checking.</remarks>
-        public UnaryExpression Unbox(Expression expression, Type type) => ExpressionUnsafe.Unbox(expression, type);
+        public virtual UnaryExpression Unbox(Expression expression, Type type) => ExpressionUnsafe.Unbox(expression, type);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.ParameterExpression" /> node that can be used to identify a parameter or a variable in an expression tree.</summary>
         /// <param name="type">The type of the parameter or variable.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.ParameterExpression" /> node with the specified name and type</returns>
         /// <remarks>This method does not provide any guarantees with regards to argument validation or type checking.</remarks>
-        public ParameterExpression Variable(Type type) => ExpressionUnsafe.Variable(type);
+        public virtual ParameterExpression Variable(Type type) => ExpressionUnsafe.Variable(type);
 
         /// <summary>Creates a <see cref="T:System.Linq.Expressions.ParameterExpression" /> node that can be used to identify a parameter or a variable in an expression tree.</summary>
         /// <param name="type">The type of the parameter or variable.</param>
         /// <param name="name">The name of the parameter or variable. This name is used for debugging or printing purpose only.</param>
         /// <returns>A <see cref="T:System.Linq.Expressions.ParameterExpression" /> node with the specified name and type.</returns>
         /// <remarks>This method does not provide any guarantees with regards to argument validation or type checking.</remarks>
-        public ParameterExpression Variable(Type type, String name) => ExpressionUnsafe.Variable(type, name);
+        public virtual ParameterExpression Variable(Type type, String name) => ExpressionUnsafe.Variable(type, name);
 
     }
 }

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices/Expressions/ExpressionUnsafeFactory.tt
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices/Expressions/ExpressionUnsafeFactory.tt
@@ -52,14 +52,17 @@ namespace System.Linq.Expressions
     /// with extreme caution, only if type safety guarantees are provided elsewhere. A typical use of this
     /// factory is for expression deserialization.
     /// </summary>
-    public sealed class ExpressionUnsafeFactory : IExpressionFactory
+    public class ExpressionUnsafeFactory : IExpressionFactory
     {
         /// <summary>
         /// Gets the singleton instance of the factory.
         /// </summary>
-        public static readonly IExpressionFactory Instance = new ExpressionUnsafeFactory();
+        public static readonly ExpressionUnsafeFactory Instance = new();
 
-        private ExpressionUnsafeFactory() {}
+        /// <summary>
+        /// Default constructor.
+        /// </summary>
+        protected ExpressionUnsafeFactory() {}
 
 <#
 foreach (var m in typeof(Expression).GetMethods().Where(m => m.IsStatic && m.DeclaringType == typeof(Expression)).Where(m => !exclude.Contains(m.Name)).OrderBy(m => m.Name).ThenBy(m => m.GetParameters().Length))
@@ -87,7 +90,7 @@ foreach (var m in typeof(Expression).GetMethods().Where(m => m.IsStatic && m.Dec
 #>
 <#=doc#>
         /// <remarks>This method does not provide any guarantees with regards to argument validation or type checking.</remarks>
-        public <#=ret#> <#=name#><#=genArgs#>(<#=pars#>) => ExpressionUnsafe.<#=name#><#=genArgs#>(<#=args#>);
+        public virtual <#=ret#> <#=name#><#=genArgs#>(<#=pars#>) => ExpressionUnsafe.<#=name#><#=genArgs#>(<#=args#>);
 
 <#
 }


### PR DESCRIPTION
Mark factory methods as `virtual` to make extensibility easier.