### PR TITLE
Crank up log verbosity of SignClient.

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -238,7 +238,8 @@ stages:
               --secret "$(SignClientSecret)" `
               --name "Reaqtive" `
               --description "Reaqtive" `
-              --descriptionUrl "https://github.com/reaqtive/reaqtor"
+              --descriptionUrl "https://github.com/reaqtive/reaqtor" `
+              --logLevel "Verbose"
             displayName: Sign packages
 
           - publish: $(Pipeline.Workspace)/BuildPackages


### PR DESCRIPTION
Use https://github.com/dotnet/SignService/pull/352 to figure out potential issue with MSAL token caching. @clairernovotny