### PR TITLE
Fix handling of LabelTarget inside ExpressionEqualityComparator.GetHashCode

### DIFF
--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices/Expressions/ExpressionEqualityComparator.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices/Expressions/ExpressionEqualityComparator.cs
@@ -1900,8 +1900,13 @@ namespace System.Linq.CompilerServices
                 GetHashCode(obj.Body)
             );
 
-        private static int GetHashCode(LabelTarget obj) =>
-            obj == null ? 17 : obj.GetHashCode();
+        /// <summary>
+        /// Gets a hash code for the given label target.
+        /// </summary>
+        /// <param name="obj">Label target to compute a hash code for.</param>
+        /// <returns>Hash code for the given label target.</returns>
+        protected virtual int GetHashCode(LabelTarget obj) =>
+            obj == null ? 17 : GetHashCode(obj.Type);
 
 #if !USE_SLIM
         /// <summary>

--- a/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.CompilerServices/Expressions/ExpressionEqualityComparerTests.cs
+++ b/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.CompilerServices/Expressions/ExpressionEqualityComparerTests.cs
@@ -168,8 +168,10 @@ namespace Tests.System.Linq.CompilerServices
 
 #if USE_SLIM
             Assert.IsTrue(eq.Equals(e1.ToExpressionSlim(), e2.ToExpressionSlim()));
+            Assert.AreEqual(eq.GetHashCode(e1.ToExpressionSlim()), eq.GetHashCode(e2.ToExpressionSlim()));
 #else
             Assert.IsTrue(eq.Equals(e1, e2));
+            Assert.AreEqual(eq.GetHashCode(e1), eq.GetHashCode(e2));
 #endif
         }
 


### PR DESCRIPTION
Fixes #113 