### PR TITLE
Drop .NET Core 2.1 build for tests.

### DIFF
--- a/Nuqleon/Core/BCL/Tests.Nuqleon.Collections.Specialized/Tests.Nuqleon.Collections.Specialized.csproj
+++ b/Nuqleon/Core/BCL/Tests.Nuqleon.Collections.Specialized/Tests.Nuqleon.Collections.Specialized.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1;net472;net50</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net472;net50</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Nuqleon/Core/BCL/Tests.Nuqleon.IO.StreamSegment/Tests.Nuqleon.IO.StreamSegment.csproj
+++ b/Nuqleon/Core/BCL/Tests.Nuqleon.IO.StreamSegment/Tests.Nuqleon.IO.StreamSegment.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1;net472;net50</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net472;net50</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Nuqleon/Core/BCL/Tests.Nuqleon.Memory/Tests.Nuqleon.Memory.csproj
+++ b/Nuqleon/Core/BCL/Tests.Nuqleon.Memory/Tests.Nuqleon.Memory.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1;net472;net50</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net472;net50</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Nuqleon/Core/BCL/Tests.Nuqleon.Reflection.Virtualization/Tests.Nuqleon.Reflection.Virtualization.csproj
+++ b/Nuqleon/Core/BCL/Tests.Nuqleon.Reflection.Virtualization/Tests.Nuqleon.Reflection.Virtualization.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1;net472;net50</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net472;net50</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Nuqleon/Core/BCL/Tests.Nuqleon.StringSegment/Tests.Nuqleon.StringSegment.csproj
+++ b/Nuqleon/Core/BCL/Tests.Nuqleon.StringSegment/Tests.Nuqleon.StringSegment.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1;net472;net50</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net472;net50</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Nuqleon/Core/BCL/Tests.Nuqleon.Time/Tests.Nuqleon.Time.csproj
+++ b/Nuqleon/Core/BCL/Tests.Nuqleon.Time/Tests.Nuqleon.Time.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1;net472;net50</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net472;net50</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Nuqleon/Core/DataModel/Tests.Nuqleon.DataModel.CompilerServices/Tests.Nuqleon.DataModel.CompilerServices.csproj
+++ b/Nuqleon/Core/DataModel/Tests.Nuqleon.DataModel.CompilerServices/Tests.Nuqleon.DataModel.CompilerServices.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1;net472;net50</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net472;net50</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Nuqleon/Core/DataModel/Tests.Nuqleon.DataModel.Serialization.Binary/Tests.Nuqleon.DataModel.Serialization.Binary.csproj
+++ b/Nuqleon/Core/DataModel/Tests.Nuqleon.DataModel.Serialization.Binary/Tests.Nuqleon.DataModel.Serialization.Binary.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1;net472;net50</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net472;net50</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Nuqleon/Core/DataModel/Tests.Nuqleon.DataModel.Serialization.Json/Tests.Nuqleon.DataModel.Serialization.Json.csproj
+++ b/Nuqleon/Core/DataModel/Tests.Nuqleon.DataModel.Serialization.Json/Tests.Nuqleon.DataModel.Serialization.Json.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1;net472;net50</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net472;net50</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Nuqleon/Core/DataModel/Tests.Nuqleon.DataModel/Tests.Nuqleon.DataModel.csproj
+++ b/Nuqleon/Core/DataModel/Tests.Nuqleon.DataModel/Tests.Nuqleon.DataModel.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1;net472;net50</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net472;net50</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Nuqleon/Core/JSON/Tests.Nuqleon.Json.Interop.Newtonsoft/Tests.Nuqleon.Json.Interop.Newtonsoft.csproj
+++ b/Nuqleon/Core/JSON/Tests.Nuqleon.Json.Interop.Newtonsoft/Tests.Nuqleon.Json.Interop.Newtonsoft.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1;net472;net50</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net472;net50</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Nuqleon/Core/JSON/Tests.Nuqleon.Json.Serialization/Tests.Nuqleon.Json.Serialization.csproj
+++ b/Nuqleon/Core/JSON/Tests.Nuqleon.Json.Serialization/Tests.Nuqleon.Json.Serialization.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1;net472;net50</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net472;net50</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Nuqleon/Core/JSON/Tests.Nuqleon.Json/Tests.Nuqleon.Json.csproj
+++ b/Nuqleon/Core/JSON/Tests.Nuqleon.Json/Tests.Nuqleon.Json.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1;net472;net50</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net472;net50</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.CompilerServices.Optimizers/Tests.Nuqleon.Linq.CompilerServices.Optimizers.csproj
+++ b/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.CompilerServices.Optimizers/Tests.Nuqleon.Linq.CompilerServices.Optimizers.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1;net472;net50</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net472;net50</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.CompilerServices/Tests.Nuqleon.Linq.CompilerServices.csproj
+++ b/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.CompilerServices/Tests.Nuqleon.Linq.CompilerServices.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1;net472;net50</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net472;net50</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.Expressions.Bonsai.Hashing/Tests.Nuqleon.Linq.Expressions.Bonsai.Hashing.csproj
+++ b/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.Expressions.Bonsai.Hashing/Tests.Nuqleon.Linq.Expressions.Bonsai.Hashing.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1;net472;net50</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net472;net50</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.Expressions.Bonsai.Serialization/Tests.Nuqleon.Linq.Expressions.Bonsai.Serialization.csproj
+++ b/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.Expressions.Bonsai.Serialization/Tests.Nuqleon.Linq.Expressions.Bonsai.Serialization.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1;net472;net50</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net472;net50</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.Expressions.Bonsai/Tests.Nuqleon.Linq.Expressions.Bonsai.csproj
+++ b/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.Expressions.Bonsai/Tests.Nuqleon.Linq.Expressions.Bonsai.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1;net472;net50</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net472;net50</TargetFrameworks>
     <DefineConstants>$(DefineConstants);USE_SLIM</DefineConstants>
   </PropertyGroup>
 

--- a/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.Expressions.Optimizers/Tests.Nuqleon.Linq.Expressions.Optimizers.csproj
+++ b/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.Expressions.Optimizers/Tests.Nuqleon.Linq.Expressions.Optimizers.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1;net472;net50</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net472;net50</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Nuqleon/Museum/Tests.Nuqleon.Serialization/Tests.Nuqleon.Serialization.csproj
+++ b/Nuqleon/Museum/Tests.Nuqleon.Serialization/Tests.Nuqleon.Serialization.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1;net472</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net472</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Nuqleon/Pearls/LINQ/BinaryExpressionSerialization/Tests/Tests.Nuqleon.Pearls.Linq.Expressions.Bonsai.Serialization.Binary.csproj
+++ b/Nuqleon/Pearls/LINQ/BinaryExpressionSerialization/Tests/Tests.Nuqleon.Pearls.Linq.Expressions.Bonsai.Serialization.Binary.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1;net472;net50</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net472;net50</TargetFrameworks>
     <!-- NB: Also supports non-slim expressions. Currently not enabled in build. -->
     <DefineConstants>$(DefineConstants);USE_SLIM</DefineConstants>
   </PropertyGroup>

--- a/Nuqleon/Pearls/LINQ/PartialExpressionEvaluator/Test/Tests.Nuqleon.Pearls.PartialExpressionTreeEvaluator.csproj
+++ b/Nuqleon/Pearls/LINQ/PartialExpressionEvaluator/Test/Tests.Nuqleon.Pearls.PartialExpressionTreeEvaluator.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1;net472;net50</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net472;net50</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Reaqtive/Core/Tests.Reaqtive.Core/Tests.Reaqtive.Core.csproj
+++ b/Reaqtive/Core/Tests.Reaqtive.Core/Tests.Reaqtive.Core.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1;net472;net50</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net472;net50</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Reaqtive/Core/Tests.Reaqtive.Linq/Tests.Reaqtive.Linq.csproj
+++ b/Reaqtive/Core/Tests.Reaqtive.Linq/Tests.Reaqtive.Linq.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1;net472;net50</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net472;net50</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Reaqtive/Core/Tests.Reaqtive.Quotation/Tests.Reaqtive.Quotation.csproj
+++ b/Reaqtive/Core/Tests.Reaqtive.Quotation/Tests.Reaqtive.Quotation.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1;net472;net50</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net472;net50</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Reaqtive/Core/Tests.Reaqtive.Scheduler/Tests.Reaqtive.Scheduler.csproj
+++ b/Reaqtive/Core/Tests.Reaqtive.Scheduler/Tests.Reaqtive.Scheduler.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1;net472;net50</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net472;net50</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Reaqtor/Core/Client/Tests.Reaqtor.Client.Core/Tests.Reaqtor.Client.Core.csproj
+++ b/Reaqtor/Core/Client/Tests.Reaqtor.Client.Core/Tests.Reaqtor.Client.Core.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1;net472;net50</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net472;net50</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Reaqtor/Core/Client/Tests.Reaqtor.Client/Tests.Reaqtor.Client.csproj
+++ b/Reaqtor/Core/Client/Tests.Reaqtor.Client/Tests.Reaqtor.Client.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1;net472;net50</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net472;net50</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Reaqtor/Core/Engine/Tests.Reaqtor.QueryEngine/Tests.Reaqtor.QueryEngine.csproj
+++ b/Reaqtor/Core/Engine/Tests.Reaqtor.QueryEngine/Tests.Reaqtor.QueryEngine.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1;net472;net50</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net472;net50</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Reaqtor/Core/Expressions/Tests.Reaqtor.Expressions.Core/Tests.Reaqtor.Expressions.Core.csproj
+++ b/Reaqtor/Core/Expressions/Tests.Reaqtor.Expressions.Core/Tests.Reaqtor.Expressions.Core.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1;net472;net50</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net472;net50</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Reaqtor/Core/Hosting/Tests.Reaqtor.Hosting.Service/Tests.Reaqtor.Hosting.Service.csproj
+++ b/Reaqtor/Core/Hosting/Tests.Reaqtor.Hosting.Service/Tests.Reaqtor.Hosting.Service.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1;net472;net50</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net472;net50</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Reaqtor/Core/Hosting/Tests.Reaqtor.Hosting.Shared/Tests.Reaqtor.Hosting.Shared.csproj
+++ b/Reaqtor/Core/Hosting/Tests.Reaqtor.Hosting.Shared/Tests.Reaqtor.Hosting.Shared.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1;net472;net50</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net472;net50</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Reaqtor/Core/Local/Tests.Reaqtor.Local.Core/Tests.Reaqtor.Local.Core.csproj
+++ b/Reaqtor/Core/Local/Tests.Reaqtor.Local.Core/Tests.Reaqtor.Local.Core.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1;net472;net50</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net472;net50</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Reaqtor/Core/Reactive/Tests.Reaqtor.Reactive.HigherOrder/Tests.Reaqtor.Reactive.HigherOrder.csproj
+++ b/Reaqtor/Core/Reactive/Tests.Reaqtor.Reactive.HigherOrder/Tests.Reaqtor.Reactive.HigherOrder.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1;net472;net50</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net472;net50</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Reaqtor/Core/Reactive/Tests.Reaqtor.Reactive.Linq.Hosted/Tests.Reaqtor.Reactive.Linq.Hosted.csproj
+++ b/Reaqtor/Core/Reactive/Tests.Reaqtor.Reactive.Linq.Hosted/Tests.Reaqtor.Reactive.Linq.Hosted.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1;net472;net50</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net472;net50</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Reaqtor/Core/Reliable/Tests.Reaqtor.Reliable/Tests.Reaqtor.Reliable.csproj
+++ b/Reaqtor/Core/Reliable/Tests.Reaqtor.Reliable/Tests.Reaqtor.Reliable.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1;net472;net50</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net472;net50</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Reaqtor/Core/Service/Tests.Reaqtor.Service.Core/Tests.Reaqtor.Service.Core.csproj
+++ b/Reaqtor/Core/Service/Tests.Reaqtor.Service.Core/Tests.Reaqtor.Service.Core.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1;net472;net50</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net472;net50</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Reaqtor/Core/Service/Tests.Reaqtor.Service/Tests.Reaqtor.Service.csproj
+++ b/Reaqtor/Core/Service/Tests.Reaqtor.Service/Tests.Reaqtor.Service.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1;net472;net50</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net472;net50</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Reaqtor/Core/Shared/Tests.Reaqtor.Shared.Core/Tests.Reaqtor.Shared.Core.csproj
+++ b/Reaqtor/Core/Shared/Tests.Reaqtor.Shared.Core/Tests.Reaqtor.Shared.Core.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1;net472;net50</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net472;net50</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
No longer build and run tests targeting .NET Core 2.1 which has reached end of support. Going forward, once released, we'll be adding .NET 6.0 at the tail of the targets.