### PR TITLE
Harden async rewriter for method call nodes.

### DIFF
--- a/Reaqtor/Core/Shared/Reaqtor.Shared.Core/Reaqtor/AsyncToSyncRewriter.cs
+++ b/Reaqtor/Core/Shared/Reaqtor.Shared.Core/Reaqtor/AsyncToSyncRewriter.cs
@@ -141,7 +141,8 @@ namespace Reaqtor
 
             protected override Expression MakeMethodCall(Expression instance, MethodInfo method, IEnumerable<Expression> arguments)
             {
-                var shouldRewrite = arguments.Last().Type == typeof(CancellationToken);
+                var lastArgument = arguments.LastOrDefault();
+                var shouldRewrite = lastArgument != null && lastArgument.Type == typeof(CancellationToken);
                 if (shouldRewrite)
                 {
                     var decl = method.DeclaringType;


### PR DESCRIPTION
Small tweak to prevent trying to access `arguments.Last()` when the argument count may be zero.