### PR TITLE
Add notebook for Nuqleon.Linq.CompilerServices.

### DIFF
--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices/GettingStarted.ipynb
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices/GettingStarted.ipynb
@@ -147,7 +147,24 @@
         "    Console.WriteLine(method);\n",
         "}"
       ],
-      "outputs": []
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "System.String ToLower()\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "System.String Substring(Int32, Int32)\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        }
+      ]
     },
     {
       "cell_type": "markdown",
@@ -200,7 +217,16 @@
         "\n",
         "Console.WriteLine(res);"
       ],
-      "outputs": []
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "() => 42\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        }
+      ]
     },
     {
       "cell_type": "markdown",
@@ -266,7 +292,16 @@
         "\n",
         "Console.WriteLine(expr);"
       ],
-      "outputs": []
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "x => (x + y)\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        }
+      ]
     },
     {
       "cell_type": "markdown",
@@ -290,7 +325,16 @@
         "\n",
         "Console.WriteLine($\"Unbound variables in `{expr}` = {{ {string.Join(\", \", fuv.UnboundVariables)} }}\");"
       ],
-      "outputs": []
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "Unbound variables in `x => (x + y)` = { y }\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        }
+      ]
     },
     {
       "cell_type": "markdown",
@@ -325,7 +369,16 @@
         "\n",
         "Console.WriteLine(expr);"
       ],
-      "outputs": []
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "((ArrayLength(Empty()) * \"foo\".Length) + 3)\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        }
+      ]
     },
     {
       "cell_type": "markdown",
@@ -392,7 +445,16 @@
         "\n",
         "Console.WriteLine(res);"
       ],
-      "outputs": []
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "((Eval(ArrayLength(Empty())) * Eval(\"foo\".Length)) + 3)\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        }
+      ]
     },
     {
       "cell_type": "markdown",
@@ -508,7 +570,16 @@
         "\n",
         "Console.WriteLine(opt);"
       ],
-      "outputs": []
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "3\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        }
+      ]
     },
     {
       "cell_type": "markdown",
@@ -536,7 +607,16 @@
         "\n",
         "Console.WriteLine(expr);"
       ],
-      "outputs": []
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "(x + 1)\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        }
+      ]
     },
     {
       "cell_type": "markdown",
@@ -615,7 +695,24 @@
         "Benchmark(\"Default\", ExpressionFactory.Instance, 1_000_000);\n",
         "Benchmark(\"Unsafe\", ExpressionUnsafeFactory.Instance, 1_000_000);"
       ],
-      "outputs": []
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "Default completed in 253 ms and allocated 168000528 bytes.\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "Unsafe completed in 74 ms and allocated 168008560 bytes.\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        }
+      ]
     },
     {
       "cell_type": "markdown",
@@ -695,7 +792,16 @@
         "\n",
         "Console.WriteLine(object.ReferenceEquals(const1, const2));"
       ],
-      "outputs": []
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "True\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        }
+      ]
     },
     {
       "cell_type": "markdown",
@@ -733,7 +839,16 @@
         "\n",
         "Console.WriteLine(eq.Equals(e1, e1));"
       ],
-      "outputs": []
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "True\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        }
+      ]
     },
     {
       "cell_type": "markdown",
@@ -756,7 +871,16 @@
         "\n",
         "Console.WriteLine(eq.Equals(p1, p2));"
       ],
-      "outputs": []
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "False\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        }
+      ]
     },
     {
       "cell_type": "markdown",
@@ -804,7 +928,16 @@
         "\n",
         "Console.WriteLine(eq.Equals(p1, p2));"
       ],
-      "outputs": []
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "True\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        }
+      ]
     },
     {
       "cell_type": "markdown",
@@ -838,7 +971,16 @@
         "\n",
         "Console.WriteLine(expr);"
       ],
-      "outputs": []
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "x => (x + y)\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        }
+      ]
     },
     {
       "cell_type": "markdown",
@@ -859,7 +1001,24 @@
         "Console.WriteLine($\"Has free variables = {FreeVariableScanner.HasFreeVariables(expr)}\");\n",
         "Console.WriteLine($\"Free variables = {{ {string.Join(\", \", FreeVariableScanner.Scan(expr))} }}\");"
       ],
-      "outputs": []
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "Has free variables = True\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "Free variables = { y }\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        }
+      ]
     },
     {
       "cell_type": "markdown",
@@ -902,7 +1061,16 @@
         "\n",
         "Console.WriteLine(res);"
       ],
-      "outputs": []
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "(1 + 2)\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        }
+      ]
     },
     {
       "cell_type": "markdown",
@@ -924,7 +1092,16 @@
         "\n",
         "var res = typeScanner.Visit(invalidExpr);"
       ],
-      "outputs": []
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "System.NotSupportedException: Expression '\"foo\"' uses 'string' which is not allowed.\r\n   at System.Linq.CompilerServices.ExpressionTypeAllowListScannerBase.ResolveExpression[T](T expression, Type type, Func`2 visit) in D:\\Projects\\Reaqtive\\reaqtor\\Nuqleon\\Core\\LINQ\\Nuqleon.Linq.CompilerServices\\Expressions\\Analysis\\ExpressionTypeAllowListScannerBase.cs:line 59\r\n   at System.Linq.CompilerServices.ExpressionTypeAllowListScannerBase.Visit(Expression node) in D:\\Projects\\Reaqtive\\reaqtor\\Nuqleon\\Core\\LINQ\\Nuqleon.Linq.CompilerServices\\Expressions\\Analysis\\ExpressionTypeAllowListScannerBase.cs:line 33\r\n   at System.Linq.Expressions.ExpressionVisitor.VisitMember(MemberExpression node)\r\n   at System.Linq.Expressions.MemberExpression.Accept(ExpressionVisitor visitor)\r\n   at System.Linq.Expressions.ExpressionVisitor.Visit(Expression node)\r\n   at System.Linq.CompilerServices.ExpressionTypeAllowListScannerBase.Visit(Expression node) in D:\\Projects\\Reaqtive\\reaqtor\\Nuqleon\\Core\\LINQ\\Nuqleon.Linq.CompilerServices\\Expressions\\Analysis\\ExpressionTypeAllowListScannerBase.cs:line 37\r\n   at System.Linq.Expressions.ExpressionVisitor.VisitBinary(BinaryExpression node)\r\n   at System.Linq.Expressions.BinaryExpression.Accept(ExpressionVisitor visitor)\r\n   at System.Linq.Expressions.ExpressionVisitor.Visit(Expression node)\r\n   at System.Linq.CompilerServices.ExpressionTypeAllowListScannerBase.Visit(Expression node) in D:\\Projects\\Reaqtive\\reaqtor\\Nuqleon\\Core\\LINQ\\Nuqleon.Linq.CompilerServices\\Expressions\\Analysis\\ExpressionTypeAllowListScannerBase.cs:line 37\r\n   at Submission#27.<<Initialize>>d__0.MoveNext()\r\n--- End of stack trace from previous location ---\r\n   at Microsoft.CodeAnalysis.Scripting.ScriptExecutionState.RunSubmissionsAsync[TResult](ImmutableArray`1 precedingExecutors, Func`2 currentExecutor, StrongBox`1 exceptionHolderOpt, Func`2 catchExceptionOpt, CancellationToken cancellationToken)"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        }
+      ]
     },
     {
       "cell_type": "markdown",
@@ -956,7 +1133,16 @@
         "\n",
         "Console.WriteLine(res);"
       ],
-      "outputs": []
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "(1 + Eval(\"foo\").Length)\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        }
+      ]
     },
     {
       "cell_type": "markdown",
@@ -988,7 +1174,16 @@
         "\n",
         "Console.WriteLine(res);"
       ],
-      "outputs": []
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "x => Abs((x + 1))\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        }
+      ]
     },
     {
       "cell_type": "markdown",
@@ -1018,7 +1213,16 @@
         "\n",
         "Console.WriteLine(fWithClosure);"
       ],
-      "outputs": []
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "x => Abs((x + value(Submission#30).y))\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        }
+      ]
     },
     {
       "cell_type": "markdown",
@@ -1038,7 +1242,16 @@
       "source": [
         "var res = memberScanner.Visit(fWithClosure);"
       ],
-      "outputs": []
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "System.NotSupportedException: Expression '__c0.y' uses 'int Submission#30.y' which is not allowed.\r\n   at System.Linq.CompilerServices.ExpressionMemberAllowListScannerBase.ResolveExpression[T](T expression, MemberInfo member, Func`2 visit) in D:\\Projects\\Reaqtive\\reaqtor\\Nuqleon\\Core\\LINQ\\Nuqleon.Linq.CompilerServices\\Expressions\\Analysis\\ExpressionMemberAllowListScannerBase.cs:line 156\r\n   at System.Linq.CompilerServices.ExpressionMemberAllowListScannerBase.CheckExpression[T](T expression, MemberInfo member, Func`2 visit) in D:\\Projects\\Reaqtive\\reaqtor\\Nuqleon\\Core\\LINQ\\Nuqleon.Linq.CompilerServices\\Expressions\\Analysis\\ExpressionMemberAllowListScannerBase.cs:line 96\r\n   at System.Linq.CompilerServices.ExpressionMemberAllowListScannerBase.VisitMember(MemberExpression node) in D:\\Projects\\Reaqtive\\reaqtor\\Nuqleon\\Core\\LINQ\\Nuqleon.Linq.CompilerServices\\Expressions\\Analysis\\ExpressionMemberAllowListScannerBase.cs:line 58\r\n   at System.Linq.Expressions.MemberExpression.Accept(ExpressionVisitor visitor)\r\n   at System.Linq.Expressions.ExpressionVisitor.VisitBinary(BinaryExpression node)\r\n   at System.Linq.CompilerServices.ExpressionMemberAllowListScannerBase.CheckExpression[T](T expression, MemberInfo member, Func`2 visit) in D:\\Projects\\Reaqtive\\reaqtor\\Nuqleon\\Core\\LINQ\\Nuqleon.Linq.CompilerServices\\Expressions\\Analysis\\ExpressionMemberAllowListScannerBase.cs:line 100\r\n   at System.Linq.CompilerServices.ExpressionMemberAllowListScannerBase.VisitBinary(BinaryExpression node) in D:\\Projects\\Reaqtive\\reaqtor\\Nuqleon\\Core\\LINQ\\Nuqleon.Linq.CompilerServices\\Expressions\\Analysis\\ExpressionMemberAllowListScannerBase.cs:line 30\r\n   at System.Linq.Expressions.BinaryExpression.Accept(ExpressionVisitor visitor)\r\n   at System.Dynamic.Utils.ExpressionVisitorUtils.VisitArguments(ExpressionVisitor visitor, IArgumentProvider nodes)\r\n   at System.Linq.Expressions.ExpressionVisitor.VisitMethodCall(MethodCallExpression node)\r\n   at System.Linq.CompilerServices.ExpressionMemberAllowListScannerBase.CheckExpression[T](T expression, MemberInfo member, Func`2 visit) in D:\\Projects\\Reaqtive\\reaqtor\\Nuqleon\\Core\\LINQ\\Nuqleon.Linq.CompilerServices\\Expressions\\Analysis\\ExpressionMemberAllowListScannerBase.cs:line 100\r\n   at System.Linq.CompilerServices.ExpressionMemberAllowListScannerBase.VisitMethodCall(MethodCallExpression node) in D:\\Projects\\Reaqtive\\reaqtor\\Nuqleon\\Core\\LINQ\\Nuqleon.Linq.CompilerServices\\Expressions\\Analysis\\ExpressionMemberAllowListScannerBase.cs:line 65\r\n   at System.Linq.Expressions.MethodCallExpression.Accept(ExpressionVisitor visitor)\r\n   at System.Linq.Expressions.ExpressionVisitor.VisitLambda[T](Expression`1 node)\r\n   at Submission#31.<<Initialize>>d__0.MoveNext()\r\n--- End of stack trace from previous location ---\r\n   at Microsoft.CodeAnalysis.Scripting.ScriptExecutionState.RunSubmissionsAsync[TResult](ImmutableArray`1 precedingExecutors, Func`2 currentExecutor, StrongBox`1 exceptionHolderOpt, Func`2 catchExceptionOpt, CancellationToken cancellationToken)"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        }
+      ]
     },
     {
       "cell_type": "markdown",
@@ -1073,7 +1286,16 @@
         "\n",
         "Console.WriteLine(res);"
       ],
-      "outputs": []
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "x => Abs((x + Eval(value(Submission#30).y)))\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        }
+      ]
     },
     {
       "cell_type": "markdown",
@@ -1099,7 +1321,16 @@
         "\n",
         "Console.WriteLine(reduced);"
       ],
-      "outputs": []
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "x => Abs((x + 1))\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        }
+      ]
     },
     {
       "cell_type": "markdown",
@@ -1146,7 +1377,24 @@
         "Console.WriteLine(ambiguousNames1);\n",
         "Console.WriteLine(ambiguousNames2);"
       ],
-      "outputs": []
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "x => x => x\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "x => x => x\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        }
+      ]
     },
     {
       "cell_type": "markdown",
@@ -1172,7 +1420,24 @@
         "Console.WriteLine(uniqueNames1);\n",
         "Console.WriteLine(uniqueNames2);"
       ],
-      "outputs": []
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "x => x0 => x0\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "x => x0 => x\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        }
+      ]
     },
     {
       "cell_type": "markdown",
@@ -1206,7 +1471,16 @@
         "\n",
         "Console.WriteLine(expr);"
       ],
-      "outputs": []
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "Invoke(x => (x + 1), 2)\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        }
+      ]
     },
     {
       "cell_type": "markdown",
@@ -1228,7 +1502,16 @@
         "\n",
         "Console.WriteLine(reduced);"
       ],
-      "outputs": []
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "(2 + 1)\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        }
+      ]
     },
     {
       "cell_type": "markdown",
@@ -1281,7 +1564,16 @@
         "\n",
         "Console.WriteLine(expr);"
       ],
-      "outputs": []
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "Invoke(abs, -2)\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        }
+      ]
     },
     {
       "cell_type": "markdown",
@@ -1310,7 +1602,16 @@
         "\n",
         "Console.WriteLine(string.Join(\", \", freeVars));"
       ],
-      "outputs": []
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "abs\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        }
+      ]
     },
     {
       "cell_type": "markdown",
@@ -1332,7 +1633,16 @@
         "\n",
         "Console.WriteLine(lambda);"
       ],
-      "outputs": []
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "abs => Invoke(abs, -2)\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        }
+      ]
     },
     {
       "cell_type": "markdown",
@@ -1354,7 +1664,16 @@
         "\n",
         "Console.WriteLine(bound);"
       ],
-      "outputs": []
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "Invoke(abs => Invoke(abs, -2), x => Abs(x))\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        }
+      ]
     },
     {
       "cell_type": "markdown",
@@ -1376,7 +1695,16 @@
       "source": [
         "Console.WriteLine(bound.Evaluate<double>());"
       ],
-      "outputs": []
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "2\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        }
+      ]
     },
     {
       "cell_type": "markdown",
@@ -1398,7 +1726,16 @@
         "\n",
         "Console.WriteLine(reduced);"
       ],
-      "outputs": []
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "Invoke(abs => Invoke(abs, -2), x => Abs(x))\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        }
+      ]
     },
     {
       "cell_type": "markdown",
@@ -1420,7 +1757,16 @@
         "\n",
         "Console.WriteLine(reduced);"
       ],
-      "outputs": []
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "Invoke(x => Abs(x), -2)\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        }
+      ]
     },
     {
       "cell_type": "markdown",
@@ -1461,7 +1807,16 @@
         "\n",
         "Console.WriteLine(reduced);"
       ],
-      "outputs": []
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "Abs(-2)\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        }
+      ]
     },
     {
       "cell_type": "markdown",
@@ -1594,7 +1949,16 @@
         "    Console.WriteLine(res);\n",
         "}"
       ],
-      "outputs": []
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "Invoke(sqrt, (Invoke(pow, 3, 2) + Invoke(pow, 4, 2)))\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        }
+      ]
     },
     {
       "cell_type": "markdown",
@@ -1626,7 +1990,16 @@
         "\n",
         "Console.WriteLine(res);"
       ],
-      "outputs": []
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "Sqrt((Pow(3, 2) + Pow(4, 2)))\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        }
+      ]
     },
     {
       "cell_type": "markdown",
@@ -1646,7 +2019,16 @@
       "source": [
         "Console.WriteLine(res.Evaluate<double>());"
       ],
-      "outputs": []
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "5\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        }
+      ]
     },
     {
       "cell_type": "markdown",
@@ -1677,7 +2059,24 @@
         "\n",
         "Console.WriteLine(simpler);"
       ],
-      "outputs": []
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "x => Invoke(f, x)\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "f\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        }
+      ]
     },
     {
       "cell_type": "markdown",
@@ -1704,7 +2103,16 @@
         "\n",
         "Console.WriteLine(res.Expression);"
       ],
-      "outputs": []
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "System.Int32[].Select(x => new <>f__AnonymousType0#51`2(x = x, y = (x + 1))).Select(<>h__TransparentIdentifier0 => new <>f__AnonymousType1#51`2(<>h__TransparentIdentifier0 = <>h__TransparentIdentifier0, z = (<>h__TransparentIdentifier0.y * 2))).Select(<>h__TransparentIdentifier1 => ((<>h__TransparentIdentifier1.<>h__TransparentIdentifier0.x + <>h__TransparentIdentifier1.<>h__TransparentIdentifier0.y) - <>h__TransparentIdentifier1.z))\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        }
+      ]
     },
     {
       "cell_type": "markdown",
@@ -1726,7 +2134,16 @@
         "\n",
         "Console.WriteLine(pretty);"
       ],
-      "outputs": []
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "System.Int32[].Select(x => new <>f__AnonymousType0#51`2(x = x, y = (x + 1))).Select(t => new <>f__AnonymousType1#51`2(<>h__TransparentIdentifier0 = t, z = (t.y * 2))).Select(t => ((t.<>h__TransparentIdentifier0.x + t.<>h__TransparentIdentifier0.y) - t.z))\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        }
+      ]
     },
     {
       "cell_type": "markdown",
@@ -1802,7 +2219,32 @@
         "Console.WriteLine(expr2);\n",
         "Console.WriteLine(expr3);"
       ],
-      "outputs": []
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "Range(1, 10).Where(x => ((x % 2) == 0)).Select(x => (x + 9))\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "Range(2, 20).Where(y => ((y % 3) == 1)).Select(y => (y + 8))\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "Range(3, 30).Where(z => ((z % 4) == 2)).Select(z => (z + 7))\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        }
+      ]
     },
     {
       "cell_type": "markdown",
@@ -1851,7 +2293,16 @@
       "source": [
         "Console.WriteLine(hoisted1.Expression);"
       ],
-      "outputs": []
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "Range(@p0, @p1).Where(x => ((x % @p2) == @p3)).Select(x => (x + @p4))\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        }
+      ]
     },
     {
       "cell_type": "markdown",
@@ -1878,7 +2329,16 @@
         "\n",
         "Console.WriteLine(sb);"
       ],
-      "outputs": []
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "  @p0 -> 1\r\n  @p1 -> 10\r\n  @p2 -> 2\r\n  @p3 -> 0\r\n  @p4 -> 9\r\n\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        }
+      ]
     },
     {
       "cell_type": "markdown",
@@ -1900,7 +2360,16 @@
         "\n",
         "Console.WriteLine(constantHoistedExpr);"
       ],
-      "outputs": []
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "(@p0, @p1, @p2, @p3, @p4) => Range(@p0, @p1).Where(x => ((x % @p2) == @p3)).Select(x => (x + @p4))\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        }
+      ]
     },
     {
       "cell_type": "markdown",
@@ -1922,7 +2391,16 @@
         "\n",
         "Console.WriteLine(reconstructedQueryExpr);"
       ],
-      "outputs": []
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "Invoke((@p0, @p1, @p2, @p3, @p4) => Range(@p0, @p1).Where(x => ((x % @p2) == @p3)).Select(x => (x + @p4)), 1, 10, 2, 0, 9)\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        }
+      ]
     },
     {
       "cell_type": "markdown",
@@ -2013,7 +2491,40 @@
         "Evaluate(expr2);\n",
         "Evaluate(expr3);"
       ],
-      "outputs": []
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "Compiling (@p0, @p1, @p2, @p3, @p4) => Range(@p0, @p1).Where(x => ((x % @p2) == @p3)).Select(x => (x + @p4))\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "Evaluating Invoke(value(System.Func`6[System.Int32,System.Int32,System.Int32,System.Int32,System.Int32,System.Collections.Generic.IEnumerable`1[System.Int32]]), 1, 10, 2, 0, 9) = System.Linq.Enumerable+WhereSelectEnumerableIterator`2[System.Int32,System.Int32]\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "Evaluating Invoke(value(System.Func`6[System.Int32,System.Int32,System.Int32,System.Int32,System.Int32,System.Collections.Generic.IEnumerable`1[System.Int32]]), 2, 20, 3, 1, 8) = System.Linq.Enumerable+WhereSelectEnumerableIterator`2[System.Int32,System.Int32]\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "Evaluating Invoke(value(System.Func`6[System.Int32,System.Int32,System.Int32,System.Int32,System.Int32,System.Collections.Generic.IEnumerable`1[System.Int32]]), 3, 30, 4, 2, 7) = System.Linq.Enumerable+WhereSelectEnumerableIterator`2[System.Int32,System.Int32]\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        }
+      ]
     },
     {
       "cell_type": "markdown",
@@ -2073,7 +2584,16 @@
         "\n",
         "Console.WriteLine(res.Expression);"
       ],
-      "outputs": []
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "() => Match(Format(\"{0}{1}\", @p0, @p1), \"[a-z]*\")\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        }
+      ]
     },
     {
       "cell_type": "markdown",
@@ -2113,7 +2633,16 @@
         "\n",
         "Console.WriteLine(rewritten);"
       ],
-      "outputs": []
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "() => DateTimeOffset.Now.AddDays(1)\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        }
+      ]
     },
     {
       "cell_type": "markdown",
@@ -2135,7 +2664,16 @@
         "\n",
         "subst.Apply(birthday);"
       ],
-      "outputs": []
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "System.InvalidOperationException: No suitable constructor on declaring type 'System.DateTimeOffset' with parameter types (System.Int32, System.Int32, System.Int32) found.\r\n   at System.Linq.CompilerServices.TypeSubstitutionExpressionVisitor.FailResolveConstructor(ConstructorInfo originalConstructor, Type declaringType, Type[] parameters) in D:\\Projects\\Reaqtive\\reaqtor\\Nuqleon\\Core\\LINQ\\Nuqleon.Linq.CompilerServices\\Expressions\\Rewriters\\TypeSystem\\TypeSubstitutionExpressionVisitor.cs:line 434\r\n   at System.Linq.CompilerServices.TypeSubstitutionExpressionVisitor.ResolveConstructor(ConstructorInfo originalConstructor, Type declaringType, Type[] parameters) in D:\\Projects\\Reaqtive\\reaqtor\\Nuqleon\\Core\\LINQ\\Nuqleon.Linq.CompilerServices\\Expressions\\Rewriters\\TypeSystem\\TypeSubstitutionExpressionVisitor.cs:line 416\r\n   at System.Linq.CompilerServices.TypeSubstitutionExpressionVisitor.VisitConstructor(ConstructorInfo constructor) in D:\\Projects\\Reaqtive\\reaqtor\\Nuqleon\\Core\\LINQ\\Nuqleon.Linq.CompilerServices\\Expressions\\Rewriters\\TypeSystem\\TypeSubstitutionExpressionVisitor.cs:line 164\r\n   at System.Linq.CompilerServices.ExpressionVisitorWithReflection.VisitNew(NewExpression node) in D:\\Projects\\Reaqtive\\reaqtor\\Nuqleon\\Core\\LINQ\\Nuqleon.Linq.CompilerServices\\Expressions\\Visitors\\ExpressionVisitorWithReflection.cs:line 965\r\n   at System.Linq.CompilerServices.TypeSubstitutionExpressionVisitor.Visit(Expression node) in D:\\Projects\\Reaqtive\\reaqtor\\Nuqleon\\Core\\LINQ\\Nuqleon.Linq.CompilerServices\\Expressions\\Rewriters\\TypeSystem\\TypeSubstitutionExpressionVisitor.cs:line 643\r\n   at System.Linq.CompilerServices.ExpressionVisitorWithReflection.VisitLambdaCore[T](Expression`1 node) in D:\\Projects\\Reaqtive\\reaqtor\\Nuqleon\\Core\\LINQ\\Nuqleon.Linq.CompilerServices\\Expressions\\Visitors\\ExpressionVisitorWithReflection.cs:line 615\r\n   at System.Linq.CompilerServices.ScopedExpressionVisitorBase.VisitLambda[T](Expression`1 node) in D:\\Projects\\Reaqtive\\reaqtor\\Nuqleon\\Core\\LINQ\\Nuqleon.Linq.CompilerServices\\Expressions\\Visitors\\ScopedExpressionVisitorBase.cs:line 166\r\n   at System.Linq.CompilerServices.TypeSubstitutionExpressionVisitor.Visit(Expression node) in D:\\Projects\\Reaqtive\\reaqtor\\Nuqleon\\Core\\LINQ\\Nuqleon.Linq.CompilerServices\\Expressions\\Rewriters\\TypeSystem\\TypeSubstitutionExpressionVisitor.cs:line 643\r\n   at System.Linq.CompilerServices.TypeSubstitutionExpressionVisitor.Apply(Expression expression) in D:\\Projects\\Reaqtive\\reaqtor\\Nuqleon\\Core\\LINQ\\Nuqleon.Linq.CompilerServices\\Expressions\\Rewriters\\TypeSystem\\TypeSubstitutionExpressionVisitor.cs:line 105\r\n   at Submission#70.<<Initialize>>d__0.MoveNext()\r\n--- End of stack trace from previous location ---\r\n   at Microsoft.CodeAnalysis.Scripting.ScriptExecutionState.RunSubmissionsAsync[TResult](ImmutableArray`1 precedingExecutors, Func`2 currentExecutor, StrongBox`1 exceptionHolderOpt, Func`2 catchExceptionOpt, CancellationToken cancellationToken)"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        }
+      ]
     },
     {
       "cell_type": "markdown",
@@ -2206,7 +2744,16 @@
         "\n",
         "Console.WriteLine(betterSubst.Apply(birthday));"
       ],
-      "outputs": []
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "() => new DateTimeOffset(new DateTime(1983, 2, 11))\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        }
+      ]
     },
     {
       "cell_type": "markdown",
@@ -2228,7 +2775,16 @@
         "\n",
         "Console.WriteLine(betterSubst.Apply(now));"
       ],
-      "outputs": []
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "System.InvalidOperationException: No suitable conversion of constant '02/28/2021 11:14:43' to type 'System.DateTimeOffset' found.\r\n   at System.Linq.CompilerServices.TypeSubstitutionExpressionVisitor.ConvertConstant(Object originalValue, Type newType) in D:\\Projects\\Reaqtive\\reaqtor\\Nuqleon\\Core\\LINQ\\Nuqleon.Linq.CompilerServices\\Expressions\\Rewriters\\TypeSystem\\TypeSubstitutionExpressionVisitor.cs:line 384\r\n   at System.Linq.CompilerServices.TypeSubstitutionExpressionVisitor.MakeConstant(Object value, Type type) in D:\\Projects\\Reaqtive\\reaqtor\\Nuqleon\\Core\\LINQ\\Nuqleon.Linq.CompilerServices\\Expressions\\Rewriters\\TypeSystem\\TypeSubstitutionExpressionVisitor.cs:line 673\r\n   at System.Linq.CompilerServices.ExpressionVisitorWithReflection.VisitConstant(ConstantExpression node) in D:\\Projects\\Reaqtive\\reaqtor\\Nuqleon\\Core\\LINQ\\Nuqleon.Linq.CompilerServices\\Expressions\\Visitors\\ExpressionVisitorWithReflection.cs:line 263\r\n   at System.Linq.CompilerServices.TypeSubstitutionExpressionVisitor.Visit(Expression node) in D:\\Projects\\Reaqtive\\reaqtor\\Nuqleon\\Core\\LINQ\\Nuqleon.Linq.CompilerServices\\Expressions\\Rewriters\\TypeSystem\\TypeSubstitutionExpressionVisitor.cs:line 643\r\n   at System.Linq.CompilerServices.TypeSubstitutionExpressionVisitor.Apply(Expression expression) in D:\\Projects\\Reaqtive\\reaqtor\\Nuqleon\\Core\\LINQ\\Nuqleon.Linq.CompilerServices\\Expressions\\Rewriters\\TypeSystem\\TypeSubstitutionExpressionVisitor.cs:line 105\r\n   at Submission#73.<<Initialize>>d__0.MoveNext()\r\n--- End of stack trace from previous location ---\r\n   at Microsoft.CodeAnalysis.Scripting.ScriptExecutionState.RunSubmissionsAsync[TResult](ImmutableArray`1 precedingExecutors, Func`2 currentExecutor, StrongBox`1 exceptionHolderOpt, Func`2 catchExceptionOpt, CancellationToken cancellationToken)"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        }
+      ]
     },
     {
       "cell_type": "markdown",
@@ -2281,7 +2837,16 @@
         "\n",
         "Console.WriteLine(evenBetterSubst.Apply(now));"
       ],
-      "outputs": []
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "2/28/2021 11:14:43 AM -08:00\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        }
+      ]
     },
     {
       "cell_type": "markdown",
@@ -2317,7 +2882,328 @@
         "    Console.WriteLine(Expression.Lambda(Expression.Constant(42), Enumerable.Range(1, i).Select(j => Expression.Parameter(typeof(int)))).Type);\n",
         "}"
       ],
-      "outputs": []
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "System.Action\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "System.Action`1[System.Int32]\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "System.Action`2[System.Int32,System.Int32]\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "System.Action`3[System.Int32,System.Int32,System.Int32]\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "System.Action`4[System.Int32,System.Int32,System.Int32,System.Int32]\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "System.Action`5[System.Int32,System.Int32,System.Int32,System.Int32,System.Int32]\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "System.Action`6[System.Int32,System.Int32,System.Int32,System.Int32,System.Int32,System.Int32]\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "System.Action`7[System.Int32,System.Int32,System.Int32,System.Int32,System.Int32,System.Int32,System.Int32]\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "System.Action`8[System.Int32,System.Int32,System.Int32,System.Int32,System.Int32,System.Int32,System.Int32,System.Int32]\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "System.Action`9[System.Int32,System.Int32,System.Int32,System.Int32,System.Int32,System.Int32,System.Int32,System.Int32,System.Int32]\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "System.Action`10[System.Int32,System.Int32,System.Int32,System.Int32,System.Int32,System.Int32,System.Int32,System.Int32,System.Int32,System.Int32]\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "System.Action`11[System.Int32,System.Int32,System.Int32,System.Int32,System.Int32,System.Int32,System.Int32,System.Int32,System.Int32,System.Int32,System.Int32]\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "System.Action`12[System.Int32,System.Int32,System.Int32,System.Int32,System.Int32,System.Int32,System.Int32,System.Int32,System.Int32,System.Int32,System.Int32,System.Int32]\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "System.Action`13[System.Int32,System.Int32,System.Int32,System.Int32,System.Int32,System.Int32,System.Int32,System.Int32,System.Int32,System.Int32,System.Int32,System.Int32,System.Int32]\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "System.Action`14[System.Int32,System.Int32,System.Int32,System.Int32,System.Int32,System.Int32,System.Int32,System.Int32,System.Int32,System.Int32,System.Int32,System.Int32,System.Int32,System.Int32]\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "System.Action`15[System.Int32,System.Int32,System.Int32,System.Int32,System.Int32,System.Int32,System.Int32,System.Int32,System.Int32,System.Int32,System.Int32,System.Int32,System.Int32,System.Int32,System.Int32]\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "System.Action`16[System.Int32,System.Int32,System.Int32,System.Int32,System.Int32,System.Int32,System.Int32,System.Int32,System.Int32,System.Int32,System.Int32,System.Int32,System.Int32,System.Int32,System.Int32,System.Int32]\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "Delegate18$1\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "Delegate19$2\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "Delegate20$3\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "System.Func`1[System.Int32]\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "System.Func`2[System.Int32,System.Int32]\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "System.Func`3[System.Int32,System.Int32,System.Int32]\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "System.Func`4[System.Int32,System.Int32,System.Int32,System.Int32]\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "System.Func`5[System.Int32,System.Int32,System.Int32,System.Int32,System.Int32]\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "System.Func`6[System.Int32,System.Int32,System.Int32,System.Int32,System.Int32,System.Int32]\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "System.Func`7[System.Int32,System.Int32,System.Int32,System.Int32,System.Int32,System.Int32,System.Int32]\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "System.Func`8[System.Int32,System.Int32,System.Int32,System.Int32,System.Int32,System.Int32,System.Int32,System.Int32]\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "System.Func`9[System.Int32,System.Int32,System.Int32,System.Int32,System.Int32,System.Int32,System.Int32,System.Int32,System.Int32]\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "System.Func`10[System.Int32,System.Int32,System.Int32,System.Int32,System.Int32,System.Int32,System.Int32,System.Int32,System.Int32,System.Int32]\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "System.Func`11[System.Int32,System.Int32,System.Int32,System.Int32,System.Int32,System.Int32,System.Int32,System.Int32,System.Int32,System.Int32,System.Int32]\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "System.Func`12[System.Int32,System.Int32,System.Int32,System.Int32,System.Int32,System.Int32,System.Int32,System.Int32,System.Int32,System.Int32,System.Int32,System.Int32]\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "System.Func`13[System.Int32,System.Int32,System.Int32,System.Int32,System.Int32,System.Int32,System.Int32,System.Int32,System.Int32,System.Int32,System.Int32,System.Int32,System.Int32]\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "System.Func`14[System.Int32,System.Int32,System.Int32,System.Int32,System.Int32,System.Int32,System.Int32,System.Int32,System.Int32,System.Int32,System.Int32,System.Int32,System.Int32,System.Int32]\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "System.Func`15[System.Int32,System.Int32,System.Int32,System.Int32,System.Int32,System.Int32,System.Int32,System.Int32,System.Int32,System.Int32,System.Int32,System.Int32,System.Int32,System.Int32,System.Int32]\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "System.Func`16[System.Int32,System.Int32,System.Int32,System.Int32,System.Int32,System.Int32,System.Int32,System.Int32,System.Int32,System.Int32,System.Int32,System.Int32,System.Int32,System.Int32,System.Int32,System.Int32]\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "System.Func`17[System.Int32,System.Int32,System.Int32,System.Int32,System.Int32,System.Int32,System.Int32,System.Int32,System.Int32,System.Int32,System.Int32,System.Int32,System.Int32,System.Int32,System.Int32,System.Int32,System.Int32]\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "Delegate18$4\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "Delegate19$5\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "Delegate20$6\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        }
+      ]
     },
     {
       "cell_type": "markdown",
@@ -2392,7 +3278,72 @@
         "    Console.WriteLine(sb);\n",
         "}"
       ],
-      "outputs": []
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "() => 42\r\n  Pack:   _ => 42\r\n  Unpack: () => 42\r\n\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "x => (x + 1)\r\n  Pack:   t => (t.Item1 + 1)\r\n  Unpack: p0 => (p0 + 1)\r\n\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "(x, y) => (x * y)\r\n  Pack:   t => (t.Item1 * t.Item2)\r\n  Unpack: (p0, p1) => (p0 * p1)\r\n\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "(x1, x2, x3, x4, x5, x6, x7, x8, x9, x10, x11, x12, x13, x14, x15, x16, x17, x18, x19, x20) => (((((((((((((((((((x1 + x2) + x3) + x4) + x5) + x6) + x7) + x8) + x9) + x10) + x11) + x12) + x13) + x14) + x15) + x16) + x17) + x18) + x19) + x20)\r\n  Pack:   t => (((((((((((((((((((t.Item1 + t.Item2) + t.Item3) + t.Item4) + t.Item5) + t.Item6) + t.Item7) + t.Rest.Item1) + t.Rest.Item2) + t.Rest.Item3) + t.Rest.Item4) + t.Rest.Item5) + t.Rest.Item6) + t.Rest.Item7) + t.Rest.Rest.Item1) + t.Rest.Rest.Item2) + t.Rest.Rest.Item3) + t.Rest.Rest.Item4) + t.Rest.Rest.Item5) + t.Rest.Rest.Item6)\r\n  Unpack: (p0, p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, p14, p15, p16, p17, p18, p19) => (((((((((((((((((((p0 + p1) + p2) + p3) + p4) + p5) + p6) + p7) + p8) + p9) + p10) + p11) + p12) + p13) + p14) + p15) + p16) + p17) + p18) + p19)\r\n\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "() => WriteLine(42)\r\n  Pack:   _ => WriteLine(42)\r\n  Unpack: () => WriteLine(42)\r\n\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "x => WriteLine((x + 1))\r\n  Pack:   t => WriteLine((t.Item1 + 1))\r\n  Unpack: p0 => WriteLine((p0 + 1))\r\n\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "(x, y) => WriteLine((x * y))\r\n  Pack:   t => WriteLine((t.Item1 * t.Item2))\r\n  Unpack: (p0, p1) => WriteLine((p0 * p1))\r\n\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "(x1, x2, x3, x4, x5, x6, x7, x8, x9, x10, x11, x12, x13, x14, x15, x16, x17, x18, x19, x20) => WriteLine((((((((((((((((((((x1 + x2) + x3) + x4) + x5) + x6) + x7) + x8) + x9) + x10) + x11) + x12) + x13) + x14) + x15) + x16) + x17) + x18) + x19) + x20))\r\n  Pack:   t => WriteLine((((((((((((((((((((t.Item1 + t.Item2) + t.Item3) + t.Item4) + t.Item5) + t.Item6) + t.Item7) + t.Rest.Item1) + t.Rest.Item2) + t.Rest.Item3) + t.Rest.Item4) + t.Rest.Item5) + t.Rest.Item6) + t.Rest.Item7) + t.Rest.Rest.Item1) + t.Rest.Rest.Item2) + t.Rest.Rest.Item3) + t.Rest.Rest.Item4) + t.Rest.Rest.Item5) + t.Rest.Rest.Item6))\r\n  Unpack: (p0, p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, p14, p15, p16, p17, p18, p19) => WriteLine((((((((((((((((((((p0 + p1) + p2) + p3) + p4) + p5) + p6) + p7) + p8) + p9) + p10) + p11) + p12) + p13) + p14) + p15) + p16) + p17) + p18) + p19))\r\n\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        }
+      ]
     },
     {
       "cell_type": "markdown",
@@ -2429,7 +3380,16 @@
         "\n",
         "Console.WriteLine(queryExpr);"
       ],
-      "outputs": []
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "System.Int32[].Select(x => new <>f__AnonymousType0#51`2(x = x, y = (x + 1))).Select(t => (t.x + t.y))\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        }
+      ]
     },
     {
       "cell_type": "markdown",
@@ -2451,7 +3411,16 @@
         "\n",
         "Console.WriteLine(tupletizedQueryExpr);"
       ],
-      "outputs": []
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "System.Int32[].Select(x => new Tuple`2(x, (x + 1))).Select(t => (t.Item1 + t.Item2))\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        }
+      ]
     },
     {
       "cell_type": "markdown",
@@ -2521,7 +3490,16 @@
         "\n",
         "Console.WriteLine(calcExpr);"
       ],
-      "outputs": []
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "() => Add(1, Add(2, 3))\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        }
+      ]
     },
     {
       "cell_type": "markdown",
@@ -2547,7 +3525,16 @@
         "\n",
         "Console.WriteLine(asyncExpr);"
       ],
-      "outputs": []
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "Add(2, 3, x0 => Add(1, x0, ret => WriteLine(ret)))\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        }
+      ]
     },
     {
       "cell_type": "markdown",
@@ -2567,7 +3554,16 @@
       "source": [
         "Expression.Lambda<Action>(asyncExpr).Compile()();"
       ],
-      "outputs": []
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "6\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        }
+      ]
     },
     {
       "cell_type": "markdown",
@@ -2619,7 +3615,16 @@
         "\n",
         "Console.WriteLine(calcExpr);"
       ],
-      "outputs": []
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "() => Add(1, Add(2, 3))\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        }
+      ]
     },
     {
       "cell_type": "markdown",
@@ -2645,7 +3650,16 @@
         "\n",
         "Console.WriteLine(continuation);"
       ],
-      "outputs": []
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "res => tcs.SetResult(res)\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        }
+      ]
     },
     {
       "cell_type": "markdown",
@@ -2669,7 +3683,16 @@
         "\n",
         "Console.WriteLine(asyncExpr);"
       ],
-      "outputs": []
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "Add(2, 3, x0 => Add(1, x0, res => tcs.SetResult(res)))\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        }
+      ]
     },
     {
       "cell_type": "markdown",
@@ -2702,7 +3725,16 @@
         "\n",
         "Console.WriteLine(calcAsync);"
       ],
-      "outputs": []
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "() => {var tcs; ... }\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        }
+      ]
     },
     {
       "cell_type": "markdown",
@@ -2724,7 +3756,16 @@
         "\n",
         "Console.WriteLine(t.Result); // This should take 2 seconds to complete due to the Task.Delay(1000) inside Add, which gets invoked twice."
       ],
-      "outputs": []
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "6\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        }
+      ]
     },
     {
       "cell_type": "markdown",
@@ -2854,7 +3895,24 @@
         "Console.WriteLine(await resSuccess);\n",
         "Console.WriteLine(await resError); // Will throw!"
       ],
-      "outputs": []
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "1\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "System.DivideByZeroException: Attempted to divide by zero.\r\n   at Submission#93.<<Initialize>>d__0.MoveNext()\r\n--- End of stack trace from previous location ---\r\n   at Microsoft.CodeAnalysis.Scripting.ScriptExecutionState.RunSubmissionsAsync[TResult](ImmutableArray`1 precedingExecutors, Func`2 currentExecutor, StrongBox`1 exceptionHolderOpt, Func`2 catchExceptionOpt, CancellationToken cancellationToken)"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        }
+      ]
     },
     {
       "cell_type": "markdown",
@@ -2882,7 +3940,16 @@
         "\n",
         "Console.WriteLine(x);"
       ],
-      "outputs": []
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "42\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        }
+      ]
     },
     {
       "cell_type": "markdown",
@@ -2906,7 +3973,16 @@
         "\n",
         "Console.WriteLine(x);"
       ],
-      "outputs": []
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "42\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        }
+      ]
     },
     {
       "cell_type": "markdown",
@@ -2939,7 +4015,16 @@
         "\n",
         "Console.WriteLine(eval);"
       ],
-      "outputs": []
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "() => 42\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        }
+      ]
     },
     {
       "cell_type": "markdown",
@@ -2961,7 +4046,16 @@
         "\n",
         "Console.WriteLine(answer);"
       ],
-      "outputs": []
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "42\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        }
+      ]
     },
     {
       "cell_type": "markdown",
@@ -3057,7 +4151,24 @@
         "Benchmark(\"Without caching\", () => expr.Compile(), 10_000);\n",
         "Benchmark(\"With caching\", () => expr.Compile(cache), 10_000);"
       ],
-      "outputs": []
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "Without caching completed in 1677 ms and allocated 49214568 bytes.\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "With caching completed in 246 ms and allocated 47700904 bytes.\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        }
+      ]
     },
     {
       "cell_type": "markdown",
@@ -3080,7 +4191,24 @@
         "Benchmark(\"Without caching\", () => expr.Compile()(\"foobar\"), 10_000);\n",
         "Benchmark(\"With caching\", () => expr.Compile(cache)(\"foobar\"), 10_000);"
       ],
-      "outputs": []
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "Without caching completed in 1881 ms and allocated 49280624 bytes.\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "With caching completed in 206 ms and allocated 48731968 bytes.\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        }
+      ]
     },
     {
       "cell_type": "markdown",
@@ -3140,7 +4268,24 @@
         "BenchmarkConcurrent(\"Without caching\", () => expr.Compile()(\"foobar\"), 10_000);\n",
         "BenchmarkConcurrent(\"With caching\", () => expr.Compile(cache)(\"foobar\"), 10_000);"
       ],
-      "outputs": []
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "Without caching completed in 470784 ms and allocated 607413072 bytes (using 12 threads).\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "With caching completed in 6037 ms and allocated 579592976 bytes (using 12 threads).\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        }
+      ]
     },
     {
       "cell_type": "markdown",
@@ -3228,7 +4373,24 @@
       "source": [
         "queryExpr1.Compile(cache);"
       ],
-      "outputs": []
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "Added t => x => (x > t.Item1) to cache.  Delegate = 1753183328\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "Added t => xs => xs.Where(t.Item1).Take(t.Item2) to cache.  Delegate = 153197105\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        }
+      ]
     },
     {
       "cell_type": "markdown",
@@ -3248,7 +4410,24 @@
       "source": [
         "queryExpr1.Compile(cache);"
       ],
-      "outputs": []
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "Retrieved t => x => (x > t.Item1) from cache. Delegate = 1753183328\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "Retrieved t => xs => xs.Where(t.Item1).Take(t.Item2) from cache. Delegate = 153197105\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        }
+      ]
     },
     {
       "cell_type": "markdown",
@@ -3268,7 +4447,24 @@
       "source": [
         "queryExpr2.Compile(cache);"
       ],
-      "outputs": []
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "Retrieved t => y => (y > t.Item1) from cache. Delegate = 1753183328\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "Added t => ys => ys.Take(t.Item1).Where(t.Item2) to cache.  Delegate = 896984621\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        }
+      ]
     },
     {
       "cell_type": "markdown",


### PR DESCRIPTION
First part of the notebook for `Nuqleon.Linq.CompilerServices`. More to follow in a future PR or extra iterations of the current PR, depending on time available.

One difference is an experiment with including the output of the notebook to see how it renders in GitHub. Seeing the output right here may be useful for users to learn about the various libraries without having to clone, build, and run through the notebooks (though, needless to say, it can be instructional to do so as well and experiment as one follows along).