### PR TITLE
Save output of notebooks.

### DIFF
--- a/Nuqleon/Core/BCL/Nuqleon.Collections.Specialized/GettingStarted.ipynb
+++ b/Nuqleon/Core/BCL/Nuqleon.Collections.Specialized/GettingStarted.ipynb
@@ -143,7 +143,16 @@
         "\n",
         "Print();"
       ],
-      "outputs": []
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "000000000000000000000000\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        }
+      ]
     },
     {
       "cell_type": "markdown",
@@ -169,7 +178,24 @@
         "\n",
         "Print();"
       ],
-      "outputs": []
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "111111111111111111111111\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "000000000000000000000000\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        }
+      ]
     },
     {
       "cell_type": "markdown",
@@ -197,7 +223,16 @@
         "\n",
         "Print();"
       ],
-      "outputs": []
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "101010101010101010101010\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        }
+      ]
     },
     {
       "cell_type": "markdown",
@@ -285,7 +320,24 @@
         "    Console.WriteLine($\"{key} = {value}\");\n",
         "}"
       ],
-      "outputs": []
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "Bar = bar\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "Foo = foo\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        }
+      ]
     },
     {
       "cell_type": "markdown",
@@ -340,7 +392,24 @@
         "    Measure(\"BCL Dictionary\", () => new Dictionary<Setting, string>(), print);\n",
         "}"
       ],
-      "outputs": []
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "EnumDictionary - 288 bytes allocated\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "BCL Dictionary - 464 bytes allocated\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        }
+      ]
     }
   ],
   "metadata": {

--- a/Nuqleon/Core/BCL/Nuqleon.IO.StreamSegment/GettingStarted.ipynb
+++ b/Nuqleon/Core/BCL/Nuqleon.IO.StreamSegment/GettingStarted.ipynb
@@ -173,7 +173,16 @@
         "    Console.WriteLine(sb.ToString());\n",
         "}"
       ],
-      "outputs": []
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "07 00 00 00 02 03 05 0B 0D 11 13 03 00 00 00 17 1D 1F \r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        }
+      ]
     },
     {
       "cell_type": "markdown",
@@ -242,7 +251,24 @@
         "    Console.WriteLine(string.Join(\", \", chunk));\n",
         "}"
       ],
-      "outputs": []
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "2, 3, 5, 11, 13, 17, 19\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "23, 29, 31\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        }
+      ]
     }
   ],
   "metadata": {

--- a/Nuqleon/Core/BCL/Nuqleon.Memory/GettingStarted.ipynb
+++ b/Nuqleon/Core/BCL/Nuqleon.Memory/GettingStarted.ipynb
@@ -194,7 +194,16 @@
         "PrintDebugView();\n",
         ""
       ],
-      "outputs": []
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "System.Collections.Generic.StackPool`1+Impl0[System.Int32] : ObjectPoolBase<System.Collections.Generic.PooledStack`1[System.Int32]>\r\n===================================================================================================================================\r\n\r\nCreation trace\r\n--------------\r\n\r\n21/03/04 16:58:31.3985714 [00:00:01.6164524 ago] @ ~13 () in 1 (Microsoft.DotNet.Interactive.App)\r\n   at System.Memory.ObjectPoolBase`1..ctor(Int32 size)\r\n   at System.Collections.Generic.StackPool`1..ctor(Int32 size)\r\n   at System.Collections.Generic.StackPool`1.Impl0..ctor(Int32 size)\r\n   at System.Collections.Generic.StackPool`1.Create(Int32 size)\r\n   at <Notebook>\r\n\r\n\r\nStatistics\r\n----------\r\n\r\n  # slots:   8\r\n  # standby: 0\r\n  # allocs:  0\r\n  # frees:   0\r\n  # create:  0\r\n  # drops:   0\r\n\r\n\r\nPool entries\r\n------------\r\n\r\n  [0] = <empty>\r\n  [1] = <empty>\r\n  [2] = <empty>\r\n  [3] = <empty>\r\n  [4] = <empty>\r\n  [5] = <empty>\r\n  [6] = <empty>\r\n  [7] = <empty>\r\n\r\n\r\nTracked objects\r\n---------------\r\n\r\n\r\n\r\n\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        }
+      ]
     },
     {
       "cell_type": "markdown",
@@ -228,7 +237,16 @@
         "    pool.Free(stack);\n",
         "}"
       ],
-      "outputs": []
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "System.Collections.Generic.StackPool`1+Impl0[System.Int32] : ObjectPoolBase<System.Collections.Generic.PooledStack`1[System.Int32]>\r\n===================================================================================================================================\r\n\r\nCreation trace\r\n--------------\r\n\r\n21/03/04 16:58:31.3985714 [00:00:08.3823493 ago] @ ~13 () in 1 (Microsoft.DotNet.Interactive.App)\r\n   at System.Memory.ObjectPoolBase`1..ctor(Int32 size)\r\n   at System.Collections.Generic.StackPool`1..ctor(Int32 size)\r\n   at System.Collections.Generic.StackPool`1.Impl0..ctor(Int32 size)\r\n   at System.Collections.Generic.StackPool`1.Create(Int32 size)\r\n   at <Notebook>\r\n\r\n\r\nStatistics\r\n----------\r\n\r\n  # slots:   8\r\n  # standby: 0\r\n  # allocs:  1\r\n  # frees:   0\r\n  # create:  1\r\n  # drops:   0\r\n\r\n\r\nPool entries\r\n------------\r\n\r\n  [0] = <empty>\r\n  [1] = <empty>\r\n  [2] = <empty>\r\n  [3] = <empty>\r\n  [4] = <empty>\r\n  [5] = <empty>\r\n  [6] = <empty>\r\n  [7] = <empty>\r\n\r\n\r\nTracked objects\r\n---------------\r\n\r\n  #1 - checked out\r\n  \r\n    Stats\r\n    ~~~~~\r\n\r\n      Usage count =  0\r\n      \r\n    History\r\n    ~~~~~~~\r\n\r\n      Alloc - 21/03/04 16:58:39.7808835 [00:00:00.0080656 ago] @ ~4 () in 1 (Microsoft.DotNet.Interactive.App)\r\n         at System.Memory.ObjectPoolBase`1.Allocate()\r\n         at <Notebook>\r\n      \r\n\r\n\r\n\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        }
+      ]
     },
     {
       "cell_type": "markdown",
@@ -248,7 +266,16 @@
       "source": [
         "PrintDebugView();"
       ],
-      "outputs": []
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "System.Collections.Generic.StackPool`1+Impl0[System.Int32] : ObjectPoolBase<System.Collections.Generic.PooledStack`1[System.Int32]>\r\n===================================================================================================================================\r\n\r\nCreation trace\r\n--------------\r\n\r\n21/03/04 16:58:31.3985714 [00:00:15.1071969 ago] @ ~13 () in 1 (Microsoft.DotNet.Interactive.App)\r\n   at System.Memory.ObjectPoolBase`1..ctor(Int32 size)\r\n   at System.Collections.Generic.StackPool`1..ctor(Int32 size)\r\n   at System.Collections.Generic.StackPool`1.Impl0..ctor(Int32 size)\r\n   at System.Collections.Generic.StackPool`1.Create(Int32 size)\r\n   at <Notebook>\r\n\r\n\r\nStatistics\r\n----------\r\n\r\n  # slots:   8\r\n  # standby: 1\r\n  # allocs:  1\r\n  # frees:   1\r\n  # create:  1\r\n  # drops:   0\r\n\r\n  avg use time: 00:00:00.0101310\r\n  max use time: 00:00:00.0101310\r\n\r\n\r\nPool entries\r\n------------\r\n\r\n  [0] = #1\r\n  [1] = <empty>\r\n  [2] = <empty>\r\n  [3] = <empty>\r\n  [4] = <empty>\r\n  [5] = <empty>\r\n  [6] = <empty>\r\n  [7] = <empty>\r\n\r\n\r\nTracked objects\r\n---------------\r\n\r\n  #1 - standby\r\n  \r\n    Stats\r\n    ~~~~~\r\n\r\n      Usage count =  1\r\n      Max use time = 00:00:00.0101310\r\n      Avg use time = 00:00:00.0101310\r\n      \r\n    History\r\n    ~~~~~~~\r\n\r\n      Free  - 21/03/04 16:58:39.7910145 [00:00:06.7154508 ago] @ ~4 () in 1 (Microsoft.DotNet.Interactive.App)\r\n         at System.Memory.ObjectPoolBase`1.Free(T obj)\r\n         at <Notebook>\r\n      Alloc - 21/03/04 16:58:39.7808835 [00:00:06.7261028 ago] @ ~4 () in 1 (Microsoft.DotNet.Interactive.App)\r\n         at System.Memory.ObjectPoolBase`1.Allocate()\r\n         at <Notebook>\r\n      \r\n\r\n\r\n\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        }
+      ]
     },
     {
       "cell_type": "markdown",
@@ -278,7 +305,16 @@
         "    s.Push(1);\n",
         "}"
       ],
-      "outputs": []
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "System.Collections.Generic.StackPool`1+Impl0[System.Int32] : ObjectPoolBase<System.Collections.Generic.PooledStack`1[System.Int32]>\r\n===================================================================================================================================\r\n\r\nCreation trace\r\n--------------\r\n\r\n21/03/04 16:58:31.3985714 [00:00:24.0868703 ago] @ ~13 () in 1 (Microsoft.DotNet.Interactive.App)\r\n   at System.Memory.ObjectPoolBase`1..ctor(Int32 size)\r\n   at System.Collections.Generic.StackPool`1..ctor(Int32 size)\r\n   at System.Collections.Generic.StackPool`1.Impl0..ctor(Int32 size)\r\n   at System.Collections.Generic.StackPool`1.Create(Int32 size)\r\n   at <Notebook>\r\n\r\n\r\nStatistics\r\n----------\r\n\r\n  # slots:   8\r\n  # standby: 0\r\n  # allocs:  2\r\n  # frees:   1\r\n  # create:  1\r\n  # drops:   0\r\n\r\n  avg use time: 00:00:00.0101310\r\n  max use time: 00:00:00.0101310\r\n\r\n\r\nPool entries\r\n------------\r\n\r\n  [0] = <empty>\r\n  [1] = <empty>\r\n  [2] = <empty>\r\n  [3] = <empty>\r\n  [4] = <empty>\r\n  [5] = <empty>\r\n  [6] = <empty>\r\n  [7] = <empty>\r\n\r\n\r\nTracked objects\r\n---------------\r\n\r\n  #1 - checked out\r\n  \r\n    Stats\r\n    ~~~~~\r\n\r\n      Usage count =  1\r\n      Max use time = 00:00:00.0101310\r\n      Avg use time = 00:00:00.0101310\r\n      \r\n    History\r\n    ~~~~~~~\r\n\r\n      Alloc - 21/03/04 16:58:55.4852846 [00:00:00.0009111 ago] @ ~13 () in 1 (Microsoft.DotNet.Interactive.App)\r\n         at System.Collections.Generic.StackPool`1.<>c.<New>b__9_0(ObjectPoolBase`1 p)\r\n         at System.Memory.PooledObject`1..ctor(ObjectPoolBase`1 pool, Func`2 allocator, Action`2 releaser)\r\n         at System.Collections.Generic.StackPool`1.New()\r\n         at <Notebook>\r\n      Free  - 21/03/04 16:58:39.7910145 [00:00:15.6958579 ago] @ ~4 () in 1 (Microsoft.DotNet.Interactive.App)\r\n         at System.Memory.ObjectPoolBase`1.Free(T obj)\r\n         at <Notebook>\r\n      Alloc - 21/03/04 16:58:39.7808835 [00:00:15.7065729 ago] @ ~4 () in 1 (Microsoft.DotNet.Interactive.App)\r\n         at System.Memory.ObjectPoolBase`1.Allocate()\r\n         at <Notebook>\r\n      \r\n\r\n\r\n\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        }
+      ]
     },
     {
       "cell_type": "markdown",
@@ -298,7 +334,16 @@
       "source": [
         "PrintDebugView();"
       ],
-      "outputs": []
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "System.Collections.Generic.StackPool`1+Impl0[System.Int32] : ObjectPoolBase<System.Collections.Generic.PooledStack`1[System.Int32]>\r\n===================================================================================================================================\r\n\r\nCreation trace\r\n--------------\r\n\r\n21/03/04 16:58:31.3985714 [00:00:28.0115706 ago] @ ~13 () in 1 (Microsoft.DotNet.Interactive.App)\r\n   at System.Memory.ObjectPoolBase`1..ctor(Int32 size)\r\n   at System.Collections.Generic.StackPool`1..ctor(Int32 size)\r\n   at System.Collections.Generic.StackPool`1.Impl0..ctor(Int32 size)\r\n   at System.Collections.Generic.StackPool`1.Create(Int32 size)\r\n   at <Notebook>\r\n\r\n\r\nStatistics\r\n----------\r\n\r\n  # slots:   8\r\n  # standby: 1\r\n  # allocs:  2\r\n  # frees:   2\r\n  # create:  1\r\n  # drops:   0\r\n\r\n  avg use time: 00:00:00.0078948\r\n  max use time: 00:00:00.0101310\r\n\r\n\r\nPool entries\r\n------------\r\n\r\n  [0] = #1\r\n  [1] = <empty>\r\n  [2] = <empty>\r\n  [3] = <empty>\r\n  [4] = <empty>\r\n  [5] = <empty>\r\n  [6] = <empty>\r\n  [7] = <empty>\r\n\r\n\r\nTracked objects\r\n---------------\r\n\r\n  #1 - standby\r\n  \r\n    Stats\r\n    ~~~~~\r\n\r\n      Usage count =  2\r\n      Max use time = 00:00:00.0101310\r\n      Avg use time = 00:00:00.0078948\r\n      \r\n    History\r\n    ~~~~~~~\r\n\r\n      Free  - 21/03/04 16:58:55.4909432 [00:00:03.9198422 ago] @ ~13 () in 1 (Microsoft.DotNet.Interactive.App)\r\n         at System.Collections.Generic.PooledStack`1.Free()\r\n         at System.Collections.Generic.StackPool`1.<>c.<New>b__9_1(ObjectPoolBase`1 _, PooledStack`1 o)\r\n         at System.Memory.PooledObject`1.Dispose()\r\n         at System.Collections.Generic.PooledStackHolder`1.Dispose()\r\n         at <Notebook>\r\n      Alloc - 21/03/04 16:58:55.4852846 [00:00:03.9259521 ago] @ ~13 () in 1 (Microsoft.DotNet.Interactive.App)\r\n         at System.Collections.Generic.StackPool`1.<>c.<New>b__9_0(ObjectPoolBase`1 p)\r\n         at System.Memory.PooledObject`1..ctor(ObjectPoolBase`1 pool, Func`2 allocator, Action`2 releaser)\r\n         at System.Collections.Generic.StackPool`1.New()\r\n         at <Notebook>\r\n      Free  - 21/03/04 16:58:39.7910145 [00:00:19.6206436 ago] @ ~4 () in 1 (Microsoft.DotNet.Interactive.App)\r\n         at System.Memory.ObjectPoolBase`1.Free(T obj)\r\n         at <Notebook>\r\n      Alloc - 21/03/04 16:58:39.7808835 [00:00:19.6311978 ago] @ ~4 () in 1 (Microsoft.DotNet.Interactive.App)\r\n         at System.Memory.ObjectPoolBase`1.Allocate()\r\n         at <Notebook>\r\n      \r\n\r\n\r\n\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        }
+      ]
     },
     {
       "cell_type": "markdown",
@@ -396,7 +441,24 @@
         "\n",
         "Console.WriteLine(myObj1);"
       ],
-      "outputs": []
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "Allocated a new MyObject instance. Hash code = 12239935\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "42, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        }
+      ]
     },
     {
       "cell_type": "markdown",
@@ -423,7 +485,24 @@
         "    Console.WriteLine(myObj2.Object);\n",
         "}"
       ],
-      "outputs": []
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "Allocated a new MyObject instance. Hash code = 31965818\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "43, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        }
+      ]
     },
     {
       "cell_type": "markdown",
@@ -450,7 +529,24 @@
         "    Console.WriteLine(myObj3.Object);\n",
         "}"
       ],
-      "outputs": []
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "Hash code = 31965818\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "43, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        }
+      ]
     },
     {
       "cell_type": "markdown",
@@ -508,7 +604,72 @@
         "    Console.WriteLine($\"objs[{i}].GetHashCode() = {objs[i].GetHashCode()}\");\n",
         "}"
       ],
-      "outputs": []
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "objs[0].GetHashCode() = 31965818\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "objs[1].GetHashCode() = 12239935\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "Allocated a new MyObject instance. Hash code = 45407009\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "objs[2].GetHashCode() = 45407009\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "Allocated a new MyObject instance. Hash code = 46471022\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "objs[3].GetHashCode() = 46471022\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "Allocated a new MyObject instance. Hash code = 46242629\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "objs[4].GetHashCode() = 46242629\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        }
+      ]
     },
     {
       "cell_type": "markdown",
@@ -558,7 +719,56 @@
         "    Console.WriteLine($\"objs[{i}].GetHashCode() = {objs[i].GetHashCode()}\");\n",
         "}"
       ],
-      "outputs": []
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "objs[0].GetHashCode() = 31965818\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "objs[1].GetHashCode() = 12239935\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "objs[2].GetHashCode() = 45407009\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "objs[3].GetHashCode() = 46471022\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "Allocated a new MyObject instance. Hash code = 45672827\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "objs[4].GetHashCode() = 45672827\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        }
+      ]
     },
     {
       "cell_type": "markdown",
@@ -657,7 +867,64 @@
         "    Console.WriteLine($\"obj#{obj.Object.GetHashCode()} = {obj.Object}\");\n",
         "}"
       ],
-      "outputs": []
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "First usage of the object\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "Allocated a new MyObject instance. Hash code = 39493100\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "obj#39493100 = 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "obj#39493100 = 42, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "Second usage of the object\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "obj#39493100 = 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "obj#39493100 = 42, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        }
+      ]
     },
     {
       "cell_type": "markdown",
@@ -750,7 +1017,368 @@
         "\n",
         "PrintFibonacci(100, TimeSpan.FromSeconds(5));"
       ],
-      "outputs": []
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "fib(0) = 1 - Took 00:00:00.0000998\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "fib(1) = 1 - Took 00:00:00.0000002\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "fib(2) = 2 - Took 00:00:00.0000001\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "fib(3) = 3 - Took 00:00:00.0000004\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "fib(4) = 5 - Took 00:00:00.0000001\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "fib(5) = 8 - Took 00:00:00.0000002\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "fib(6) = 13 - Took 00:00:00.0000002\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "fib(7) = 21 - Took 00:00:00.0000002\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "fib(8) = 34 - Took 00:00:00.0000003\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "fib(9) = 55 - Took 00:00:00.0000005\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "fib(10) = 89 - Took 00:00:00.0000008\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "fib(11) = 144 - Took 00:00:00.0000012\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "fib(12) = 233 - Took 00:00:00.0000019\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "fib(13) = 377 - Took 00:00:00.0000030\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "fib(14) = 610 - Took 00:00:00.0000048\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "fib(15) = 987 - Took 00:00:00.0000076\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "fib(16) = 1597 - Took 00:00:00.0000123\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "fib(17) = 2584 - Took 00:00:00.0000200\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "fib(18) = 4181 - Took 00:00:00.0000323\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "fib(19) = 6765 - Took 00:00:00.0000521\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "fib(20) = 10946 - Took 00:00:00.0000843\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "fib(21) = 17711 - Took 00:00:00.0001366\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "fib(22) = 28657 - Took 00:00:00.0002287\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "fib(23) = 46368 - Took 00:00:00.0003679\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "fib(24) = 75025 - Took 00:00:00.0005690\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "fib(25) = 121393 - Took 00:00:00.0009238\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "fib(26) = 196418 - Took 00:00:00.0015070\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "fib(27) = 317811 - Took 00:00:00.0023645\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "fib(28) = 514229 - Took 00:00:00.0037919\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "fib(29) = 832040 - Took 00:00:00.0066606\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "fib(30) = 1346269 - Took 00:00:00.0184343\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "fib(31) = 2178309 - Took 00:00:00.0170979\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "fib(32) = 3524578 - Took 00:00:00.0252016\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "fib(33) = 5702887 - Took 00:00:00.0422791\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "fib(34) = 9227465 - Took 00:00:00.0661603\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "fib(35) = 14930352 - Took 00:00:00.1092889\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "fib(36) = 24157817 - Took 00:00:00.1707919\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "fib(37) = 39088169 - Took 00:00:00.2902803\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "fib(38) = 63245986 - Took 00:00:00.4512719\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "fib(39) = 102334155 - Took 00:00:00.7811258\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "fib(40) = 165580141 - Took 00:00:01.3919132\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "fib(41) = 267914296 - Took 00:00:02.1608034\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "fib(42) = 433494437 - Took 00:00:03.1233396\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "fib(43) = 701408733 - Took 00:00:05.2934294\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "Aborted at iteration 43. This is starting to take too long.\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        }
+      ]
     },
     {
       "cell_type": "markdown",
@@ -829,7 +1457,752 @@
         "// Now we should get much further along.\n",
         "PrintFibonacci(100, TimeSpan.FromSeconds(5));"
       ],
-      "outputs": []
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "fib(0) = 1 - Took 00:00:00.0036124\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "fib(1) = 1 - Took 00:00:00.0000302\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "fib(2) = 2 - Took 00:00:00.0001916\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "fib(3) = 3 - Took 00:00:00.0006244\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "fib(4) = 5 - Took 00:00:00.0000033\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "fib(5) = 8 - Took 00:00:00.0000008\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "fib(6) = 13 - Took 00:00:00.0000004\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "fib(7) = 21 - Took 00:00:00.0000011\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "fib(8) = 34 - Took 00:00:00.0000004\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "fib(9) = 55 - Took 00:00:00.0000004\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "fib(10) = 89 - Took 00:00:00.0000004\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "fib(11) = 144 - Took 00:00:00.0000004\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "fib(12) = 233 - Took 00:00:00.0000003\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "fib(13) = 377 - Took 00:00:00.0000003\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "fib(14) = 610 - Took 00:00:00.0000004\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "fib(15) = 987 - Took 00:00:00.0000003\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "fib(16) = 1597 - Took 00:00:00.0000005\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "fib(17) = 2584 - Took 00:00:00.0000008\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "fib(18) = 4181 - Took 00:00:00.0000005\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "fib(19) = 6765 - Took 00:00:00.0000009\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "fib(20) = 10946 - Took 00:00:00.0000004\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "fib(21) = 17711 - Took 00:00:00.0000018\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "fib(22) = 28657 - Took 00:00:00.0000005\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "fib(23) = 46368 - Took 00:00:00.0000004\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "fib(24) = 75025 - Took 00:00:00.0000004\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "fib(25) = 121393 - Took 00:00:00.0000003\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "fib(26) = 196418 - Took 00:00:00.0000004\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "fib(27) = 317811 - Took 00:00:00.0000004\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "fib(28) = 514229 - Took 00:00:00.0000003\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "fib(29) = 832040 - Took 00:00:00.0000003\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "fib(30) = 1346269 - Took 00:00:00.0000004\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "fib(31) = 2178309 - Took 00:00:00.0000004\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "fib(32) = 3524578 - Took 00:00:00.0000003\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "fib(33) = 5702887 - Took 00:00:00.0000005\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "fib(34) = 9227465 - Took 00:00:00.0000003\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "fib(35) = 14930352 - Took 00:00:00.0000003\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "fib(36) = 24157817 - Took 00:00:00.0000004\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "fib(37) = 39088169 - Took 00:00:00.0000029\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "fib(38) = 63245986 - Took 00:00:00.0000004\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "fib(39) = 102334155 - Took 00:00:00.0000003\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "fib(40) = 165580141 - Took 00:00:00.0000004\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "fib(41) = 267914296 - Took 00:00:00.0000004\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "fib(42) = 433494437 - Took 00:00:00.0000004\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "fib(43) = 701408733 - Took 00:00:00.0000003\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "fib(44) = 1134903170 - Took 00:00:00.0000003\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "fib(45) = 1836311903 - Took 00:00:00.0000004\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "fib(46) = 2971215073 - Took 00:00:00.0000003\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "fib(47) = 4807526976 - Took 00:00:00.0000004\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "fib(48) = 7778742049 - Took 00:00:00.0000004\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "fib(49) = 12586269025 - Took 00:00:00.0000004\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "fib(50) = 20365011074 - Took 00:00:00.0000008\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "fib(51) = 32951280099 - Took 00:00:00.0000003\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "fib(52) = 53316291173 - Took 00:00:00.0000004\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "fib(53) = 86267571272 - Took 00:00:00.0000003\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "fib(54) = 139583862445 - Took 00:00:00.0000004\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "fib(55) = 225851433717 - Took 00:00:00.0000004\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "fib(56) = 365435296162 - Took 00:00:00.0000003\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "fib(57) = 591286729879 - Took 00:00:00.0000003\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "fib(58) = 956722026041 - Took 00:00:00.0000004\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "fib(59) = 1548008755920 - Took 00:00:00.0000004\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "fib(60) = 2504730781961 - Took 00:00:00.0000004\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "fib(61) = 4052739537881 - Took 00:00:00.0000003\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "fib(62) = 6557470319842 - Took 00:00:00.0000003\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "fib(63) = 10610209857723 - Took 00:00:00.0000004\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "fib(64) = 17167680177565 - Took 00:00:00.0000003\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "fib(65) = 27777890035288 - Took 00:00:00.0000004\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "fib(66) = 44945570212853 - Took 00:00:00.0000004\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "fib(67) = 72723460248141 - Took 00:00:00.0000003\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "fib(68) = 117669030460994 - Took 00:00:00.0000003\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "fib(69) = 190392490709135 - Took 00:00:00.0000003\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "fib(70) = 308061521170129 - Took 00:00:00.0000006\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "fib(71) = 498454011879264 - Took 00:00:00.0000003\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "fib(72) = 806515533049393 - Took 00:00:00.0000003\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "fib(73) = 1304969544928657 - Took 00:00:00.0000004\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "fib(74) = 2111485077978050 - Took 00:00:00.0000004\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "fib(75) = 3416454622906707 - Took 00:00:00.0000010\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "fib(76) = 5527939700884757 - Took 00:00:00.0000003\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "fib(77) = 8944394323791464 - Took 00:00:00.0000004\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "fib(78) = 14472334024676221 - Took 00:00:00.0000004\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "fib(79) = 23416728348467685 - Took 00:00:00.0000003\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "fib(80) = 37889062373143906 - Took 00:00:00.0000005\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "fib(81) = 61305790721611591 - Took 00:00:00.0000004\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "fib(82) = 99194853094755497 - Took 00:00:00.0000003\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "fib(83) = 160500643816367088 - Took 00:00:00.0000003\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "fib(84) = 259695496911122585 - Took 00:00:00.0000003\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "fib(85) = 420196140727489673 - Took 00:00:00.0000003\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "fib(86) = 679891637638612258 - Took 00:00:00.0000003\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "fib(87) = 1100087778366101931 - Took 00:00:00.0000003\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "fib(88) = 1779979416004714189 - Took 00:00:00.0000003\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "fib(89) = 2880067194370816120 - Took 00:00:00.0000088\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "fib(90) = 4660046610375530309 - Took 00:00:00.0000004\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "fib(91) = 7540113804746346429 - Took 00:00:00.0000004\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "fib(92) = Overflow\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        }
+      ]
     },
     {
       "cell_type": "markdown",
@@ -849,7 +2222,16 @@
       "source": [
         "cache.DebugView"
       ],
-      "outputs": []
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "Number of entries = 92\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        }
+      ]
     },
     {
       "cell_type": "markdown",
@@ -873,7 +2255,16 @@
         "\n",
         "cache.DebugView"
       ],
-      "outputs": []
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "Number of entries = 0\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        }
+      ]
     },
     {
       "cell_type": "markdown",
@@ -923,7 +2314,24 @@
         "var sw = Stopwatch.StartNew();\n",
         "Console.WriteLine($\"GetRadius(3, 4) = {GetRadius(3, 4)} in {sw.Elapsed}\");"
       ],
-      "outputs": []
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "GetRadius(3, 4) was called\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "GetRadius(3, 4) = 5 in 00:00:01.0052418\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        }
+      ]
     },
     {
       "cell_type": "markdown",
@@ -995,7 +2403,32 @@
         "sw.Restart();\n",
         "Console.WriteLine($\"GetRadius(3, 4) = {getRadiusMemoized.Delegate(3, 4)} in {sw.Elapsed}\");"
       ],
-      "outputs": []
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "GetRadius(3, 4) was called\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "GetRadius(3, 4) = 5 in 00:00:01.0102280\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "GetRadius(3, 4) = 5 in 00:00:00.0003059\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        }
+      ]
     },
     {
       "cell_type": "markdown",
@@ -1023,7 +2456,40 @@
         "sw.Restart();\n",
         "Console.WriteLine($\"GetRadius(3, 4) = {getRadiusMemoized.Delegate(3, 4)} in {sw.Elapsed}\");"
       ],
-      "outputs": []
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "Entries\r\n-------\r\n\r\n  (3, 4) -> 5\r\n    Invoke duration     = 00:00:01.0013880\r\n    Hit count           = 2\r\n    Average access time = 00:00:00.5047844\r\n    Speed up factor     = 1.9837934769774976\r\n\r\nSummary\r\n-------\r\n\r\n  Invocation count = 1\r\n  Access count     = 2\r\n  Eviction count   = 0\r\n\r\n\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "GetRadius(3, 4) was called\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "GetRadius(3, 4) = 5 in 00:00:01.0153758\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "GetRadius(3, 4) = 5 in 00:00:00.0000438\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        }
+      ]
     },
     {
       "cell_type": "markdown",
@@ -1056,7 +2522,80 @@
         "\n",
         "Console.WriteLine(getRadiusMemoized.Cache.DebugView);"
       ],
-      "outputs": []
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "GetRadius(1, 2) was called\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "GetRadius(1, 2) = 2.23606797749979 in 00:00:01.0120257\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "GetRadius(2, 3) was called\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "GetRadius(2, 3) = 3.605551275463989 in 00:00:01.0046993\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "GetRadius(3, 4) = 5 in 00:00:00.0000081\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "GetRadius(1, 2) = 2.23606797749979 in 00:00:00.0000033\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "GetRadius(2, 3) = 3.605551275463989 in 00:00:00.0000029\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "GetRadius(3, 4) = 5 in 00:00:00.0000023\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "Entries\r\n-------\r\n\r\n  (3, 4) -> 5\r\n    Invoke duration     = 00:00:01.0152318\r\n    Hit count           = 4\r\n    Average access time = 00:00:00.2538540\r\n    Speed up factor     = 3.999274386064431\r\n\r\n  (2, 3) -> 3.605551275463989\r\n    Invoke duration     = 00:00:01.0046303\r\n    Hit count           = 2\r\n    Average access time = 00:00:00.5023476\r\n    Speed up factor     = 1.9998708065889037\r\n\r\n  (1, 2) -> 2.23606797749979\r\n    Invoke duration     = 00:00:01.0119472\r\n    Hit count           = 2\r\n    Average access time = 00:00:00.5060107\r\n    Speed up factor     = 1.999853362784621\r\n\r\nSummary\r\n-------\r\n\r\n  Invocation count = 3\r\n  Access count     = 8\r\n  Eviction count   = 0\r\n\r\n\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        }
+      ]
     },
     {
       "cell_type": "markdown",
@@ -1079,7 +2618,32 @@
         "\n",
         "Console.WriteLine(getRadiusMemoized.Cache.DebugView);"
       ],
-      "outputs": []
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "GetRadius(4, 5) was called\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "GetRadius(4, 5) = 6.4031242374328485 in 00:00:01.0039645\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "Entries\r\n-------\r\n\r\n  (4, 5) -> 6.4031242374328485\r\n    Invoke duration     = 00:00:01.0026460\r\n    Hit count           = 1\r\n    Average access time = 00:00:01.0039598\r\n    Speed up factor     = 0.9986913818660866 [DEGRADATION]\r\n\r\n  (3, 4) -> 5\r\n    Invoke duration     = 00:00:01.0152318\r\n    Hit count           = 4\r\n    Average access time = 00:00:00.2538540\r\n    Speed up factor     = 3.999274386064431\r\n\r\n  (2, 3) -> 3.605551275463989\r\n    Invoke duration     = 00:00:01.0046303\r\n    Hit count           = 2\r\n    Average access time = 00:00:00.5023476\r\n    Speed up factor     = 1.9998708065889037\r\n\r\n  (1, 2) -> 2.23606797749979\r\n    Invoke duration     = 00:00:01.0119472\r\n    Hit count           = 2\r\n    Average access time = 00:00:00.5060107\r\n    Speed up factor     = 1.999853362784621\r\n\r\nSummary\r\n-------\r\n\r\n  Invocation count = 4\r\n  Access count     = 9\r\n  Eviction count   = 0\r\n\r\n\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        }
+      ]
     },
     {
       "cell_type": "markdown",
@@ -1110,7 +2674,48 @@
         "\n",
         "Console.WriteLine(getRadiusMemoized.Cache.DebugView);"
       ],
-      "outputs": []
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "GetRadius(4, 5) = 6.4031242374328485 in 00:00:00.0000144\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "GetRadius(1, 2) = 2.23606797749979 in 00:00:00.0000095\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "GetRadius(2, 3) = 3.605551275463989 in 00:00:00.0000017\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "GetRadius(3, 4) = 5 in 00:00:00.0000030\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "Entries\r\n-------\r\n\r\n  (3, 4) -> 5\r\n    Invoke duration     = 00:00:01.0152318\r\n    Hit count           = 5\r\n    Average access time = 00:00:00.2030838\r\n    Speed up factor     = 4.999078213033241\r\n\r\n  (2, 3) -> 3.605551275463989\r\n    Invoke duration     = 00:00:01.0046303\r\n    Hit count           = 3\r\n    Average access time = 00:00:00.3348989\r\n    Speed up factor     = 2.9998017312090304\r\n\r\n  (1, 2) -> 2.23606797749979\r\n    Invoke duration     = 00:00:01.0119472\r\n    Hit count           = 3\r\n    Average access time = 00:00:00.3373434\r\n    Speed up factor     = 2.999753959911473\r\n\r\n  (4, 5) -> 6.4031242374328485\r\n    Invoke duration     = 00:00:01.0026460\r\n    Hit count           = 2\r\n    Average access time = 00:00:00.5019845\r\n    Speed up factor     = 1.9973644604564484\r\n\r\nSummary\r\n-------\r\n\r\n  Invocation count = 4\r\n  Access count     = 13\r\n  Eviction count   = 0\r\n\r\n\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        }
+      ]
     },
     {
       "cell_type": "markdown",
@@ -1133,7 +2738,32 @@
         "\n",
         "Console.WriteLine(getRadiusMemoized.Cache.DebugView);"
       ],
-      "outputs": []
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "GetRadius(5, 6) was called\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "GetRadius(5, 6) = 7.810249675906654 in 00:00:01.0163047\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "Entries\r\n-------\r\n\r\n  (5, 6) -> 7.810249675906654\r\n    Invoke duration     = 00:00:01.0150146\r\n    Hit count           = 1\r\n    Average access time = 00:00:01.0162988\r\n    Speed up factor     = 0.998736395241242 [DEGRADATION]\r\n\r\n  (3, 4) -> 5\r\n    Invoke duration     = 00:00:01.0152318\r\n    Hit count           = 5\r\n    Average access time = 00:00:00.2030838\r\n    Speed up factor     = 4.999078213033241\r\n\r\n  (2, 3) -> 3.605551275463989\r\n    Invoke duration     = 00:00:01.0046303\r\n    Hit count           = 3\r\n    Average access time = 00:00:00.3348989\r\n    Speed up factor     = 2.9998017312090304\r\n\r\n  (1, 2) -> 2.23606797749979\r\n    Invoke duration     = 00:00:01.0119472\r\n    Hit count           = 3\r\n    Average access time = 00:00:00.3373434\r\n    Speed up factor     = 2.999753959911473\r\n\r\nSummary\r\n-------\r\n\r\n  Invocation count = 5\r\n  Access count     = 14\r\n  Eviction count   = 1\r\n\r\n  Last eviction\r\n    Invoke duration     = 00:00:01.0026460\r\n    Hit count           = 2\r\n    Average access time = 00:00:00.5019845\r\n    Speed up factor     = 1.9973644604564484\r\n\r\n\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        }
+      ]
     },
     {
       "cell_type": "markdown",
@@ -1156,7 +2786,32 @@
         "\n",
         "Console.WriteLine(getRadiusMemoized.Cache.DebugView);"
       ],
-      "outputs": []
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "GetRadius(4, 5) was called\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "GetRadius(4, 5) = 6.4031242374328485 in 00:00:01.0060432\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "Entries\r\n-------\r\n\r\n  (4, 5) -> 6.4031242374328485\r\n    Invoke duration     = 00:00:01.0059979\r\n    Hit count           = 1\r\n    Average access time = 00:00:01.0060376\r\n    Speed up factor     = 0.9999605382542363 [DEGRADATION]\r\n\r\n  (5, 6) -> 7.810249675906654\r\n    Invoke duration     = 00:00:01.0150146\r\n    Hit count           = 1\r\n    Average access time = 00:00:01.0162988\r\n    Speed up factor     = 0.998736395241242 [DEGRADATION]\r\n\r\n  (3, 4) -> 5\r\n    Invoke duration     = 00:00:01.0152318\r\n    Hit count           = 5\r\n    Average access time = 00:00:00.2030838\r\n    Speed up factor     = 4.999078213033241\r\n\r\n  (2, 3) -> 3.605551275463989\r\n    Invoke duration     = 00:00:01.0046303\r\n    Hit count           = 3\r\n    Average access time = 00:00:00.3348989\r\n    Speed up factor     = 2.9998017312090304\r\n\r\nSummary\r\n-------\r\n\r\n  Invocation count = 6\r\n  Access count     = 15\r\n  Eviction count   = 2\r\n\r\n  Last eviction\r\n    Invoke duration     = 00:00:01.0119472\r\n    Hit count           = 3\r\n    Average access time = 00:00:00.3373434\r\n    Speed up factor     = 2.999753959911473\r\n\r\n\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        }
+      ]
     },
     {
       "cell_type": "markdown",
@@ -1240,7 +2895,16 @@
         "\n",
         "Console.WriteLine(getValueDelayedMemoized.Cache.DebugView);"
       ],
-      "outputs": []
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "Entries\r\n-------\r\n\r\n  (42, 10) -> 42\r\n    Invoke duration     = 00:00:00.0223207\r\n    Hit count           = 100\r\n    Average access time = 00:00:00.0002765\r\n    Speed up factor     = 80.72585895117541\r\n\r\n  (42, 20) -> 42\r\n    Invoke duration     = 00:00:00.0283414\r\n    Hit count           = 100\r\n    Average access time = 00:00:00.0002853\r\n    Speed up factor     = 99.33894146512444\r\n\r\n  (42, 30) -> 42\r\n    Invoke duration     = 00:00:00.0315064\r\n    Hit count           = 100\r\n    Average access time = 00:00:00.0003152\r\n    Speed up factor     = 99.95685279187818\r\n\r\n  (42, 40) -> 42\r\n    Invoke duration     = 00:00:00.0480687\r\n    Hit count           = 100\r\n    Average access time = 00:00:00.0004882\r\n    Speed up factor     = 98.46108152396559\r\n\r\nSummary\r\n-------\r\n\r\n  Invocation count = 4\r\n  Access count     = 400\r\n  Trim count       = 0\r\n  Trim elapsed     = 00:00:00\r\n  Eviction count   = 0\r\n\r\n\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        }
+      ]
     },
     {
       "cell_type": "markdown",
@@ -1262,7 +2926,16 @@
         "\n",
         "Console.WriteLine(getValueDelayedMemoized.Cache.DebugView);"
       ],
-      "outputs": []
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "Entries\r\n-------\r\n\r\n  (43, 10) -> 43\r\n    Invoke duration     = 00:00:00.0243194\r\n    Hit count           = 1\r\n    Average access time = 00:00:00.0279688\r\n    Speed up factor     = 0.8695188924801922 [DEGRADATION]\r\n\r\n  (42, 20) -> 42\r\n    Invoke duration     = 00:00:00.0283414\r\n    Hit count           = 100\r\n    Average access time = 00:00:00.0002853\r\n    Speed up factor     = 99.33894146512444\r\n\r\n  (42, 30) -> 42\r\n    Invoke duration     = 00:00:00.0315064\r\n    Hit count           = 100\r\n    Average access time = 00:00:00.0003152\r\n    Speed up factor     = 99.95685279187818\r\n\r\n  (42, 40) -> 42\r\n    Invoke duration     = 00:00:00.0480687\r\n    Hit count           = 100\r\n    Average access time = 00:00:00.0004882\r\n    Speed up factor     = 98.46108152396559\r\n\r\nSummary\r\n-------\r\n\r\n  Invocation count = 5\r\n  Access count     = 401\r\n  Trim count       = 1\r\n  Trim elapsed     = 00:00:00.0036386\r\n  Eviction count   = 1\r\n\r\n  Last eviction\r\n    Invoke duration     = 00:00:00.0223207\r\n    Hit count           = 100\r\n    Average access time = 00:00:00.0002765\r\n    Speed up factor     = 80.72585895117541\r\n\r\n\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        }
+      ]
     },
     {
       "cell_type": "markdown",
@@ -1285,7 +2958,24 @@
         "\n",
         "Console.WriteLine(getValueDelayedMemoized.Cache.DebugView);"
       ],
-      "outputs": []
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "Trimmed 1 entries.\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "Entries\r\n-------\r\n\r\n  (42, 20) -> 42\r\n    Invoke duration     = 00:00:00.0283414\r\n    Hit count           = 100\r\n    Average access time = 00:00:00.0002853\r\n    Speed up factor     = 99.33894146512444\r\n\r\n  (42, 30) -> 42\r\n    Invoke duration     = 00:00:00.0315064\r\n    Hit count           = 100\r\n    Average access time = 00:00:00.0003152\r\n    Speed up factor     = 99.95685279187818\r\n\r\n  (42, 40) -> 42\r\n    Invoke duration     = 00:00:00.0480687\r\n    Hit count           = 100\r\n    Average access time = 00:00:00.0004882\r\n    Speed up factor     = 98.46108152396559\r\n\r\nSummary\r\n-------\r\n\r\n  Invocation count = 5\r\n  Access count     = 401\r\n  Trim count       = 1\r\n  Trim elapsed     = 00:00:00.0036386\r\n  Eviction count   = 1\r\n\r\n  Last eviction\r\n    Invoke duration     = 00:00:00.0223207\r\n    Hit count           = 100\r\n    Average access time = 00:00:00.0002765\r\n    Speed up factor     = 80.72585895117541\r\n\r\n\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        }
+      ]
     },
     {
       "cell_type": "markdown",
@@ -1367,7 +3057,56 @@
         "t2.Start();\n",
         "t2.Join();"
       ],
-      "outputs": []
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "~28 - f(1)\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "~28 - f(2)\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "Entries\r\n-------\r\n\r\n  1 -> 2\r\n    Invoke duration     = 00:00:00.0003984\r\n    Hit count           = 2\r\n    Average access time = 00:00:00.0022092\r\n    Speed up factor     = 0.18033677349266702 [DEGRADATION]\r\n\r\n  2 -> 3\r\n    Invoke duration     = 00:00:00.0001152\r\n    Hit count           = 1\r\n    Average access time = 00:00:00.0001554\r\n    Speed up factor     = 0.7413127413127413 [DEGRADATION]\r\n\r\nSummary\r\n-------\r\n\r\n  Invocation count = 2\r\n  Access count     = 3\r\n  Eviction count   = 0\r\n\r\n\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "~7 - f(1)\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "~7 - f(2)\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "Entries\r\n-------\r\n\r\n  1 -> 2\r\n    Invoke duration     = 00:00:00.0000585\r\n    Hit count           = 2\r\n    Average access time = 00:00:00.0000394\r\n    Speed up factor     = 1.484771573604061\r\n\r\n  2 -> 3\r\n    Invoke duration     = 00:00:00.0000154\r\n    Hit count           = 1\r\n    Average access time = 00:00:00.0000176\r\n    Speed up factor     = 0.875 [DEGRADATION]\r\n\r\nSummary\r\n-------\r\n\r\n  Invocation count = 2\r\n  Access count     = 3\r\n  Eviction count   = 0\r\n\r\n\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        }
+      ]
     },
     {
       "cell_type": "markdown",
@@ -1423,8 +3162,7 @@
         "\n",
         "        return h.ToHashCode();\n",
         "    }\n",
-        "}\n",
-        ""
+        "}"
       ],
       "outputs": []
     },
@@ -1483,7 +3221,40 @@
         "\n",
         "Console.WriteLine($\"ys.GetHashCode() = {ys.GetHashCode()} after interning\");"
       ],
-      "outputs": []
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "xs.GetHashCode() = 11261288\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "xs.GetHashCode() = 11261288 after interning\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "ys.GetHashCode() = 37913673\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "ys.GetHashCode() = 11261288 after interning\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        }
+      ]
     }
   ],
   "metadata": {

--- a/Nuqleon/Core/BCL/Nuqleon.Reflection.Virtualization/GettingStarted.ipynb
+++ b/Nuqleon/Core/BCL/Nuqleon.Reflection.Virtualization/GettingStarted.ipynb
@@ -117,7 +117,192 @@
         "    Console.WriteLine(declaration);\n",
         "}"
       ],
-      "outputs": []
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "interface IAssemblyIntrospectionProvider;\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "interface IAssemblyLoadingProvider;\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "interface IComTypeLoadingProvider;\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "interface IEventInfoIntrospectionProvider : IMemberInfoIntrospectionProvider;\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "interface IFieldInfoIntrospectionProvider : IMemberInfoIntrospectionProvider;\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "interface IMemberInfoIntrospectionProvider;\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "interface IMethodBaseIntrospectionProvider : IMemberInfoIntrospectionProvider;\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "interface IMethodCreationProvider;\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "interface IMethodInfoIntrospectionProvider : IMemberInfoIntrospectionProvider;\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "interface IModuleIntrospectionProvider;\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "interface IModuleLoadingProvider;\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "interface IParameterInfoIntrospectionProvider;\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "interface IPropertyInfoIntrospectionProvider : IMemberInfoIntrospectionProvider;\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "interface IReflectionCreationProvider : ITypeCreationProvider, IMethodCreationProvider;\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "interface IReflectionHandlerResolver;\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "interface IReflectionIntrospectionProvider : IAssemblyIntrospectionProvider, IModuleIntrospectionProvider, ITypeIntrospectionProvider, IMemberInfoIntrospectionProvider, IReflectionTypeSystemProvider, IFieldInfoIntrospectionProvider, IMethodInfoIntrospectionProvider, IMethodBaseIntrospectionProvider, IPropertyInfoIntrospectionProvider, IEventInfoIntrospectionProvider, IParameterInfoIntrospectionProvider;\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "interface IReflectionInvocationProvider;\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "interface IReflectionLoadingProvider : IAssemblyLoadingProvider, IModuleLoadingProvider, ITypeLoadingProvider, IComTypeLoadingProvider;\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "interface IReflectionProvider : IReflectionIntrospectionProvider, IAssemblyIntrospectionProvider, IModuleIntrospectionProvider, ITypeIntrospectionProvider, IMemberInfoIntrospectionProvider, IReflectionTypeSystemProvider, IFieldInfoIntrospectionProvider, IMethodInfoIntrospectionProvider, IMethodBaseIntrospectionProvider, IPropertyInfoIntrospectionProvider, IEventInfoIntrospectionProvider, IParameterInfoIntrospectionProvider, IReflectionCreationProvider, ITypeCreationProvider, IMethodCreationProvider, IReflectionInvocationProvider, IReflectionLoadingProvider, IAssemblyLoadingProvider, IModuleLoadingProvider, ITypeLoadingProvider, IComTypeLoadingProvider, IReflectionHandlerResolver;\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "interface IReflectionTypeSystemProvider;\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "interface ITypeCreationProvider;\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "interface ITypeIntrospectionProvider : IMemberInfoIntrospectionProvider, IReflectionTypeSystemProvider;\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "interface ITypeLoadingProvider : IComTypeLoadingProvider;\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        }
+      ]
     },
     {
       "cell_type": "markdown",
@@ -160,7 +345,16 @@
         "\n",
         "Console.WriteLine(string.Join(\", \", listOfInt));"
       ],
-      "outputs": []
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "System.String, System.Int32\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        }
+      ]
     },
     {
       "cell_type": "markdown",
@@ -188,7 +382,16 @@
         "\n",
         "Console.WriteLine(string.Join(\", \", listOfInt));"
       ],
-      "outputs": []
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "System.String, System.Int32\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        }
+      ]
     },
     {
       "cell_type": "markdown",
@@ -280,7 +483,56 @@
         "    Console.WriteLine();\n",
         "}"
       ],
-      "outputs": []
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "default\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "40000120 bytes allocated; 107 ms spent.\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "caching\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "288 bytes allocated; 75 ms spent.\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        }
+      ]
     }
   ],
   "metadata": {

--- a/Nuqleon/Core/BCL/Nuqleon.StringSegment/GettingStarted.ipynb
+++ b/Nuqleon/Core/BCL/Nuqleon.StringSegment/GettingStarted.ipynb
@@ -138,7 +138,40 @@
         "    Console.WriteLine(sentence);\n",
         "}"
       ],
-      "outputs": []
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        }
+      ]
     },
     {
       "cell_type": "markdown",
@@ -171,7 +204,592 @@
         "    }\n",
         "}"
       ],
-      "outputs": []
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "  Lorem\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "  ipsum\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "  dolor\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "  sit\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "  amet\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "  consectetur\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "  adipiscing\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "  elit\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "  sed\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "  do\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "  eiusmod\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "  tempor\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "  incididunt\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "  ut\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "  labore\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "  et\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "  dolore\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "  magna\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "  aliqua\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "  Ut\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "  enim\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "  ad\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "  minim\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "  veniam\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "  quis\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "  nostrud\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "  exercitation\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "  ullamco\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "  laboris\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "  nisi\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "  ut\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "  aliquip\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "  ex\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "  ea\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "  commodo\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "  consequat\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "  Duis\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "  aute\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "  irure\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "  dolor\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "  in\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "  reprehenderit\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "  in\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "  voluptate\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "  velit\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "  esse\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "  cillum\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "  dolore\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "  eu\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "  fugiat\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "  nulla\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "  pariatur\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "  Excepteur\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "  sint\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "  occaecat\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "  cupidatat\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "  non\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "  proident\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "  sunt\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "  in\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "  culpa\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "  qui\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "  officia\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "  deserunt\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "  mollit\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "  anim\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "  id\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "  est\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "  laborum\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        }
+      ]
     },
     {
       "cell_type": "markdown",
@@ -201,7 +819,560 @@
         "    Console.WriteLine(word);\n",
         "}"
       ],
-      "outputs": []
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "lorem\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "ipsum\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "dolor\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "sit\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "amet\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "consectetur\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "adipiscing\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "elit\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "sed\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "do\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "eiusmod\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "tempor\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "incididunt\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "ut\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "labore\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "et\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "dolore\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "magna\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "aliqua\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "ut\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "enim\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "ad\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "minim\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "veniam\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "quis\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "nostrud\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "exercitation\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "ullamco\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "laboris\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "nisi\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "ut\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "aliquip\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "ex\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "ea\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "commodo\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "consequat\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "duis\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "aute\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "irure\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "dolor\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "in\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "reprehenderit\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "in\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "voluptate\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "velit\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "esse\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "cillum\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "dolore\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "eu\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "fugiat\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "nulla\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "pariatur\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "excepteur\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "sint\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "occaecat\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "cupidatat\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "non\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "proident\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "sunt\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "in\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "culpa\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "qui\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "officia\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "deserunt\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "mollit\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "anim\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "id\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "est\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "laborum\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        }
+      ]
     },
     {
       "cell_type": "markdown",
@@ -231,7 +1402,40 @@
         "    Console.WriteLine(word);\n",
         "}"
       ],
-      "outputs": []
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "{ Word = ut, Count = 3 }\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "{ Word = in, Count = 3 }\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "{ Word = dolor, Count = 2 }\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "{ Word = dolore, Count = 2 }\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        }
+      ]
     }
   ],
   "metadata": {

--- a/Nuqleon/Core/BCL/Nuqleon.Time/GettingStarted.ipynb
+++ b/Nuqleon/Core/BCL/Nuqleon.Time/GettingStarted.ipynb
@@ -159,7 +159,16 @@
         "\n",
         "Console.WriteLine(sw.ElapsedTicks);"
       ],
-      "outputs": []
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "0\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        }
+      ]
     },
     {
       "cell_type": "markdown",
@@ -181,7 +190,16 @@
         "\n",
         "Console.WriteLine(sw.ElapsedTicks);"
       ],
-      "outputs": []
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "1\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        }
+      ]
     },
     {
       "cell_type": "markdown",
@@ -205,7 +223,16 @@
         "\n",
         "Console.WriteLine(sw.ElapsedTicks);"
       ],
-      "outputs": []
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "1\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        }
+      ]
     },
     {
       "cell_type": "markdown",
@@ -229,7 +256,16 @@
         "\n",
         "Console.WriteLine(sw.ElapsedTicks);"
       ],
-      "outputs": []
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "4\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        }
+      ]
     },
     {
       "cell_type": "markdown",
@@ -251,7 +287,16 @@
         "\n",
         "Console.WriteLine(sw.ElapsedTicks);"
       ],
-      "outputs": []
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "639\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        }
+      ]
     },
     {
       "cell_type": "markdown",
@@ -310,7 +355,24 @@
         "\n",
         "Console.WriteLine(monotonicSystemClock.Now);"
       ],
-      "outputs": []
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "1072192265\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "1072193265\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        }
+      ]
     },
     {
       "cell_type": "markdown",
@@ -345,7 +407,16 @@
         "var mem = new MemoryClock();\n",
         "Console.WriteLine(mem.Now);"
       ],
-      "outputs": []
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "1691144\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        }
+      ]
     },
     {
       "cell_type": "markdown",
@@ -428,7 +499,40 @@
         "Console.WriteLine($\"Bytes allocated to print = {swPrint.ElapsedTicks}\");\n",
         "Console.WriteLine($\"Total bytes allocated = {swAll.ElapsedTicks}\");"
       ],
-      "outputs": []
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "Bytes allocated by F() = 640\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "Bytes allocated by G() = 144\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "Bytes allocated to print = 8488\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "Total bytes allocated = 9272\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        }
+      ]
     },
     {
       "cell_type": "markdown",

--- a/Nuqleon/Core/JSON/Nuqleon.Json.Interop.Newtonsoft/GettingStarted.ipynb
+++ b/Nuqleon/Core/JSON/Nuqleon.Json.Interop.Newtonsoft/GettingStarted.ipynb
@@ -143,7 +143,16 @@
         "\n",
         "Console.WriteLine(json);"
       ],
-      "outputs": []
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "{\"Name\":\"Bart\",\"Age\":21}\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        }
+      ]
     },
     {
       "cell_type": "markdown",
@@ -170,7 +179,16 @@
         "\n",
         "Console.WriteLine(res);"
       ],
-      "outputs": []
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "Person { Name = Bart, Age = 21 }\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        }
+      ]
     }
   ],
   "metadata": {

--- a/Nuqleon/Core/JSON/Nuqleon.Json.Serialization/GettingStarted.ipynb
+++ b/Nuqleon/Core/JSON/Nuqleon.Json.Serialization/GettingStarted.ipynb
@@ -163,7 +163,16 @@
         "\n",
         "Console.WriteLine(json);"
       ],
-      "outputs": []
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "{\"Age\":21,\"Name\":\"Bart\"}\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        }
+      ]
     },
     {
       "cell_type": "markdown",
@@ -192,7 +201,16 @@
       "source": [
         "#r \"nuget:Newtonsoft.Json\""
       ],
-      "outputs": []
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "Installed package Newtonsoft.Json version 12.0.3"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        }
+      ]
     },
     {
       "cell_type": "markdown",
@@ -285,7 +303,24 @@
         "Benchmark(\"Newtonsoft\", TestN, 1_000_000);\n",
         "Benchmark(\"Nuqleon\", TestJ, 1_000_000);"
       ],
-      "outputs": []
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "Newtonsoft completed in 632 ms and allocated 448201408 bytes.\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "Nuqleon completed in 98 ms and allocated 216 bytes.\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        }
+      ]
     },
     {
       "cell_type": "markdown",
@@ -345,7 +380,16 @@
         "\n",
         "Console.WriteLine(p);"
       ],
-      "outputs": []
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "Person { Name = Bart, Age = 21 }\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        }
+      ]
     },
     {
       "cell_type": "markdown",
@@ -397,7 +441,24 @@
         "Benchmark(\"Newtonsoft\", TestN, 1_000_000);\n",
         "Benchmark(\"Nuqleon\", TestJ, 1_000_000);"
       ],
-      "outputs": []
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "Newtonsoft completed in 1780 ms and allocated 2736021672 bytes.\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "Nuqleon completed in 931 ms and allocated 64000048 bytes.\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        }
+      ]
     },
     {
       "cell_type": "markdown",

--- a/Nuqleon/Core/JSON/Nuqleon.Json/GettingStarted.ipynb
+++ b/Nuqleon/Core/JSON/Nuqleon.Json/GettingStarted.ipynb
@@ -148,7 +148,16 @@
         "\n",
         "Console.WriteLine(s);"
       ],
-      "outputs": []
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "{\"Name\":\"Bart\",\"Age\":21,\"Hobbies\":[\"Code\",\"Walk\",\"Run\"]}\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        }
+      ]
     },
     {
       "cell_type": "markdown",
@@ -174,7 +183,16 @@
         "\n",
         "Console.WriteLine(pretty);"
       ],
-      "outputs": []
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "{\r\n  \"Name\": \"Bart\",\r\n  \"Age\": 21,\r\n  \"Hobbies\": [\r\n    \"Code\",\r\n    \"Walk\",\r\n    \"Run\"\r\n  ]\r\n}\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        }
+      ]
     },
     {
       "cell_type": "markdown",
@@ -213,7 +231,16 @@
         "\n",
         "Console.WriteLine(string.Join(\", \", fsc.Strings));"
       ],
-      "outputs": []
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "Bart, Code, Walk, Run\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        }
+      ]
     },
     {
       "cell_type": "markdown",
@@ -275,7 +302,16 @@
         "\n",
         "Console.WriteLine(test);"
       ],
-      "outputs": []
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "True\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        }
+      ]
     },
     {
       "cell_type": "markdown",
@@ -319,7 +355,40 @@
         "\n",
         "Console.WriteLine(oldBart == newBart);"
       ],
-      "outputs": []
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "Person { Name = Bart, Age = 21 }\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "{\"Name\":\"Bart\",\"Age\":21}\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "Person { Name = Bart, Age = 21 }\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "True\r\n"
+          },
+          "execution_count": 1,
+          "metadata": {}
+        }
+      ]
     }
   ],
   "metadata": {


### PR DESCRIPTION
Going for a consistent approach across the board. Having the output in the notebooks makes for an easy read (e.g. in the previewer in GitHub) without having to run the notebook. One can always click "Clear all" in the UI and start afresh to walk through the notebook step-by-step.