### PR TITLE
Some optimizations for expression tree compilation caches.

### DIFF
--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices/Collections/ScopedSymbolTable.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices/Collections/ScopedSymbolTable.cs
@@ -20,7 +20,6 @@ namespace System.Linq.CompilerServices
     /// <typeparam name="TValue">Type of the values associated with the symbols stored in the table.</typeparam>
     public class ScopedSymbolTable<TSymbol, TValue> : IEnumerable<Indexed<SymbolTable<TSymbol, TValue>>>
     {
-        private readonly IEqualityComparer<TSymbol> _symbolComparer;
         private readonly Stack<SymbolTable<TSymbol, TValue>> _environment;
 
         /// <summary>
@@ -37,8 +36,7 @@ namespace System.Linq.CompilerServices
         /// <param name="symbolComparer">Equality comparer to compare symbols. A scoped symbol table can only contain distinct symbols within each level. Symbols can shadow declarations in the enclosing scope.</param>
         public ScopedSymbolTable(IEqualityComparer<TSymbol> symbolComparer)
         {
-            _symbolComparer = symbolComparer ?? throw new ArgumentNullException(nameof(symbolComparer));
-            GlobalScope = new SymbolTable<TSymbol, TValue>(parent: null, symbolComparer);
+            GlobalScope = new SymbolTable<TSymbol, TValue>(parent: null, symbolComparer ?? throw new ArgumentNullException(nameof(symbolComparer)));
             _environment = new Stack<SymbolTable<TSymbol, TValue>>();
         }
 
@@ -56,7 +54,7 @@ namespace System.Linq.CompilerServices
         /// <summary>
         /// Pushes a new scope onto the scoped symbol table.
         /// </summary>
-        public void Push() => _environment.Push(new SymbolTable<TSymbol, TValue>(CurrentScope, _symbolComparer));
+        public void Push() => _environment.Push(new SymbolTable<TSymbol, TValue>(CurrentScope, GlobalScope.Comparer));
 
         /// <summary>
         /// Pops the most recent scope from the scoped symbol table.

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices/Collections/SymbolTable.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices/Collections/SymbolTable.cs
@@ -49,6 +49,11 @@ namespace System.Linq.CompilerServices
         }
 
         /// <summary>
+        /// Gets the comparer used to compare symbols.
+        /// </summary>
+        public IEqualityComparer<TSymbol> Comparer => _table.Comparer;
+
+        /// <summary>
         /// Gets the parent symbol table. Returns null if no parent table was specified during creation of the symbol table.
         /// </summary>
         public SymbolTable<TSymbol, TValue> Parent { get; }

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices/Expressions/Visitors/ScopedExpressionVisitor.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices/Expressions/Visitors/ScopedExpressionVisitor.cs
@@ -92,7 +92,12 @@ namespace System.Linq.CompilerServices
             if (parameters == null)
                 throw new ArgumentNullException(nameof(parameters));
 
-            PushCore(parameters.Select(p => new KeyValuePair<ParameterExpression, TState>(p, GetState(p))));
+            _symbolTable.Push();
+
+            foreach (var parameter in parameters)
+            {
+                _symbolTable.Add(parameter, GetState(parameter));
+            }
         }
 
         /// <summary>
@@ -104,16 +109,6 @@ namespace System.Linq.CompilerServices
             if (scope == null)
                 throw new ArgumentNullException(nameof(scope));
 
-            PushCore(scope);
-        }
-
-        /// <summary>
-        /// Pops a scope from the symbol table.
-        /// </summary>
-        protected override void Pop() => _symbolTable.Pop();
-
-        private void PushCore(IEnumerable<KeyValuePair<ParameterExpression, TState>> scope)
-        {
             _symbolTable.Push();
 
             foreach (var entry in scope)
@@ -121,5 +116,10 @@ namespace System.Linq.CompilerServices
                 _symbolTable.Add(entry.Key, entry.Value);
             }
         }
+
+        /// <summary>
+        /// Pops a scope from the symbol table.
+        /// </summary>
+        protected override void Pop() => _symbolTable.Pop();
     }
 }

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices/README.md
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices/README.md
@@ -391,7 +391,7 @@ where `<>__blah` is some compiler-generated identifier. This can make debug outp
 
 ### Constant hoisting
 
-Contant expressions often occur in expression trees due to partial evaluation of locals at the point of rewriting an expression for submission to a service. For example:
+Constant expressions often occur in expression trees due to partial evaluation of locals at the point of rewriting an expression for submission to a service. For example:
 
 ```csharp
 int a = 41;
@@ -514,7 +514,7 @@ var subst = new TypeSubstitutionExpressionVisitor(new Dictionary<Type, Type>
 Expression rewritten = subst.Apply(expr);
 ```
 
-By default, members are located by finding a member with the same name (and parameter types, after type substitution in child nodes, in case of methods and constructors) on the target type. For example, when rewriting `dt => dt.Now.AddDays(1)` from `DateTime` to `DateTimeOffset`, both `Now` and `AddDays` will be located successfully.
+By default, members are located by finding a member with the same name (and parameter types, after type substitution in child nodes, in case of methods and constructors) on the target type. For example, when rewriting `() => DateTime.Now.AddDays(1)` from `DateTime` to `DateTimeOffset`, both `Now` and `AddDays` will be located successfully.
 
 However, if more advanced rules are needed to retarget members on types, a subclass of `TypeSubstitutionExpressionVisitor` can be used to override various `Resolve*` methods. An an example, consider the method used to resolve a `MethodInfo`:
 


### PR DESCRIPTION
This is the fall-out from analyzing the code paths around `Compile(ICompiledDelegateCache)` and friends, which are hit quite commonly in high-density Reaqtor hosting scenarios. For a micro-benchmark compiling the following sample expression tree

```csharp
Expression<Func<string, int>> expr = s => s.ToUpper().Substring(1, 2).ToLower().Length - 1;
```

with caching enabled, we're seeing about ~20% savings in memory allocations. As a result, the comparison to the regular `Compile()` in the BCL is now better in terms of execution time (always was up to 10x for moderately complex expressions) and memory allocations which are harder to beat because we have to do a bunch of cache management, while `Compile()` is pretty much "just" populating a buffer with IL instructions (if we just account for the managed side of the house).