### PR TITLE
Add building and example instructions to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,13 +3,13 @@
 [![.NET Foundation](https://img.shields.io/badge/.NET%20Foundation-blueviolet.svg)](https://www.dotnetfoundation.org/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Build Status](https://dev.azure.com/dotnet/Reaqtor-private/_apis/build/status/reaqtive.reaqtor?branchName=main)](https://dev.azure.com/dotnet/Reaqtor-private/_build/latest?definitionId=155&branchName=main)
-[![codecov](https://codecov.io/gh/reaqtive/reaqtor/branch/main/graph/badge.svg?token=AD59K911YN)](https://codecov.io/gh/reaqtive/reaqtor)
+[![codecov](https://codecov.io/gh/reaqtive/reaqtor/branch/main/graph/badge.svg?token=AD59K911YN)](https://codecov.io/gh/reaqtive/reaqtor) [![NuGet](https://img.shields.io/badge/nuget-reaqtive-blue)](https://www.nuget.org/profiles/reaqtive)
 
 # About Reaqtor
 
 [Reaqtor](https://reaqtive.net) is a framework for reliable, stateful, distributed, and scalable event processing based on [Reactive Extensions (Rx)](https://github.com/dotnet/reactive).
 
-Reaqtor has been in [development for over 10 years](https://reaqtive.net/history). It is the evolution of the Reactive Extensions & powers services across Bing and M365.
+Reaqtor has been in development for over 10 years. It is the evolution of the Reactive Extensions & powers services across Bing and M365.
 
 ## .NET Foundation
 
@@ -18,6 +18,22 @@ Reaqtor is part of the [.NET Foundation](https://www.dotnetfoundation.org/).
 ## License
 
 Reaqtor is available under the [MIT open source license](https://opensource.org/licenses/MIT).
+
+## Building
+
+To build Reaqtor, you will need to install the [.NET SDK](https://dotnet.microsoft.com/download) ([version 5.0](https://dotnet.microsoft.com/download/dotnet/5.0) or later). Clone this repo, and in the root folder run this command:
+
+```
+dotnet build All.sln
+```
+
+Alternatively, if you use Visual Studio 2019, then as long as you have enabled the .NET SDK and .NET 5 runtimes in the Visual Studio installer, you can open that same `All.sln` file in Visual Studio and build it in the usual way.
+
+### Running Example Notebooks
+
+Many of the examples in the documentation in this repository take the form of notebooks, to make the examples interactively runnable. Since Reaqtor is a .NET technology, these notebooks contain C#, so you'll need a Jupyter notebook editor with support for a .NET kernel. For example, you use Visual Studio Code with the .NET Interactive Notebooks extension. You can install Visual Studio Code from https://code.visualstudio.com/ and then you can install the free [.NET Interactive Notebook](https://marketplace.visualstudio.com/items?itemName=ms-dotnettools.dotnet-interactive-vscode) extension from the VS Code marketplace.
+
+With these installed, you will be able to open any of the `.ipynb` files in this repository. For example, in the [Reaqtor/Samples/IoT/Reaqtor.IoT](./Reaqtor/Samples/IoT/Reaqtor.IoT) folder, there are two such files. When you open one, VS Code might ask you whether you want to trust the file. You will need to indicate that you do if you want to run the code in a notebook. If you had already installed tools in Visual Studio Code for running Python notebooks, you may see a prompt asking which notebook kernel to use. Select `.NET Interactive` (and not a Python kernel). You will then be able to run the C# code in any of the code cells in the notebook. (You will need to have built Reaqtor first for this to work, because these various example notebooks load the libraries built by the source in this repository.)
 
 ## Contributor License Agreement
 


### PR DESCRIPTION
Also remove a now-defunct link, and add a link to the `reaqtive` profile on
NuGet.org.