### PR TITLE
Upgrade projects, conditionals and paths to support .NET 6.0

### DIFF
--- a/Nuqleon/Core/BCL/Nuqleon.Collections.Specialized/GettingStarted.ipynb
+++ b/Nuqleon/Core/BCL/Nuqleon.Collections.Specialized/GettingStarted.ipynb
@@ -35,7 +35,7 @@
       },
       "outputs": [],
       "source": [
-        "#r \"bin/Debug/net50/Nuqleon.Collections.Specialized.dll\""
+        "#r \"bin/Debug/net6.0/Nuqleon.Collections.Specialized.dll\""
       ]
     },
     {

--- a/Nuqleon/Core/BCL/Nuqleon.Collections.Specialized/Nuqleon.Collections.Specialized.csproj
+++ b/Nuqleon/Core/BCL/Nuqleon.Collections.Specialized/Nuqleon.Collections.Specialized.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netstandard2.1;net472;net50</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;net472;net6.0</TargetFrameworks>
     <Description>Specialized data structures implemented for performance. Currently includes an optimized BitArray implementation, and a dictionary implementation optimized for enum keys.</Description>
   </PropertyGroup>
 

--- a/Nuqleon/Core/BCL/Nuqleon.IO.StreamSegment/GettingStarted.ipynb
+++ b/Nuqleon/Core/BCL/Nuqleon.IO.StreamSegment/GettingStarted.ipynb
@@ -35,7 +35,7 @@
       },
       "outputs": [],
       "source": [
-        "#r \"bin/Debug/net50/Nuqleon.IO.StreamSegment.dll\""
+        "#r \"bin/Debug/net6.0/Nuqleon.IO.StreamSegment.dll\""
       ]
     },
     {

--- a/Nuqleon/Core/BCL/Nuqleon.IO.StreamSegment/Nuqleon.IO.StreamSegment.csproj
+++ b/Nuqleon/Core/BCL/Nuqleon.IO.StreamSegment/Nuqleon.IO.StreamSegment.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netstandard2.1;net472;net50</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;net472;net6.0</TargetFrameworks>
     <Description>Provides functionality to create a segment over a System.IO.Stream.</Description>
   </PropertyGroup>
 

--- a/Nuqleon/Core/BCL/Nuqleon.Memory/GettingStarted.ipynb
+++ b/Nuqleon/Core/BCL/Nuqleon.Memory/GettingStarted.ipynb
@@ -35,7 +35,7 @@
       },
       "outputs": [],
       "source": [
-        "#r \"bin/Debug/net50/Nuqleon.Memory.dll\""
+        "#r \"bin/Debug/net6.0/Nuqleon.Memory.dll\""
       ]
     },
     {

--- a/Nuqleon/Core/BCL/Nuqleon.Memory/Nuqleon.Memory.csproj
+++ b/Nuqleon/Core/BCL/Nuqleon.Memory/Nuqleon.Memory.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netstandard2.1;net472;net50</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;net472;net6.0</TargetFrameworks>
     <Description>A collection of utilities for optimizing memory usage.</Description>
   </PropertyGroup>
 

--- a/Nuqleon/Core/BCL/Nuqleon.Memory/System/Memory/ObjectPoolBase.cs
+++ b/Nuqleon/Core/BCL/Nuqleon.Memory/System/Memory/ObjectPoolBase.cs
@@ -769,7 +769,7 @@ namespace System.Memory
         private void Write(StringBuilder sb, string str)
         {
             var parts =
-#if NET5_0 || NETSTANDARD2_1
+#if NET6_0 || NETSTANDARD2_1
                 str.Replace("\r\n", "\n", StringComparison.Ordinal)
 #else
                 str.Replace("\r\n", "\n")

--- a/Nuqleon/Core/BCL/Nuqleon.Reflection.Virtualization/GettingStarted.ipynb
+++ b/Nuqleon/Core/BCL/Nuqleon.Reflection.Virtualization/GettingStarted.ipynb
@@ -35,7 +35,7 @@
       },
       "outputs": [],
       "source": [
-        "#r \"bin/Debug/net50/Nuqleon.Reflection.Virtualization.dll\""
+        "#r \"bin/Debug/net6.0/Nuqleon.Reflection.Virtualization.dll\""
       ]
     },
     {

--- a/Nuqleon/Core/BCL/Nuqleon.Reflection.Virtualization/Nuqleon.Reflection.Virtualization.csproj
+++ b/Nuqleon/Core/BCL/Nuqleon.Reflection.Virtualization/Nuqleon.Reflection.Virtualization.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netstandard2.1;net472;net50</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;net472;net6.0</TargetFrameworks>
     <Description>Provides a virtualization layer for reflection.</Description>
   </PropertyGroup>
 

--- a/Nuqleon/Core/BCL/Nuqleon.Reflection.Virtualization/System/Reflection/Virtualization/DefaultReflectionProvider.cs
+++ b/Nuqleon/Core/BCL/Nuqleon.Reflection.Virtualization/System/Reflection/Virtualization/DefaultReflectionProvider.cs
@@ -201,7 +201,7 @@ namespace System.Reflection
         /// <returns>A <see cref="MethodBase" /> object representing the method or constructor specified by <paramref name="handle" />, in the generic type specified by <paramref name="declaringType" />.</returns>
         public override MethodBase GetMethodFromHandle(RuntimeMethodHandle handle, RuntimeTypeHandle declaringType) => MethodBase.GetMethodFromHandle(handle, declaringType);
 
-#if !NET5_0
+#if !NET6_0
         /// <summary>
         /// Gets the location of the assembly as specified originally, for example, in an <see cref="AssemblyName" /> object.
         /// </summary>
@@ -224,7 +224,7 @@ namespace System.Reflection
         /// <returns>An object that represents the entry point of this assembly. If no entry point is found (for example, the assembly is a DLL), null is returned.</returns>
         public override MethodInfo GetEntryPoint(Assembly assembly) => assembly.EntryPoint;
 
-#if !NET5_0
+#if !NET6_0
         /// <summary>
         /// Gets the URI, including escape characters, that represents the codebase.
         /// </summary>
@@ -249,7 +249,7 @@ namespace System.Reflection
         /// <returns>The display name of the assembly.</returns>
         public override string GetFullName(Assembly assembly) => assembly.FullName;
 
-#if !NET5_0
+#if !NET6_0
         /// <summary>
         /// Gets a value indicating whether the assembly was loaded from the global assembly cache.
         /// </summary>
@@ -1621,7 +1621,7 @@ namespace System.Reflection
         /// <returns>An array of <see cref="MemberInfo" /> objects representing all members defined for the specified type that match the specified binding constraints.-or- An empty array of type <see cref="MemberInfo" />, if no members are defined for the specified type, or if none of the defined members match the binding constraints.</returns>
         public override IReadOnlyList<MemberInfo> GetMembers(Type type, BindingFlags bindingAttr) => type.GetMembers(bindingAttr);
 
-#if NET5_0 || NETSTANDARD2_1
+#if NET6_0 || NETSTANDARD2_1
         /// <summary>
         /// Searches for the specified method whose parameters match the specified generic parameter count, argument types and modifiers, using the specified binding constraints and the specified calling convention.
         /// </summary>

--- a/Nuqleon/Core/BCL/Nuqleon.Reflection.Virtualization/System/Reflection/Virtualization/IAssemblyIntrospectionProvider.cs
+++ b/Nuqleon/Core/BCL/Nuqleon.Reflection.Virtualization/System/Reflection/Virtualization/IAssemblyIntrospectionProvider.cs
@@ -26,7 +26,7 @@ namespace System.Reflection
     [GeneratedCode("", "1.0.0.0")] // NB: A mirror image of System.Reflection APIs, so considering this to be "generated".
     public interface IAssemblyIntrospectionProvider
     {
-#if !NET5_0
+#if !NET6_0
         /// <summary>
         /// Gets the location of the assembly as specified originally, for example, in an <see cref="AssemblyName" /> object.
         /// </summary>
@@ -49,7 +49,7 @@ namespace System.Reflection
         /// <returns>An object that represents the entry point of this assembly. If no entry point is found (for example, the assembly is a DLL), null is returned.</returns>
         MethodInfo GetEntryPoint(Assembly assembly);
 
-#if !NET5_0
+#if !NET6_0
         /// <summary>
         /// Gets the URI, including escape characters, that represents the codebase.
         /// </summary>
@@ -74,7 +74,7 @@ namespace System.Reflection
         /// <returns>The display name of the assembly.</returns>
         string GetFullName(Assembly assembly);
 
-#if !NET5_0
+#if !NET6_0
         /// <summary>
         /// Gets a value indicating whether the assembly was loaded from the global assembly cache.
         /// </summary>

--- a/Nuqleon/Core/BCL/Nuqleon.Reflection.Virtualization/System/Reflection/Virtualization/ITypeIntrospectionProvider.cs
+++ b/Nuqleon/Core/BCL/Nuqleon.Reflection.Virtualization/System/Reflection/Virtualization/ITypeIntrospectionProvider.cs
@@ -426,7 +426,7 @@ namespace System.Reflection
         /// <returns>An array of <see cref="MemberInfo" /> objects representing all members defined for the specified type that match the specified binding constraints.-or- An empty array of type <see cref="MemberInfo" />, if no members are defined for the specified type, or if none of the defined members match the binding constraints.</returns>
         IReadOnlyList<MemberInfo> GetMembers(Type type, BindingFlags bindingAttr);
 
-#if NET5_0 || NETSTANDARD2_1
+#if NET6_0 || NETSTANDARD2_1
         /// <summary>
         /// Searches for the specified method whose parameters match the specified generic parameter count, argument types and modifiers, using the specified binding constraints and the specified calling convention.
         /// </summary>

--- a/Nuqleon/Core/BCL/Nuqleon.Reflection.Virtualization/System/Reflection/Virtualization/ReflectionProvider.cs
+++ b/Nuqleon/Core/BCL/Nuqleon.Reflection.Virtualization/System/Reflection/Virtualization/ReflectionProvider.cs
@@ -192,7 +192,7 @@ namespace System.Reflection
         /// <returns>A <see cref="MethodBase" /> object representing the method or constructor specified by <paramref name="handle" />, in the generic type specified by <paramref name="declaringType" />.</returns>
         public abstract MethodBase GetMethodFromHandle(RuntimeMethodHandle handle, RuntimeTypeHandle declaringType);
 
-#if !NET5_0
+#if !NET6_0
         /// <summary>
         /// Gets the location of the assembly as specified originally, for example, in an <see cref="AssemblyName" /> object.
         /// </summary>
@@ -215,7 +215,7 @@ namespace System.Reflection
         /// <returns>An object that represents the entry point of this assembly. If no entry point is found (for example, the assembly is a DLL), null is returned.</returns>
         public abstract MethodInfo GetEntryPoint(Assembly assembly);
 
-#if !NET5_0
+#if !NET6_0
         /// <summary>
         /// Gets the URI, including escape characters, that represents the codebase.
         /// </summary>
@@ -240,7 +240,7 @@ namespace System.Reflection
         /// <returns>The display name of the assembly.</returns>
         public abstract string GetFullName(Assembly assembly);
 
-#if !NET5_0
+#if !NET6_0
         /// <summary>
         /// Gets a value indicating whether the assembly was loaded from the global assembly cache.
         /// </summary>
@@ -611,7 +611,7 @@ namespace System.Reflection
         /// <returns>An array of type <see cref="FieldInfo" /> representing the global fields defined on the module that match the specified binding flags; if no global fields match the binding flags, an empty array is returned.</returns>
         public abstract IReadOnlyList<FieldInfo> GetFields(Module module, BindingFlags bindingFlags);
 
-#if NET5_0 || NETSTANDARD2_1
+#if NET6_0 || NETSTANDARD2_1
         /// <summary>
         /// Searches for the specified method whose parameters match the specified generic parameter count, argument types and modifiers, using the specified binding constraints and the specified calling convention.
         /// </summary>

--- a/Nuqleon/Core/BCL/Nuqleon.Reflection.Virtualization/System/Reflection/Virtualization/TypeIntrospectionProviderExtensions.cs
+++ b/Nuqleon/Core/BCL/Nuqleon.Reflection.Virtualization/System/Reflection/Virtualization/TypeIntrospectionProviderExtensions.cs
@@ -297,7 +297,7 @@ namespace System.Reflection
         /// <returns>An object representing the method that matches the specified requirements, if found; otherwise, null.</returns>
         public static MethodInfo GetMethod(this ITypeIntrospectionProvider provider, Type type, string name) => NotNull(NotNull(provider)).GetMethod(type, name, BindingFlags.Instance | BindingFlags.Static | BindingFlags.Public);
 
-#if NET5_0 || NETSTANDARD2_1
+#if NET6_0 || NETSTANDARD2_1
         /// <summary>
         /// Searches for the specified public method whose parameters match the specified generic parameter count and argument types.
         /// </summary>

--- a/Nuqleon/Core/BCL/Nuqleon.Reflection.Virtualization/System/Reflection/Virtualization/Utils.cs
+++ b/Nuqleon/Core/BCL/Nuqleon.Reflection.Virtualization/System/Reflection/Virtualization/Utils.cs
@@ -33,7 +33,7 @@ namespace System
 
         public static int GetHashCode<TDefinition>(TDefinition def, Type[] args)
         {
-#if NET5_0
+#if NET6_0
             HashCode h = new();
 
             h.Add(def);

--- a/Nuqleon/Core/BCL/Nuqleon.StringSegment/GettingStarted.ipynb
+++ b/Nuqleon/Core/BCL/Nuqleon.StringSegment/GettingStarted.ipynb
@@ -37,7 +37,7 @@
       },
       "outputs": [],
       "source": [
-        "#r \"bin/Debug/net50/Nuqleon.StringSegment.dll\""
+        "#r \"bin/Debug/net6.0/Nuqleon.StringSegment.dll\""
       ]
     },
     {

--- a/Nuqleon/Core/BCL/Nuqleon.StringSegment/Nuqleon.StringSegment.csproj
+++ b/Nuqleon/Core/BCL/Nuqleon.StringSegment/Nuqleon.StringSegment.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netstandard2.1;net472;net50</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;net472;net6.0</TargetFrameworks>
     <Description>Provides a string segment representation and operations on these.</Description>
   </PropertyGroup>
 

--- a/Nuqleon/Core/BCL/Nuqleon.StringSegment/System/StringSegment.cs
+++ b/Nuqleon/Core/BCL/Nuqleon.StringSegment/System/StringSegment.cs
@@ -780,7 +780,7 @@ namespace System
                     count--;
 
                 if (value.Length == 0 && count >= 0 && minIndex >= 0)
-#if NET5_0 // https://github.com/dotnet/runtime/issues/13383
+#if NET6_0 // https://github.com/dotnet/runtime/issues/13383
                     return startIndex + 1;
 #else
                     return startIndex;
@@ -791,7 +791,7 @@ namespace System
                 throw new ArgumentOutOfRangeException(nameof(count));
 
             if (value.Length == 0)
-#if NET5_0 // https://github.com/dotnet/runtime/issues/13383
+#if NET6_0 // https://github.com/dotnet/runtime/issues/13383
                 return startIndex + 1;
 #else
                 return startIndex;
@@ -2578,7 +2578,7 @@ namespace System
         /// <returns>The concatenated members in values.</returns>
         public static StringSegment Concat<T>(IEnumerable<T> values) => typeof(T) == typeof(StringSegment) ? Concat((IEnumerable<StringSegment>)values) : string.Concat(values);
 
-#if !NET5_0 // https://github.com/dotnet/runtime/issues/27515
+#if !NET6_0 // https://github.com/dotnet/runtime/issues/27515
         /// <summary>
         /// Creates a string segment containing new instance of a System.String with the same value as a specified string segment.
         /// </summary>
@@ -2997,7 +2997,7 @@ namespace System
             }
         }
 
-#if NET5_0
+#if NET6_0
         /// <summary>
         /// Creates a new read-only span over the string segment.
         /// </summary>

--- a/Nuqleon/Core/BCL/Nuqleon.Time/GettingStarted.ipynb
+++ b/Nuqleon/Core/BCL/Nuqleon.Time/GettingStarted.ipynb
@@ -35,7 +35,7 @@
       },
       "outputs": [],
       "source": [
-        "#r \"bin/Debug/net50/Nuqleon.Time.dll\""
+        "#r \"bin/Debug/net6.0/Nuqleon.Time.dll\""
       ]
     },
     {

--- a/Nuqleon/Core/BCL/Nuqleon.Time/Nuqleon.Time.csproj
+++ b/Nuqleon/Core/BCL/Nuqleon.Time/Nuqleon.Time.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netstandard2.1;net472;net50</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;net472;net6.0</TargetFrameworks>
     <Description>A collection of utilities to deal with physical and virtual time.</Description>
   </PropertyGroup>
 

--- a/Nuqleon/Core/BCL/Tests.Nuqleon.Collections.Specialized/System/Collections/Specialized/EnumDictionaryTests.cs
+++ b/Nuqleon/Core/BCL/Tests.Nuqleon.Collections.Specialized/System/Collections/Specialized/EnumDictionaryTests.cs
@@ -17,7 +17,7 @@ using System.Collections.Specialized;
 using System.Linq;
 using System.Linq.Expressions;
 
-#if !NET5_0
+#if !NET6_0
 using System.IO;
 using System.Runtime.Serialization.Formatters.Binary;
 #endif
@@ -789,7 +789,7 @@ namespace Tests.System.Collections.Specialized
             Z = ushort.MaxValue,
         }
 
-#if !NET5_0 // https://aka.ms/binaryformatter
+#if !NET6_0 // https://aka.ms/binaryformatter
         [TestMethod]
         public void EnumSizeResolutionException_Serialization()
         {

--- a/Nuqleon/Core/BCL/Tests.Nuqleon.Collections.Specialized/Tests.Nuqleon.Collections.Specialized.csproj
+++ b/Nuqleon/Core/BCL/Tests.Nuqleon.Collections.Specialized/Tests.Nuqleon.Collections.Specialized.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net472;net50</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net472;net6.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Nuqleon/Core/BCL/Tests.Nuqleon.IO.StreamSegment/Tests.Nuqleon.IO.StreamSegment.csproj
+++ b/Nuqleon/Core/BCL/Tests.Nuqleon.IO.StreamSegment/Tests.Nuqleon.IO.StreamSegment.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net472;net50</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net472;net6.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Nuqleon/Core/BCL/Tests.Nuqleon.Memory/System/Collections/Generic/PooledDictionaryTests.cs
+++ b/Nuqleon/Core/BCL/Tests.Nuqleon.Memory/System/Collections/Generic/PooledDictionaryTests.cs
@@ -14,7 +14,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 
-#if !NET5_0
+#if !NET6_0
 using System.IO;
 using System.Runtime.Serialization.Formatters.Binary;
 #endif
@@ -215,7 +215,7 @@ namespace Tests
             }
         }
 
-#if !NET5_0 // https://aka.ms/binaryformatter
+#if !NET6_0 // https://aka.ms/binaryformatter
         [TestMethod]
         public void PooledDictionary_Serialization()
         {

--- a/Nuqleon/Core/BCL/Tests.Nuqleon.Memory/System/Collections/Generic/PooledHashSetTests.cs
+++ b/Nuqleon/Core/BCL/Tests.Nuqleon.Memory/System/Collections/Generic/PooledHashSetTests.cs
@@ -14,7 +14,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 
-#if !NET5_0
+#if !NET6_0
 using System.IO;
 using System.Runtime.Serialization.Formatters.Binary;
 #endif
@@ -203,7 +203,7 @@ namespace Tests
             }
         }
 
-#if !NET5_0 // https://aka.ms/binaryformatter
+#if !NET6_0 // https://aka.ms/binaryformatter
         [TestMethod]
         public void PooledHashSet_Serialization()
         {

--- a/Nuqleon/Core/BCL/Tests.Nuqleon.Memory/Tests.Nuqleon.Memory.csproj
+++ b/Nuqleon/Core/BCL/Tests.Nuqleon.Memory/Tests.Nuqleon.Memory.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net472;net50</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net472;net6.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Nuqleon/Core/BCL/Tests.Nuqleon.Reflection.Virtualization/System/Reflection/Tests.cs
+++ b/Nuqleon/Core/BCL/Tests.Nuqleon.Reflection.Virtualization/System/Reflection/Tests.cs
@@ -255,7 +255,7 @@ namespace Tests.System.Reflection.Virtualization
             Assert.AreEqual(substring, p.GetMethod(typeof(string), nameof(string.Substring), BindingFlags.Public | BindingFlags.Instance, binder: null, new[] { typeof(int), typeof(int) }, modifiers: null));
             Assert.AreEqual(substring, p.GetMethod(typeof(string), nameof(string.Substring), BindingFlags.Public | BindingFlags.Instance, binder: null, CallingConventions.Any, new[] { typeof(int), typeof(int) }, modifiers: null));
 
-#if NET5_0 || NETSTANDARD2_1
+#if NET6_0 || NETSTANDARD2_1
             Assert.AreEqual(substring, p.GetMethod(typeof(string), nameof(string.Substring), genericParameterCount: 0, new[] { typeof(int), typeof(int) }));
             Assert.AreEqual(substring, p.GetMethod(typeof(string), nameof(string.Substring), genericParameterCount: 0, new[] { typeof(int), typeof(int) }, modifiers: null));
             Assert.AreEqual(substring, p.GetMethod(typeof(string), nameof(string.Substring), genericParameterCount: 0, BindingFlags.Public | BindingFlags.Instance, binder: null, new[] { typeof(int), typeof(int) }, modifiers: null));
@@ -1068,7 +1068,7 @@ namespace Tests.System.Reflection.Virtualization
         {
             var asm = typeof(string).Assembly;
 
-#if !NET5_0
+#if !NET6_0
             Assert.AreEqual(asm.CodeBase, p.GetCodeBase(asm));
             Assert.AreEqual(asm.EscapedCodeBase, p.GetEscapedCodeBase(asm));
             Assert.AreEqual(asm.GlobalAssemblyCache, p.GetGlobalAssemblyCache(asm));

--- a/Nuqleon/Core/BCL/Tests.Nuqleon.Reflection.Virtualization/Tests.Nuqleon.Reflection.Virtualization.csproj
+++ b/Nuqleon/Core/BCL/Tests.Nuqleon.Reflection.Virtualization/Tests.Nuqleon.Reflection.Virtualization.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net472;net50</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net472;net6.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Nuqleon/Core/BCL/Tests.Nuqleon.StringSegment/System/StringSegmentTests.cs
+++ b/Nuqleon/Core/BCL/Tests.Nuqleon.StringSegment/System/StringSegmentTests.cs
@@ -1184,7 +1184,7 @@ namespace Tests
             );
         }
 
-#if !NET5_0
+#if !NET6_0
         [TestMethod]
         public void StringSegment_Copy_StringSegment_ArgumentChecking()
         {

--- a/Nuqleon/Core/BCL/Tests.Nuqleon.StringSegment/Tests.Nuqleon.StringSegment.csproj
+++ b/Nuqleon/Core/BCL/Tests.Nuqleon.StringSegment/Tests.Nuqleon.StringSegment.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net472;net50</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net472;net6.0</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup Condition="$(TargetFramework) == 'net472'">

--- a/Nuqleon/Core/BCL/Tests.Nuqleon.Time/Tests.Nuqleon.Time.csproj
+++ b/Nuqleon/Core/BCL/Tests.Nuqleon.Time/Tests.Nuqleon.Time.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net472;net50</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net472;net6.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Nuqleon/Core/DataModel/Nuqleon.DataModel.CompilerServices/Bonsai/EntitySubstitution/PropertyDataSlim.cs
+++ b/Nuqleon/Core/DataModel/Nuqleon.DataModel.CompilerServices/Bonsai/EntitySubstitution/PropertyDataSlim.cs
@@ -53,7 +53,7 @@ namespace Nuqleon.DataModel.CompilerServices.Bonsai
         /// <returns>A hash code.</returns>
         public override int GetHashCode() =>
             HashHelpers.Combine(
-#if NET5_0 || NETSTANDARD2_1
+#if NET6_0 || NETSTANDARD2_1
                 Name?.GetHashCode(StringComparison.Ordinal) ?? 0,
 #else
                 Name?.GetHashCode() ?? 0,

--- a/Nuqleon/Core/DataModel/Nuqleon.DataModel.CompilerServices/Nuqleon.DataModel.CompilerServices.csproj
+++ b/Nuqleon/Core/DataModel/Nuqleon.DataModel.CompilerServices/Nuqleon.DataModel.CompilerServices.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netstandard2.1;net472;net50</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;net472;net6.0</TargetFrameworks>
     <Description>Tools for creating and substituting anonymized versions of data model types in expressions.</Description>
   </PropertyGroup>
 

--- a/Nuqleon/Core/DataModel/Nuqleon.DataModel.CompilerServices/TypeSystem/DataType.cs
+++ b/Nuqleon/Core/DataModel/Nuqleon.DataModel.CompilerServices/TypeSystem/DataType.cs
@@ -340,7 +340,7 @@ namespace Nuqleon.DataModel.TypeSystem
                 var sortedTypes =
                     _namedTypes.OrderBy(kv =>
                         int.Parse(
-#if NET5_0 || NETSTANDARD2_1
+#if NET6_0 || NETSTANDARD2_1
                             kv.Value.Name[TYPEPREFIX.Length..],
 #else
                             kv.Value.Name.Substring(TYPEPREFIX.Length),

--- a/Nuqleon/Core/DataModel/Nuqleon.DataModel.CompilerServices/TypeSystem/DataTypeObjectEqualityComparator.cs
+++ b/Nuqleon/Core/DataModel/Nuqleon.DataModel.CompilerServices/TypeSystem/DataTypeObjectEqualityComparator.cs
@@ -384,7 +384,7 @@ namespace Nuqleon.DataModel.TypeSystem
                     }
 #else
                     hash = (int)(hash * Prime) +
-#if NET5_0 || NETSTANDARD2_1
+#if NET6_0 || NETSTANDARD2_1
                         property.Name.GetHashCode(StringComparison.Ordinal)
 #else
                         property.Name.GetHashCode()

--- a/Nuqleon/Core/DataModel/Nuqleon.DataModel.Serialization.Binary/Nuqleon.DataModel.Serialization.Binary.csproj
+++ b/Nuqleon/Core/DataModel/Nuqleon.DataModel.Serialization.Binary/Nuqleon.DataModel.Serialization.Binary.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netstandard2.1;net50</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;net6.0</TargetFrameworks>
     <Description>Serializers for instances of data model types.</Description>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>

--- a/Nuqleon/Core/DataModel/Nuqleon.DataModel.Serialization.Json/Nuqleon.DataModel.Serialization.Json.csproj
+++ b/Nuqleon/Core/DataModel/Nuqleon.DataModel.Serialization.Json/Nuqleon.DataModel.Serialization.Json.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netstandard2.1;net472;net50</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;net472;net6.0</TargetFrameworks>
     <Description>Serializers for instances of data model types.</Description>
   </PropertyGroup>
 

--- a/Nuqleon/Core/DataModel/Nuqleon.DataModel/Nuqleon.DataModel.csproj
+++ b/Nuqleon/Core/DataModel/Nuqleon.DataModel/Nuqleon.DataModel.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netstandard2.1;net472;net50</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;net472;net6.0</TargetFrameworks>
     <Description>Attributes for declaration of data model types.</Description>
   </PropertyGroup>
 

--- a/Nuqleon/Core/DataModel/Tests.Nuqleon.DataModel.CompilerServices/Tests.Nuqleon.DataModel.CompilerServices.csproj
+++ b/Nuqleon/Core/DataModel/Tests.Nuqleon.DataModel.CompilerServices/Tests.Nuqleon.DataModel.CompilerServices.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net472;net50</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net472;net6.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Nuqleon/Core/DataModel/Tests.Nuqleon.DataModel.Serialization.Binary/DataModelSerializerFactoryTests.cs
+++ b/Nuqleon/Core/DataModel/Tests.Nuqleon.DataModel.Serialization.Binary/DataModelSerializerFactoryTests.cs
@@ -10,7 +10,7 @@ using System.Linq;
 using System.Linq.Expressions;
 using System.Threading;
 
-#if !DEBUG && !NET5_0 // REVIEW: Some behavioral changes with finalization have been found in .NET 5.0 in Release builds.
+#if !DEBUG && !NET6_0 // REVIEW: Some behavioral changes with finalization have been found in .NET 5.0 in Release builds.
 using System.Runtime.CompilerServices;
 #endif
 
@@ -319,7 +319,7 @@ namespace Tests.Nuqleon.DataModel.Serialization.Binary
             Run(tests);
         }
 
-#if !DEBUG && !NET5_0 // REVIEW: Some behavioral changes with finalization have been found in .NET 5.0 in Release builds.
+#if !DEBUG && !NET6_0 // REVIEW: Some behavioral changes with finalization have been found in .NET 5.0 in Release builds.
         [TestMethod]
         public void DataModelSerializerFactory_GarbageCollectibleSerializerWithCycles()
         {

--- a/Nuqleon/Core/DataModel/Tests.Nuqleon.DataModel.Serialization.Binary/Tests.Nuqleon.DataModel.Serialization.Binary.csproj
+++ b/Nuqleon/Core/DataModel/Tests.Nuqleon.DataModel.Serialization.Binary/Tests.Nuqleon.DataModel.Serialization.Binary.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net472;net50</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net472;net6.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Nuqleon/Core/DataModel/Tests.Nuqleon.DataModel.Serialization.Json/DataSerializerExceptionTests.cs
+++ b/Nuqleon/Core/DataModel/Tests.Nuqleon.DataModel.Serialization.Json/DataSerializerExceptionTests.cs
@@ -10,7 +10,7 @@
 
 using System;
 
-#if !NET5_0 // https://aka.ms/binaryformatter
+#if !NET6_0 // https://aka.ms/binaryformatter
 using System.IO;
 using System.Runtime.Serialization.Formatters.Binary;
 #endif
@@ -48,7 +48,7 @@ namespace Tests.Nuqleon.DataModel.Serialization.Json
             Assert.AreSame(err, ex.InnerException);
         }
 
-#if !NET5_0 // https://aka.ms/binaryformatter
+#if !NET6_0 // https://aka.ms/binaryformatter
         [TestMethod]
         public void DataSerializerException_Serialize()
         {

--- a/Nuqleon/Core/DataModel/Tests.Nuqleon.DataModel.Serialization.Json/Tests.Nuqleon.DataModel.Serialization.Json.csproj
+++ b/Nuqleon/Core/DataModel/Tests.Nuqleon.DataModel.Serialization.Json/Tests.Nuqleon.DataModel.Serialization.Json.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net472;net50</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net472;net6.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Nuqleon/Core/DataModel/Tests.Nuqleon.DataModel/Tests.Nuqleon.DataModel.csproj
+++ b/Nuqleon/Core/DataModel/Tests.Nuqleon.DataModel/Tests.Nuqleon.DataModel.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net472;net50</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net472;net6.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Nuqleon/Core/JSON/Nuqleon.Json.Interop.Newtonsoft/GettingStarted.ipynb
+++ b/Nuqleon/Core/JSON/Nuqleon.Json.Interop.Newtonsoft/GettingStarted.ipynb
@@ -37,7 +37,7 @@
       },
       "outputs": [],
       "source": [
-        "#r \"bin/Debug/net50/Nuqleon.Json.Interop.Newtonsoft.dll\""
+        "#r \"bin/Debug/net6.0/Nuqleon.Json.Interop.Newtonsoft.dll\""
       ]
     },
     {

--- a/Nuqleon/Core/JSON/Nuqleon.Json.Interop.Newtonsoft/JsonExpressionReader.cs
+++ b/Nuqleon/Core/JSON/Nuqleon.Json.Interop.Newtonsoft/JsonExpressionReader.cs
@@ -124,7 +124,7 @@ namespace Nuqleon.Json.Interop.Newtonsoft
                         break;
                     case ExpressionType.Number:
                         var str = (string)((ConstantExpression)expr).Value;
-#if NET5_0 || NETSTANDARD2_1
+#if NET6_0 || NETSTANDARD2_1
                         if (str.Contains('.', StringComparison.Ordinal))
 #else
                         if (str.IndexOf('.') >= 0)

--- a/Nuqleon/Core/JSON/Nuqleon.Json.Interop.Newtonsoft/JsonExpressionWriter.cs
+++ b/Nuqleon/Core/JSON/Nuqleon.Json.Interop.Newtonsoft/JsonExpressionWriter.cs
@@ -637,7 +637,7 @@ namespace Nuqleon.Json.Interop.Newtonsoft
         {
             // NB: This helper is modified from Newtonsoft JSON.
 
-#if NET5_0 || NETSTANDARD2_1
+#if NET6_0 || NETSTANDARD2_1
             if (text.Contains('.', StringComparison.Ordinal) || text.Contains('E', StringComparison.Ordinal) || text.Contains('e', StringComparison.Ordinal))
 #else
             if (text.IndexOf('.') >= 0 || text.IndexOf('E') >= 0 || text.IndexOf('e') >= 0)

--- a/Nuqleon/Core/JSON/Nuqleon.Json.Interop.Newtonsoft/Nuqleon.Json.Interop.Newtonsoft.csproj
+++ b/Nuqleon/Core/JSON/Nuqleon.Json.Interop.Newtonsoft/Nuqleon.Json.Interop.Newtonsoft.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netstandard2.1;net472;net50</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;net472;net6.0</TargetFrameworks>
     <Description>Interoperability functionality between Nuqleon.Json and Newtonsoft.Json.</Description>
   </PropertyGroup>
 

--- a/Nuqleon/Core/JSON/Nuqleon.Json.Serialization/GettingStarted.ipynb
+++ b/Nuqleon/Core/JSON/Nuqleon.Json.Serialization/GettingStarted.ipynb
@@ -37,7 +37,7 @@
       },
       "outputs": [],
       "source": [
-        "#r \"bin/Debug/net50/Nuqleon.Json.Serialization.dll\""
+        "#r \"bin/Debug/net6.0/Nuqleon.Json.Serialization.dll\""
       ]
     },
     {

--- a/Nuqleon/Core/JSON/Nuqleon.Json.Serialization/Nuqleon.Json.Serialization.csproj
+++ b/Nuqleon/Core/JSON/Nuqleon.Json.Serialization/Nuqleon.Json.Serialization.csproj
@@ -1,12 +1,12 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netstandard2.1;net472;net50</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;net472;net6.0</TargetFrameworks>
     <Description>Fast serialization support for JSON data.</Description>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(TargetFramework)' == 'net50'">
+  <PropertyGroup Condition="'$(TargetFramework)' == 'net6.0'">
     <DefineConstants>USE_SPAN</DefineConstants>
   </PropertyGroup>
 

--- a/Nuqleon/Core/JSON/Nuqleon.Json.Serialization/Parser/Parser.String.cs
+++ b/Nuqleon/Core/JSON/Nuqleon.Json.Serialization/Parser/Parser.String.cs
@@ -107,7 +107,7 @@ namespace Nuqleon.Json.Serialization
                     case '"':
                         var end = i;
                         i++;
-#if NET5_0 || NETSTANDARD2_1
+#if NET6_0 || NETSTANDARD2_1
                         return str[start..end];
 #else
                         return str.Substring(start, end - start);

--- a/Nuqleon/Core/JSON/Nuqleon.Json.Serialization/Parser/Parser.cs
+++ b/Nuqleon/Core/JSON/Nuqleon.Json.Serialization/Parser/Parser.cs
@@ -582,7 +582,7 @@ namespace Nuqleon.Json.Serialization
 
 #if USE_SPAN
                             res = str.AsSpan(b, i - b);
-#elif NET5_0 || NETSTANDARD2_1
+#elif NET6_0 || NETSTANDARD2_1
                             res = str[b..i];
 #else
                             res = str.Substring(b, i - b);
@@ -735,7 +735,7 @@ namespace Nuqleon.Json.Serialization
         /// <returns>true if the specified string starts with the specified value at the specified index; otherwise, false.</returns>
         internal static bool StartsWithFast(string str, ref int i, string value)
         {
-#if NET5_0 || NETSTANDARD2_1
+#if NET6_0 || NETSTANDARD2_1
             Debug.Assert(value.IndexOf('\\', System.StringComparison.Ordinal) < 0 && value.IndexOf('"', System.StringComparison.Ordinal) < 0);
 #else
             Debug.Assert(value.IndexOf('\\') < 0 && value.IndexOf('"') < 0);

--- a/Nuqleon/Core/JSON/Nuqleon.Json/GettingStarted.ipynb
+++ b/Nuqleon/Core/JSON/Nuqleon.Json/GettingStarted.ipynb
@@ -37,7 +37,7 @@
       },
       "outputs": [],
       "source": [
-        "#r \"bin/Debug/net50/Nuqleon.Json.dll\""
+        "#r \"bin/Debug/net6.0/Nuqleon.Json.dll\""
       ]
     },
     {

--- a/Nuqleon/Core/JSON/Nuqleon.Json/Nuqleon.Json.csproj
+++ b/Nuqleon/Core/JSON/Nuqleon.Json/Nuqleon.Json.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netstandard2.1;net472;net50</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;net472;net6.0</TargetFrameworks>
     <Description>Object models, visitors, and serialization support for JSON data.</Description>
   </PropertyGroup>
 

--- a/Nuqleon/Core/JSON/Nuqleon.Json/Parser/Tokenizer.cs
+++ b/Nuqleon/Core/JSON/Nuqleon.Json/Parser/Tokenizer.cs
@@ -8,7 +8,7 @@
 // BD - November 2009 - Created this file.
 //
 
-#if NET5_0 || NETSTANDARD2_1
+#if NET6_0 || NETSTANDARD2_1
 using System;
 #endif
 using System.Collections.Generic;
@@ -238,7 +238,7 @@ namespace Nuqleon.Json.Parser
                                                     }
                                                     else
                                                     {
-#if NET5_0 || NETSTANDARD2_1
+#if NET6_0 || NETSTANDARD2_1
                                                         if (!int.TryParse(_input.AsSpan(i, 4), NumberStyles.AllowHexSpecifier, CultureInfo.InvariantCulture, out int val))
 #else
                                                         if (!int.TryParse(_input.Substring(i, 4), NumberStyles.AllowHexSpecifier, CultureInfo.InvariantCulture, out int val))
@@ -457,7 +457,7 @@ namespace Nuqleon.Json.Parser
                 }
             }
 
-#if NET5_0 || NETSTANDARD2_1
+#if NET6_0 || NETSTANDARD2_1
             return Token.Number(b, _input[b..i]);
 #else
             return Token.Number(b, _input.Substring(b, i - b));
@@ -490,7 +490,7 @@ namespace Nuqleon.Json.Parser
                 }
             }
 
-#if NET5_0 || NETSTANDARD2_1
+#if NET6_0 || NETSTANDARD2_1
             return Token.Number(b, _input[b..i]);
 #else
             return Token.Number(b, _input.Substring(b, i - b));

--- a/Nuqleon/Core/JSON/Perf.Nuqleon.Json.Serialization/Perf.Nuqleon.Json.Serialization.csproj
+++ b/Nuqleon/Core/JSON/Perf.Nuqleon.Json.Serialization/Perf.Nuqleon.Json.Serialization.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net50</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net6.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
   </PropertyGroup>
   <PropertyGroup>

--- a/Nuqleon/Core/JSON/Tests.Nuqleon.Json.Interop.Newtonsoft/Tests.Nuqleon.Json.Interop.Newtonsoft.csproj
+++ b/Nuqleon/Core/JSON/Tests.Nuqleon.Json.Interop.Newtonsoft/Tests.Nuqleon.Json.Interop.Newtonsoft.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net472;net50</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net472;net6.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Nuqleon/Core/JSON/Tests.Nuqleon.Json.Serialization/Tests.Nuqleon.Json.Serialization.csproj
+++ b/Nuqleon/Core/JSON/Tests.Nuqleon.Json.Serialization/Tests.Nuqleon.Json.Serialization.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net472;net50</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net472;net6.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Nuqleon/Core/JSON/Tests.Nuqleon.Json/ParseExceptionTests.cs
+++ b/Nuqleon/Core/JSON/Tests.Nuqleon.Json/ParseExceptionTests.cs
@@ -8,7 +8,7 @@
 // BD - May 2014 - Created this file.
 //
 
-#if !NET5_0 // https://aka.ms/binaryformatter
+#if !NET6_0 // https://aka.ms/binaryformatter
 
 using System.IO;
 using System.Runtime.Serialization.Formatters.Binary;

--- a/Nuqleon/Core/JSON/Tests.Nuqleon.Json/Tests.Nuqleon.Json.csproj
+++ b/Nuqleon/Core/JSON/Tests.Nuqleon.Json/Tests.Nuqleon.Json.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net472;net50</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net472;net6.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices.Optimizers/GettingStarted.ipynb
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices.Optimizers/GettingStarted.ipynb
@@ -35,7 +35,7 @@
       },
       "outputs": [],
       "source": [
-        "#r \"bin/Debug/net50/Nuqleon.Linq.CompilerServices.Optimizers.dll\""
+        "#r \"bin/Debug/net6.0/Nuqleon.Linq.CompilerServices.Optimizers.dll\""
       ]
     },
     {

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices.Optimizers/Nuqleon.Linq.CompilerServices.Optimizers.csproj
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices.Optimizers/Nuqleon.Linq.CompilerServices.Optimizers.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netstandard2.1;net472;net50</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;net472;net6.0</TargetFrameworks>
     <Description>Optimizers for query expressions.</Description>
   </PropertyGroup>
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices/Expressions/Diagnostics/ExpressionCSharpPrinter.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices/Expressions/Diagnostics/ExpressionCSharpPrinter.cs
@@ -561,7 +561,7 @@ namespace System.Linq.Expressions
             {
                 if (n.EndsWith("()", StringComparison.Ordinal))
                 {
-#if NET5_0 || NETSTANDARD2_1
+#if NET6_0 || NETSTANDARD2_1
                     n = n[0..^2];
 #else
                     n = n.Substring(0, n.Length - 2);
@@ -626,7 +626,7 @@ namespace System.Linq.Expressions
             {
                 if (n.EndsWith("()", StringComparison.Ordinal))
                 {
-#if NET5_0 || NETSTANDARD2_1
+#if NET6_0 || NETSTANDARD2_1
                     n = n[0..^2];
 #else
                     n = n.Substring(0, n.Length - 2);

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices/Expressions/Evaluation/LeastRecentlyUsedCompiledDelegateCache.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices/Expressions/Evaluation/LeastRecentlyUsedCompiledDelegateCache.cs
@@ -137,7 +137,7 @@ namespace System.Linq.Expressions
 
             lock (_cache)
             {
-#if NET5_0 || NETSTANDARD3_1
+#if NET6_0 || NETSTANDARD3_1
                 if (_cache.TryAdd(key, cacheEntry)) // PERF: expensive comparer (2)
                 {
 #else

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices/Expressions/ExpressionEqualityComparator.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices/Expressions/ExpressionEqualityComparator.cs
@@ -2140,7 +2140,7 @@ namespace System.Linq.CompilerServices
         /// <returns>Hash code for the given expression sequence.</returns>
         protected int GetHashCode(ReadOnlyCollection<Expression> obj)
         {
-#if NET5_0 || NETSTANDARD3_1
+#if NET6_0 || NETSTANDARD3_1
             HashCode h = default;
 
             if (obj != null)
@@ -2177,7 +2177,7 @@ namespace System.Linq.CompilerServices
         /// <returns>Hash code for the given parameter expression sequence.</returns>
         protected int GetHashCode(ReadOnlyCollection<ParameterExpression> obj)
         {
-#if NET5_0 || NETSTANDARD3_1
+#if NET6_0 || NETSTANDARD3_1
             HashCode h = default;
 
             if (obj != null)
@@ -2214,7 +2214,7 @@ namespace System.Linq.CompilerServices
         /// <returns>Hash code for the given member binding sequence.</returns>
         protected int GetHashCode(ReadOnlyCollection<MemberBinding> obj)
         {
-#if NET5_0 || NETSTANDARD3_1
+#if NET6_0 || NETSTANDARD3_1
             HashCode h = default;
 
             if (obj != null)
@@ -2251,7 +2251,7 @@ namespace System.Linq.CompilerServices
         /// <returns>Hash code for the given element initializer sequence.</returns>
         protected int GetHashCode(ReadOnlyCollection<ElementInit> obj)
         {
-#if NET5_0 || NETSTANDARD3_1
+#if NET6_0 || NETSTANDARD3_1
             HashCode h = default;
 
             if (obj != null)
@@ -2288,7 +2288,7 @@ namespace System.Linq.CompilerServices
         /// <returns>Hash code for the given switch case sequence.</returns>
         protected int GetHashCode(ReadOnlyCollection<SwitchCase> obj)
         {
-#if NET5_0 || NETSTANDARD3_1
+#if NET6_0 || NETSTANDARD3_1
             HashCode h = default;
 
             if (obj != null)
@@ -2325,7 +2325,7 @@ namespace System.Linq.CompilerServices
         /// <returns>Hash code for the given catch block sequence.</returns>
         protected int GetHashCode(ReadOnlyCollection<CatchBlock> obj)
         {
-#if NET5_0 || NETSTANDARD3_1
+#if NET6_0 || NETSTANDARD3_1
             HashCode h = default;
 
             if (obj != null)
@@ -2363,7 +2363,7 @@ namespace System.Linq.CompilerServices
         /// <returns>Hash code composed from the specified values.</returns>
         protected static int Hash(int a, int b)
         {
-#if NET5_0 || NETSTANDARD3_1
+#if NET6_0 || NETSTANDARD3_1
             return HashCode.Combine(a, b);
 #else
             unchecked
@@ -2385,7 +2385,7 @@ namespace System.Linq.CompilerServices
         /// <returns>Hash code composed from the specified values.</returns>
         protected static int Hash(int a, int b, int c)
         {
-#if NET5_0 || NETSTANDARD3_1
+#if NET6_0 || NETSTANDARD3_1
             return HashCode.Combine(a, b, c);
 #else
             unchecked
@@ -2409,7 +2409,7 @@ namespace System.Linq.CompilerServices
         /// <returns>Hash code composed from the specified values.</returns>
         protected static int Hash(int a, int b, int c, int d)
         {
-#if NET5_0 || NETSTANDARD3_1
+#if NET6_0 || NETSTANDARD3_1
             return HashCode.Combine(a, b, c, d);
 #else
             unchecked

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices/Expressions/Optimization/Interning/ExpressionToHashedExpressionTreeConverter.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices/Expressions/Optimization/Interning/ExpressionToHashedExpressionTreeConverter.cs
@@ -602,7 +602,7 @@ namespace System.Linq.Expressions
 
         private struct Hasher
         {
-#if NET5_0 || NETSTANDARD3_1
+#if NET6_0 || NETSTANDARD3_1
             private HashCode _hashCode;
 
             public void Add(int h) => _hashCode.Add(h);

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices/GettingStarted.ipynb
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices/GettingStarted.ipynb
@@ -35,7 +35,7 @@
       },
       "outputs": [],
       "source": [
-        "#r \"bin/Debug/net50/Nuqleon.Linq.CompilerServices.dll\""
+        "#r \"bin/Debug/net6.0/Nuqleon.Linq.CompilerServices.dll\""
       ]
     },
     {

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices/Nuqleon.Linq.CompilerServices.csproj
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices/Nuqleon.Linq.CompilerServices.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netstandard2.1;net472;net50</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;net472;net6.0</TargetFrameworks>
     <Description>Various utilities for creating, comparing, and modifying LINQ expression trees.</Description>
   </PropertyGroup>
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices/Reflection/Emit/RuntimeCompiler.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices/Reflection/Emit/RuntimeCompiler.cs
@@ -617,7 +617,7 @@ namespace System.Linq.CompilerServices
         {
             var asmn = new AssemblyName("__GeneratedTypes_" + Guid.NewGuid());
 
-#if NETSTANDARD || NET5_0
+#if NETSTANDARD || NET6_0
             var asmb = AssemblyBuilder.DefineDynamicAssembly(
 #else
             var asmb = AppDomain.CurrentDomain.DefineDynamicAssembly(
@@ -881,7 +881,7 @@ namespace System.Linq.CompilerServices
                 {
                     var name = property.Name;
 
-#if NET5_0 || NETSTANDARD2_1
+#if NET6_0 || NETSTANDARD2_1
                     var nameHash = name.GetHashCode(StringComparison.Ordinal);
 #else
                     var nameHash = name.GetHashCode();

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Bonsai.Hashing/GettingStarted.ipynb
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Bonsai.Hashing/GettingStarted.ipynb
@@ -35,7 +35,7 @@
       },
       "outputs": [],
       "source": [
-        "#r \"bin/Debug/net50/Nuqleon.Linq.Expressions.Bonsai.Hashing.dll\""
+        "#r \"bin/Debug/net6.0/Nuqleon.Linq.Expressions.Bonsai.Hashing.dll\""
       ]
     },
     {

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Bonsai.Hashing/Nuqleon.Linq.Expressions.Bonsai.Hashing.csproj
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Bonsai.Hashing/Nuqleon.Linq.Expressions.Bonsai.Hashing.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netstandard2.1;net472;net50</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;net472;net6.0</TargetFrameworks>
     <Description>Support for stable hashing of expression trees.</Description>
   </PropertyGroup>
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Bonsai.Hashing/System/Linq/Expressions/ExpressionSlimHasher.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Bonsai.Hashing/System/Linq/Expressions/ExpressionSlimHasher.cs
@@ -111,7 +111,7 @@ namespace System.Linq.Expressions
         /// <param name="value">The string value to get the hash code for.</param>
         /// <returns>A hash code for the specified string <paramref name="value"/>.</returns>
         protected virtual int GetHashCode(string value) =>
-#if NET5_0 || NETSTANDARD2_1
+#if NET6_0 || NETSTANDARD2_1
             value?.GetHashCode(StringComparison.Ordinal) ?? 0
 #else
             value?.GetHashCode() ?? 0

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Bonsai.Hashing/System/Linq/Expressions/StableExpressionSlimHasher.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Bonsai.Hashing/System/Linq/Expressions/StableExpressionSlimHasher.cs
@@ -50,7 +50,7 @@ namespace System.Linq.Expressions
 
             if (name != null && (_options & StableExpressionSlimHashingOptions.UseAssemblySimpleName) != 0)
             {
-#if NET5_0 || NETSTANDARD2_1
+#if NET6_0 || NETSTANDARD2_1
                 var comma = name.IndexOf(',', StringComparison.Ordinal);
 #else
                 var comma = name.IndexOf(',');

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Bonsai.Serialization/GettingStarted.ipynb
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Bonsai.Serialization/GettingStarted.ipynb
@@ -35,7 +35,7 @@
       },
       "outputs": [],
       "source": [
-        "#r \"bin/Debug/net50/Nuqleon.Linq.Expressions.Bonsai.Serialization.dll\""
+        "#r \"bin/Debug/net6.0/Nuqleon.Linq.Expressions.Bonsai.Serialization.dll\""
       ]
     },
     {

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Bonsai.Serialization/Nuqleon.Linq.Expressions.Bonsai.Serialization.csproj
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Bonsai.Serialization/Nuqleon.Linq.Expressions.Bonsai.Serialization.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netstandard2.1;net472;net50</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;net472;net6.0</TargetFrameworks>
     <Description>Isomorphic object models for a subset of the LINQ Expressions API that can be constructed and modified without type safety limitations.</Description>
   </PropertyGroup>
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Bonsai/GettingStarted.ipynb
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Bonsai/GettingStarted.ipynb
@@ -35,7 +35,7 @@
       },
       "outputs": [],
       "source": [
-        "#r \"bin/Debug/net50/Nuqleon.Linq.Expressions.Bonsai.dll\""
+        "#r \"bin/Debug/net6.0/Nuqleon.Linq.Expressions.Bonsai.dll\""
       ]
     },
     {

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Bonsai/Nuqleon.Linq.Expressions.Bonsai.csproj
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Bonsai/Nuqleon.Linq.Expressions.Bonsai.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netstandard2.1;net472;net50</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;net472;net6.0</TargetFrameworks>
     <Description>Serialization for the LINQ expressions API via slim expressions API.</Description>
     <DefineConstants>$(DefineConstants);USE_SLIM</DefineConstants>
   </PropertyGroup>

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Bonsai/System/Linq/Expressions/BlockExpressionSlim.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Bonsai/System/Linq/Expressions/BlockExpressionSlim.cs
@@ -51,7 +51,7 @@ namespace System.Linq.Expressions
             get
             {
                 Debug.Assert(Expressions.Count > 0);
-#if NET5_0 || NETSTANDARD2_1
+#if NET6_0 || NETSTANDARD2_1
                 return Expressions[^1];
 #else
                 return Expressions[Expressions.Count - 1];

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Bonsai/System/Linq/Expressions/ExpressionSlimCSharpPrinter.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Bonsai/System/Linq/Expressions/ExpressionSlimCSharpPrinter.cs
@@ -560,7 +560,7 @@ namespace System.Linq.Expressions.Bonsai
             {
                 if (n.EndsWith("()", StringComparison.Ordinal))
                 {
-#if NET5_0 || NETSTANDARD2_1
+#if NET6_0 || NETSTANDARD2_1
                     n = n[0..^2];
 #else
                     n = n.Substring(0, n.Length - 2);
@@ -638,7 +638,7 @@ namespace System.Linq.Expressions.Bonsai
                 {
                     if (n.EndsWith("()", StringComparison.Ordinal))
                     {
-#if NET5_0 || NETSTANDARD2_1
+#if NET6_0 || NETSTANDARD2_1
                         n = n[0..^2];
 #else
                         n = n.Substring(0, n.Length - 2);
@@ -916,7 +916,7 @@ namespace System.Linq.Expressions.Bonsai
 
         private static string EscapeFormat(string s)
         {
-#if NET5_0 || NETSTANDARD2_1
+#if NET6_0 || NETSTANDARD2_1
             return s.Replace("{", "{{", StringComparison.Ordinal).Replace("}", "}}", StringComparison.Ordinal);
 #else
             return s.Replace("{", "{{").Replace("}", "}}");

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Bonsai/System/Reflection/AssemblySlim.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Bonsai/System/Reflection/AssemblySlim.cs
@@ -68,7 +68,7 @@ namespace System.Reflection
         /// </summary>
         /// <returns>A hash code for the current instance.</returns>
         public override int GetHashCode() =>
-#if NET5_0 || NETSTANDARD2_1
+#if NET6_0 || NETSTANDARD2_1
             Name.GetHashCode(StringComparison.Ordinal);
 #else
             Name.GetHashCode();

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Bonsai/System/Reflection/MemberInfoSlimEqualityComparer.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Bonsai/System/Reflection/MemberInfoSlimEqualityComparer.cs
@@ -480,7 +480,7 @@ namespace System.Reflection
 
                 hash = (int)(hash * Prime) + (int)obj.MemberType;
                 hash = (int)(hash * Prime) +
-#if NET5_0 || NETSTANDARD2_1
+#if NET6_0 || NETSTANDARD2_1
                     obj.Name.GetHashCode(StringComparison.Ordinal)
 #else
                     obj.Name.GetHashCode()
@@ -524,7 +524,7 @@ namespace System.Reflection
                 var hash = _typeComparer.GetHashCode(obj.DeclaringType);
 
                 hash = (int)(hash * Prime) +
-#if NET5_0 || NETSTANDARD2_1
+#if NET6_0 || NETSTANDARD2_1
                     obj.Name.GetHashCode(StringComparison.Ordinal)
 #else
                     obj.Name.GetHashCode()
@@ -646,7 +646,7 @@ namespace System.Reflection
 
                 hash = (int)(hash * Prime) + (int)obj.MemberType;
                 hash = (int)(hash * Prime) +
-#if NET5_0 || NETSTANDARD2_1
+#if NET6_0 || NETSTANDARD2_1
                     obj.Name.GetHashCode(StringComparison.Ordinal)
 #else
                     obj.Name.GetHashCode()

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Bonsai/System/Reflection/SimpleTypeSlimBase.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Bonsai/System/Reflection/SimpleTypeSlimBase.cs
@@ -62,7 +62,7 @@ namespace System.Reflection
         {
             if (_hashCode == 0)
             {
-#if NET5_0 || NETSTANDARD2_1
+#if NET6_0 || NETSTANDARD2_1
                 var hash = Assembly?.Name?.GetHashCode(StringComparison.Ordinal) ?? 0;
                 _hashCode = (int)(hash * TypeSlimEqualityComparator.Prime) + Name.GetHashCode(StringComparison.Ordinal);
 #else

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Bonsai/System/Reflection/TypeSlimCSharpPrinter.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Bonsai/System/Reflection/TypeSlimCSharpPrinter.cs
@@ -153,7 +153,7 @@ namespace System.Reflection
 
             if (i + 1 < type.Name.Length)
             {
-#if NET5_0 || NETSTANDARD2_1
+#if NET6_0 || NETSTANDARD2_1
                 arity = int.Parse(type.Name[(i + 1)..], CultureInfo.InvariantCulture);
 #else
                 arity = int.Parse(type.Name.Substring(i + 1), CultureInfo.InvariantCulture);

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Bonsai/System/Reflection/TypeSlimEqualityComparator.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Bonsai/System/Reflection/TypeSlimEqualityComparator.cs
@@ -488,7 +488,7 @@ namespace System.Reflection
                 }
 
                 hash = (int)(hash * Prime) +
-#if NET5_0 || NETSTANDARD2_1
+#if NET6_0 || NETSTANDARD2_1
                     obj.Name.GetHashCode(StringComparison.Ordinal)
 #else
                     obj.Name.GetHashCode()

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Optimizers/GettingStarted.ipynb
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Optimizers/GettingStarted.ipynb
@@ -35,7 +35,7 @@
       },
       "outputs": [],
       "source": [
-        "#r \"bin/Debug/net50/Nuqleon.Linq.Expressions.Optimizers.dll\""
+        "#r \"bin/Debug/net6.0/Nuqleon.Linq.Expressions.Optimizers.dll\""
       ]
     },
     {

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Optimizers/Nuqleon.Linq.Expressions.Optimizers.csproj
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Optimizers/Nuqleon.Linq.Expressions.Optimizers.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netstandard2.1;net472;net50</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;net472;net6.0</TargetFrameworks>
     <Description>A set of optimizers for LINQ expression trees.</Description>
   </PropertyGroup>
 

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Optimizers/System/Linq/Expressions/ConstParameterCatalog.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Optimizers/System/Linq/Expressions/ConstParameterCatalog.cs
@@ -101,7 +101,7 @@ namespace System.Linq.Expressions
                 (byte[] inArray, int offset, int length, Base64FormattingOptions options) => global::System.Convert.ToBase64String(inArray, offset, length, options),
                 (byte[] inArray, global::System.Base64FormattingOptions options) => global::System.Convert.ToBase64String(inArray, options),
 
-#if NET5_0
+#if NET6_0
                 (byte[] inArray) => global::System.Convert.ToHexString(inArray),
                 (byte[] inArray, int offset, int length) => global::System.Convert.ToHexString(inArray, offset, length),
 #endif

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Optimizers/System/Linq/Expressions/ImmutableTypeCatalog.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Optimizers/System/Linq/Expressions/ImmutableTypeCatalog.cs
@@ -166,10 +166,10 @@ namespace System.Linq.Expressions
 
                 // NB: ValueTuple types are mutable.
 
-#if NET5_0
+#if NET6_0
                 typeof(Half),
 #endif
-#if NET5_0 || NETSTANDARD2_1
+#if NET6_0 || NETSTANDARD2_1
                 typeof(Index),
                 typeof(Range),
 #endif

--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Optimizers/System/Linq/Expressions/PureMemberCatalog.cs
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Optimizers/System/Linq/Expressions/PureMemberCatalog.cs
@@ -198,7 +198,7 @@ namespace System.Linq.Expressions
                 (ulong i, ulong j) => i.Equals(j),
             }.ToReadOnly();
 
-#if NET5_0
+#if NET6_0
             /// <summary>
             /// Gets a table of pure members on <see cref="global::System.Half" />.
             /// </summary>
@@ -250,7 +250,7 @@ namespace System.Linq.Expressions
                 (float i, float j) => i.CompareTo(j),
                 (float i, float j) => i.Equals(j),
 
-#if NET5_0 || NETSTANDARD2_1
+#if NET6_0 || NETSTANDARD2_1
                 (float i) => float.IsFinite(i),
                 (float i) => float.IsNegative(i),
                 (float i) => float.IsNormal(i),
@@ -271,7 +271,7 @@ namespace System.Linq.Expressions
                 (double i, double j) => i.CompareTo(j),
                 (double i, double j) => i.Equals(j),
 
-#if NET5_0 || NETSTANDARD2_1
+#if NET6_0 || NETSTANDARD2_1
                 (double i) => double.IsFinite(i),
                 (double i) => double.IsNegative(i),
                 (double i) => double.IsNormal(i),
@@ -442,7 +442,7 @@ namespace System.Linq.Expressions
                 (string s1, string s2) => s1 == s2,
                 (string s1, string s2) => s1 != s2,
 
-#if NET5_0 || NETSTANDARD2_1
+#if NET6_0 || NETSTANDARD2_1
                 (string s, char c) => s.Contains(c),
                 (string s, char c) => s.StartsWith(c),
                 (string s, char c) => s.EndsWith(c),
@@ -647,7 +647,7 @@ namespace System.Linq.Expressions
                 (global::System.TimeSpan t1, global::System.TimeSpan t2) => t1 > t2,
                 (global::System.TimeSpan t1, global::System.TimeSpan t2) => t1 >= t2,
 
-#if NET5_0 || NETSTANDARD2_1
+#if NET6_0 || NETSTANDARD2_1
                 (global::System.TimeSpan t, double divisor) => t.Divide(divisor),
                 (global::System.TimeSpan t, global::System.TimeSpan ts) => t.Divide(ts),
                 (global::System.TimeSpan t, double factor) => t.Multiply(factor),
@@ -742,7 +742,7 @@ namespace System.Linq.Expressions
                 (char character) => global::System.Uri.IsHexDigit(character),
                 (string pattern, int index) => global::System.Uri.IsHexEncoding(pattern, index),
                 (string stringToEscape) => global::System.Uri.EscapeDataString(stringToEscape),
-                (string stringToEscape) => global::System.Uri.EscapeUriString(stringToEscape),
+                //(string stringToEscape) => global::System.Uri.EscapeUriString(stringToEscape),
                 (string stringToUnescape) => global::System.Uri.UnescapeDataString(stringToUnescape),
                 (string uriString, global::System.UriKind uriKind) => global::System.Uri.IsWellFormedUriString(uriString, uriKind),
 
@@ -977,7 +977,7 @@ namespace System.Linq.Expressions
             {
                 () => global::System.Math.E,
                 () => global::System.Math.PI,
-#if NET5_0
+#if NET6_0
                 () => global::System.Math.Tau,
 #endif
 
@@ -1050,7 +1050,7 @@ namespace System.Linq.Expressions
                 (decimal value) => global::System.Math.Sign(value),
                 (int a, int b) => global::System.Math.BigMul(a, b),
 
-#if NET5_0 || NETSTANDARD2_1
+#if NET6_0 || NETSTANDARD2_1
                 (double d) => global::System.Math.Acosh(d),
                 (double d) => global::System.Math.Asinh(d),
                 (double d) => global::System.Math.Atanh(d),
@@ -1067,7 +1067,7 @@ namespace System.Linq.Expressions
                 (float value, float min, float max) => global::System.Math.Clamp(value, min, max),
                 (decimal value, decimal min, decimal max) => global::System.Math.Clamp(value, min, max),
 #endif
-#if NET5_0
+#if NET6_0
                 (double x) => global::System.Math.BitDecrement(x),
                 (double x) => global::System.Math.BitIncrement(x),
                 (double x) => global::System.Math.ILogB(x),
@@ -1080,7 +1080,7 @@ namespace System.Linq.Expressions
 #endif
             }.ToReadOnly();
 
-#if NET5_0 || NETSTANDARD2_1
+#if NET6_0 || NETSTANDARD2_1
             /// <summary>
             /// Gets a table of pure members on <see cref="global::System.MathF" />.
             /// </summary>
@@ -1122,7 +1122,7 @@ namespace System.Linq.Expressions
                 (float x) => global::System.MathF.Tanh(x),
                 (float x) => global::System.MathF.Truncate(x),
 
-#if NET5_0
+#if NET6_0
                 () => global::System.MathF.Tau,
 
                 (float x) => global::System.MathF.BitDecrement(x),
@@ -1161,7 +1161,7 @@ namespace System.Linq.Expressions
                 (byte[] value, int startIndex) => global::System.BitConverter.ToString(value, startIndex),
                 (byte[] value, int startIndex, int length) => global::System.BitConverter.ToString(value, startIndex, length),
 
-#if NET5_0 || NETSTANDARD2_1
+#if NET6_0 || NETSTANDARD2_1
                 (float value) => global::System.BitConverter.SingleToInt32Bits(value),
                 (int value) => global::System.BitConverter.Int32BitsToSingle(value),
 #endif
@@ -1388,7 +1388,7 @@ namespace System.Linq.Expressions
                 (byte[] inArray, int offset, int length, Base64FormattingOptions options) => global::System.Convert.ToBase64String(inArray, offset, length, options),
                 (byte[] inArray, Base64FormattingOptions options) => global::System.Convert.ToBase64String(inArray, options),
 
-#if NET5_0
+#if NET6_0
                 (byte[] inArray) => global::System.Convert.ToHexString(inArray),
                 (byte[] inArray, int offset, int length) => global::System.Convert.ToHexString(inArray, offset, length),
 #endif
@@ -1439,7 +1439,7 @@ namespace System.Linq.Expressions
                 // REVIEW: In practice, it is assumed that predicates are pure. Should we provide a table including these members, so users can opt-in?
             }.ToReadOnly();
 
-#if NET5_0 || NETSTANDARD2_1
+#if NET6_0 || NETSTANDARD2_1
             /// <summary>
             /// Gets a table of pure members on <see cref="global::System.Index" />.
             /// </summary>
@@ -1755,10 +1755,10 @@ namespace System.Linq.Expressions
                 BitConverter,
                 Convert,
                 Array,
-#if NET5_0
+#if NET6_0
                 Half,
 #endif
-#if NET5_0 || NETSTANDARD2_1
+#if NET6_0 || NETSTANDARD2_1
                 Index,
                 Range,
                 MathF,

--- a/Nuqleon/Core/LINQ/SampleTrees/SampleTrees.csproj
+++ b/Nuqleon/Core/LINQ/SampleTrees/SampleTrees.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netstandard2.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;net6.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
     <AnalysisMode>Default</AnalysisMode>

--- a/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.CompilerServices.Optimizers/Tests.Nuqleon.Linq.CompilerServices.Optimizers.csproj
+++ b/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.CompilerServices.Optimizers/Tests.Nuqleon.Linq.CompilerServices.Optimizers.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net472;net50</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net472;net6.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.CompilerServices/Evaluation/EvaluationTests.cs
+++ b/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.CompilerServices/Evaluation/EvaluationTests.cs
@@ -338,7 +338,7 @@ namespace Tests.System.Linq.CompilerServices
         [TestMethod]
         public void CachedLambdaCompiler_TooManyConstantsForLCGTypes()
         {
-#if NETCOREAPP2_1 || NETCOREAPP3_1 || NET5_0
+#if NETCOREAPP2_1 || NETCOREAPP3_1 || NET6_0
             var asm = AssemblyBuilder.DefineDynamicAssembly(new AssemblyName("EvalTests_foo"), AssemblyBuilderAccess.RunAndCollect);
 #else
             var asm = AppDomain.CurrentDomain.DefineDynamicAssembly(new AssemblyName("EvalTests_foo"), AssemblyBuilderAccess.RunAndCollect);

--- a/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.CompilerServices/Expressions/UnboundParameterExceptionTests.cs
+++ b/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.CompilerServices/Expressions/UnboundParameterExceptionTests.cs
@@ -13,7 +13,7 @@ using System.Linq;
 using System.Linq.CompilerServices;
 using System.Linq.Expressions;
 
-#if !NET5_0 // https://aka.ms/binaryformatter
+#if !NET6_0 // https://aka.ms/binaryformatter
 using System.IO;
 using System.Runtime.Serialization.Formatters.Binary;
 #endif
@@ -44,7 +44,7 @@ namespace Tests.System.Linq.CompilerServices
             Assert.IsTrue(p.SequenceEqual(ex.Parameters));
         }
 
-#if !NET5_0 // https://aka.ms/binaryformatter
+#if !NET6_0 // https://aka.ms/binaryformatter
         [TestMethod]
         public void UnboundParameterException_Serialize()
         {

--- a/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.CompilerServices/Tests.Nuqleon.Linq.CompilerServices.csproj
+++ b/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.CompilerServices/Tests.Nuqleon.Linq.CompilerServices.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net472;net50</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net472;net6.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.Expressions.Bonsai.Hashing/Tests.Nuqleon.Linq.Expressions.Bonsai.Hashing.csproj
+++ b/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.Expressions.Bonsai.Hashing/Tests.Nuqleon.Linq.Expressions.Bonsai.Hashing.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net472;net50</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net472;net6.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.Expressions.Bonsai.Serialization/BonsaiParseException.cs
+++ b/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.Expressions.Bonsai.Serialization/BonsaiParseException.cs
@@ -14,7 +14,7 @@ using System.Linq.Expressions.Bonsai.Serialization;
 
 using Json = Nuqleon.Json.Expressions;
 
-#if !NET5_0 // https://aka.ms/binaryformatter
+#if !NET6_0 // https://aka.ms/binaryformatter
 using System.IO;
 using System.Runtime.Serialization.Formatters.Binary;
 #endif
@@ -34,7 +34,7 @@ namespace Tests
             Assert.AreEqual("foo", ex.Message);
             Assert.AreSame(json, ex.Node);
 
-#if !NET5_0 // https://aka.ms/binaryformatter
+#if !NET6_0 // https://aka.ms/binaryformatter
             var f = new BinaryFormatter();
 
             var ms = new MemoryStream();

--- a/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.Expressions.Bonsai.Serialization/Tests.Nuqleon.Linq.Expressions.Bonsai.Serialization.csproj
+++ b/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.Expressions.Bonsai.Serialization/Tests.Nuqleon.Linq.Expressions.Bonsai.Serialization.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net472;net50</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net472;net6.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.Expressions.Bonsai/System/Reflection/TypeSlimEqualityComparer.cs
+++ b/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.Expressions.Bonsai/System/Reflection/TypeSlimEqualityComparer.cs
@@ -234,7 +234,7 @@ namespace Tests.System.Reflection
             Assert.IsTrue(true);
         }
 
-#if NET5_0 || NETCOREAPP3_1
+#if NET6_0 || NETCOREAPP3_1
         [Ignore] // See NB comment below; the implementation detail changed in .NET Core 3.1 and above.
 #endif
         [TestMethod]

--- a/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.Expressions.Bonsai/System/Reflection/TypeSlimVisitor.cs
+++ b/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.Expressions.Bonsai/System/Reflection/TypeSlimVisitor.cs
@@ -330,7 +330,7 @@ namespace Tests.System.Reflection
             {
                 if (type.Name.StartsWith("System.Func`"))
                 {
-#if NET5_0 || NETCOREAPP3_1
+#if NET6_0 || NETCOREAPP3_1
                     var action = "System.Action`" + type.Name["System.Func`".Length..];
 #else
                     var action = "System.Action`" + type.Name.Substring("System.Func`".Length);

--- a/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.Expressions.Bonsai/Tests.Nuqleon.Linq.Expressions.Bonsai.csproj
+++ b/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.Expressions.Bonsai/Tests.Nuqleon.Linq.Expressions.Bonsai.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net472;net50</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net472;net6.0</TargetFrameworks>
     <DefineConstants>$(DefineConstants);USE_SLIM</DefineConstants>
   </PropertyGroup>
 

--- a/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.Expressions.Optimizers/PureMemberCatalogTests.cs
+++ b/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.Expressions.Optimizers/PureMemberCatalogTests.cs
@@ -64,12 +64,12 @@ namespace Tests.System.Linq.Expressions.Optimizers
 
             { typeof(Array), new HashSet<object> { Array.Empty<int>(), Array.Empty<string>(), new int[] { 1 }, new int[] { 1, 2, 3, 4, 5 } } }, // TODO: Add multi-dimensional arrays
 
-#if NET5_0 || NETCOREAPP3_1
+#if NET6_0 || NETCOREAPP3_1
             { typeof(Index), new HashSet<object> { (Index)0, ^0, (Index)1, ^2 } },
             { typeof(Range), new HashSet<object> { .., 0.., ..0, 1.., ..1, ^1.., ..^1, 1..2, ^2..^1 } },
 #endif
 
-#if NET5_0
+#if NET6_0
             { typeof(Half), new HashSet<object> { (Half)0.0, (Half)1.0, Half.PositiveInfinity } },
 #endif
         };

--- a/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.Expressions.Optimizers/Tests.Nuqleon.Linq.Expressions.Optimizers.csproj
+++ b/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.Expressions.Optimizers/Tests.Nuqleon.Linq.Expressions.Optimizers.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net472;net50</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net472;net6.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Nuqleon/Pearls/BCL/ProjectJohnnie/Nuqleon.Memory.Diagnostics/Nuqleon.Memory.Diagnostics.csproj
+++ b/Nuqleon/Pearls/BCL/ProjectJohnnie/Nuqleon.Memory.Diagnostics/Nuqleon.Memory.Diagnostics.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net472;net50</TargetFrameworks>
+    <TargetFrameworks>net472;net6.0</TargetFrameworks>
     <Description>Provides utilities to analyze memory usage.</Description>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>

--- a/Nuqleon/Pearls/BCL/ProjectJohnnie/Nuqleon.Memory.Diagnostics/System/Runtime/CompilerServices/TypeHelpers.cs
+++ b/Nuqleon/Pearls/BCL/ProjectJohnnie/Nuqleon.Memory.Diagnostics/System/Runtime/CompilerServices/TypeHelpers.cs
@@ -98,7 +98,7 @@ namespace System.Runtime.CompilerServices
             // Define a dynamic assembly and module only usable for execution of dynamic code at runtime.
             //
 
-#if NETSTANDARD || NET5_0
+#if NETSTANDARD || NET6_0
             var asm = AssemblyBuilder.DefineDynamicAssembly(
 #else
             var asm = AppDomain.CurrentDomain.DefineDynamicAssembly(

--- a/Nuqleon/Pearls/BCL/ProjectJohnnie/Tests.Nuqleon.Memory.Diagnostics/HeapEditorTests.cs
+++ b/Nuqleon/Pearls/BCL/ProjectJohnnie/Tests.Nuqleon.Memory.Diagnostics/HeapEditorTests.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#if !NET5_0
+#if !NET6_0
 using System;
 #endif
 using System.Collections.Generic;
@@ -100,7 +100,7 @@ namespace Tests
             Assert.AreEqual("FOO", p.Value.t.s);
         }
 
-#if !NET5_0 // NB: Broken due to change to KeyValuePair<K, V> where fields are now read-only (where they weren't before). See test case below.
+#if !NET6_0 // NB: Broken due to change to KeyValuePair<K, V> where fields are now read-only (where they weren't before). See test case below.
         [TestMethod]
         public void HeapEditor_Basics_Struct_Nested2()
         {

--- a/Nuqleon/Pearls/BCL/ProjectJohnnie/Tests.Nuqleon.Memory.Diagnostics/Tests.Nuqleon.Memory.Diagnostics.csproj
+++ b/Nuqleon/Pearls/BCL/ProjectJohnnie/Tests.Nuqleon.Memory.Diagnostics/Tests.Nuqleon.Memory.Diagnostics.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net472;net50</TargetFrameworks>
+    <TargetFrameworks>net472;net6.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Nuqleon/Pearls/LINQ/BinaryExpressionSerialization/BinaryExpressionSerialization/Nuqleon.Pearls.Linq.Expressions.Bonsai.Serialization.Binary.Perf.csproj
+++ b/Nuqleon/Pearls/LINQ/BinaryExpressionSerialization/BinaryExpressionSerialization/Nuqleon.Pearls.Linq.Expressions.Bonsai.Serialization.Binary.Perf.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <OutputType>Exe</OutputType>
   </PropertyGroup>

--- a/Nuqleon/Pearls/LINQ/BinaryExpressionSerialization/Tests/Tests.Nuqleon.Pearls.Linq.Expressions.Bonsai.Serialization.Binary.csproj
+++ b/Nuqleon/Pearls/LINQ/BinaryExpressionSerialization/Tests/Tests.Nuqleon.Pearls.Linq.Expressions.Bonsai.Serialization.Binary.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net472;net50</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net472;net6.0</TargetFrameworks>
     <!-- NB: Also supports non-slim expressions. Currently not enabled in build. -->
     <DefineConstants>$(DefineConstants);USE_SLIM</DefineConstants>
   </PropertyGroup>

--- a/Nuqleon/Pearls/LINQ/ExpressionJit/ExpressionJit/Nuqleon.Linq.Expressions.Jit.Playground.csproj
+++ b/Nuqleon/Pearls/LINQ/ExpressionJit/ExpressionJit/Nuqleon.Linq.Expressions.Jit.Playground.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net50</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Nuqleon.Linq.Expressions.Jit\Nuqleon.Linq.Expressions.Jit.csproj" />

--- a/Nuqleon/Pearls/LINQ/ExpressionJit/Nuqleon.Linq.Expressions.Jit/Nuqleon.Linq.Expressions.Jit.csproj
+++ b/Nuqleon/Pearls/LINQ/ExpressionJit/Nuqleon.Linq.Expressions.Jit/Nuqleon.Linq.Expressions.Jit.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net472;net50</TargetFrameworks>
+    <TargetFrameworks>net472;net6.0</TargetFrameworks>
     <Description>Just-in-time compiler for expression trees.</Description>
   </PropertyGroup>
 

--- a/Nuqleon/Pearls/LINQ/ExpressionJit/Nuqleon.Linq.Expressions.Jit/System/Linq/Expressions/Optimizer.cs
+++ b/Nuqleon/Pearls/LINQ/ExpressionJit/Nuqleon.Linq.Expressions.Jit/System/Linq/Expressions/Optimizer.cs
@@ -341,7 +341,7 @@ namespace System.Linq.Expressions
                             //
                             // Stuff the result in the last expression slot.
                             //
-#if NET5_0
+#if NET6_0
                             outerBlock[^1] = result;
 #else
                             outerBlock[outerBlock.Length - 1] = result;

--- a/Nuqleon/Pearls/LINQ/ExpressionJit/Nuqleon.Linq.Expressions.Jit/System/Runtime/CompilerServices/RuntimeOps.cs
+++ b/Nuqleon/Pearls/LINQ/ExpressionJit/Nuqleon.Linq.Expressions.Jit/System/Runtime/CompilerServices/RuntimeOps.cs
@@ -1,7 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#if NET5_0
+#if NET6_0
 
 //
 // NB: These are stubs on .NET 5.0 because these APIs are no longer public. We could reimplement RuntimeVariables support

--- a/Nuqleon/Pearls/LINQ/ExpressionJit/Nuqleon.Linq.Expressions.Jit/System/Runtime/CompilerServices/RuntimeTypeFactory.ClosureTypeCompiler.cs
+++ b/Nuqleon/Pearls/LINQ/ExpressionJit/Nuqleon.Linq.Expressions.Jit/System/Runtime/CompilerServices/RuntimeTypeFactory.ClosureTypeCompiler.cs
@@ -20,7 +20,7 @@ namespace System.Runtime.CompilerServices
         /// </summary>
         private static class ClosureTypeCompiler
         {
-#if !NET5_0
+#if !NET6_0
             /// <summary>
             /// The lock to protect against double-initialization of the module builder.
             /// </summary>

--- a/Nuqleon/Pearls/LINQ/ExpressionJit/Nuqleon.Linq.Expressions.Jit/System/Runtime/CompilerServices/RuntimeTypeFactory.ThunkTypeCompiler.cs
+++ b/Nuqleon/Pearls/LINQ/ExpressionJit/Nuqleon.Linq.Expressions.Jit/System/Runtime/CompilerServices/RuntimeTypeFactory.ThunkTypeCompiler.cs
@@ -26,7 +26,7 @@ namespace System.Runtime.CompilerServices
         /// </summary>
         private static class ThunkTypeCompiler
         {
-#if !NET5_0
+#if !NET6_0
             /// <summary>
             /// The lock to protect against double-initialization of the module builder.
             /// </summary>
@@ -126,7 +126,7 @@ namespace System.Runtime.CompilerServices
             /// </summary>
             private static readonly MethodInfo s_interlockedIncrement = typeof(Interlocked).GetMethod(nameof(Interlocked.Increment), new[] { typeof(int).MakeByRefType() });
 
-#if !NET5_0
+#if !NET6_0
             /// <summary>
             /// Gets the module builder used to emit dynamically generated thunk (and related) types.
             /// </summary>

--- a/Nuqleon/Pearls/LINQ/ExpressionJit/Nuqleon.Linq.Expressions.Jit/System/Runtime/CompilerServices/RuntimeTypeFactory.cs
+++ b/Nuqleon/Pearls/LINQ/ExpressionJit/Nuqleon.Linq.Expressions.Jit/System/Runtime/CompilerServices/RuntimeTypeFactory.cs
@@ -23,7 +23,7 @@ namespace System.Runtime.CompilerServices
         /// </summary>
         private static readonly object s_lock = new();
 
-#if NET5_0
+#if NET6_0
         //
         // NB: Deals with the following exception:
         //

--- a/Nuqleon/Pearls/LINQ/ExpressionJit/Tests.Nuqleon.Linq.Expressions.Jit/System/Runtime/CompilerServices/RuntimeOpsExTests.cs
+++ b/Nuqleon/Pearls/LINQ/ExpressionJit/Tests.Nuqleon.Linq.Expressions.Jit/System/Runtime/CompilerServices/RuntimeOpsExTests.cs
@@ -361,7 +361,7 @@ namespace Tests
             Assert.AreEqual(44, r[0]);
         }
 
-#if !NET5_0 // See RuntimeOps. Some functionality is currently not supported.
+#if !NET6_0 // See RuntimeOps. Some functionality is currently not supported.
         [TestMethod]
         public void Quote_RuntimeVariables_Hoisted3()
         {

--- a/Nuqleon/Pearls/LINQ/ExpressionJit/Tests.Nuqleon.Linq.Expressions.Jit/Tests.Nuqleon.Linq.Expressions.Jit.csproj
+++ b/Nuqleon/Pearls/LINQ/ExpressionJit/Tests.Nuqleon.Linq.Expressions.Jit/Tests.Nuqleon.Linq.Expressions.Jit.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net472;net50</TargetFrameworks>
+    <TargetFrameworks>net472;net6.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Nuqleon/Pearls/LINQ/PartialExpressionEvaluator/Library/Nuqleon.Pearls.PartialExpressionTreeEvaluator.csproj
+++ b/Nuqleon/Pearls/LINQ/PartialExpressionEvaluator/Library/Nuqleon.Pearls.PartialExpressionTreeEvaluator.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netstandard2.1;net472;net50</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;net472;net6.0</TargetFrameworks>
     <Description>Prototype of partial expression tree evaluation.</Description>
   </PropertyGroup>
 

--- a/Nuqleon/Pearls/LINQ/PartialExpressionEvaluator/PartialTreeEvaluator/Nuqleon.Pearls.PartialExpressionTreeEvaluator.Playground.csproj
+++ b/Nuqleon/Pearls/LINQ/PartialExpressionEvaluator/PartialTreeEvaluator/Nuqleon.Pearls.PartialExpressionTreeEvaluator.Playground.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <OutputType>Exe</OutputType>
   </PropertyGroup>

--- a/Nuqleon/Pearls/LINQ/PartialExpressionEvaluator/Test/Tests.Nuqleon.Pearls.PartialExpressionTreeEvaluator.csproj
+++ b/Nuqleon/Pearls/LINQ/PartialExpressionEvaluator/Test/Tests.Nuqleon.Pearls.PartialExpressionTreeEvaluator.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net472;net50</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net472;net6.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Reaqtive/Core/Reaqtive.Core/Reaqtive.Core.csproj
+++ b/Reaqtive/Core/Reaqtive.Core/Reaqtive.Core.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netstandard2.1;net472;net50</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;net472;net6.0</TargetFrameworks>
     <Description>Base classes for building query operators in Reaqtive.</Description>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>

--- a/Reaqtive/Core/Reaqtive.Interfaces/Reaqtive.Interfaces.csproj
+++ b/Reaqtive/Core/Reaqtive.Interfaces/Reaqtive.Interfaces.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netstandard2.1;net472;net50</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;net472;net6.0</TargetFrameworks>
     <Description>Interfaces for building query operators in Reaqtive.</Description>
   </PropertyGroup>
 

--- a/Reaqtive/Core/Reaqtive.Linq/Reaqtive.Linq.csproj
+++ b/Reaqtive/Core/Reaqtive.Linq/Reaqtive.Linq.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netstandard2.1;net472;net50</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;net472;net6.0</TargetFrameworks>
     <Description>Provides implementations of Rx-style query operators.</Description>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>

--- a/Reaqtive/Core/Reaqtive.Quotation/Reaqtive.Quotation.csproj
+++ b/Reaqtive/Core/Reaqtive.Quotation/Reaqtive.Quotation.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netstandard2.1;net472;net50</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;net472;net6.0</TargetFrameworks>
     <Description>Provides support for quotation of reactive artifacts when hosted in a query engine.</Description>
   </PropertyGroup>
 

--- a/Reaqtive/Core/Reaqtive.Scheduler/Reaqtive.Scheduler.csproj
+++ b/Reaqtive/Core/Reaqtive.Scheduler/Reaqtive.Scheduler.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netstandard2.1;net472;net50</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;net472;net6.0</TargetFrameworks>
     <Description>Reaqtive scheduler interface and implementation for managing asynchronous behavior.</Description>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>

--- a/Reaqtive/Core/Reaqtive.TestingFramework/Reaqtive.TestingFramework.csproj
+++ b/Reaqtive/Core/Reaqtive.TestingFramework/Reaqtive.TestingFramework.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netstandard2.1;net472;net50</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;net472;net6.0</TargetFrameworks>
     <Description>Testing framework for Reaqtive query operators.</Description>
     <!-- TODODOC -->
     <GenerateDocumentationFile>false</GenerateDocumentationFile>

--- a/Reaqtive/Core/Reaqtive.TestingFramework/TestRunner/TestAssemblyRunner.cs
+++ b/Reaqtive/Core/Reaqtive.TestingFramework/TestRunner/TestAssemblyRunner.cs
@@ -43,7 +43,7 @@ namespace Reaqtive.TestingFramework.TestRunner
             _testClasses.ForEach(r => r.Dispose());
         }
 
-#if NET5_0
+#if NET6_0
         [Obsolete("This Remoting API is not supported and throws PlatformNotSupportedException.")]
 #endif
         public override object InitializeLifetimeService() => null;

--- a/Reaqtive/Core/Tests.Reaqtive.Core/Tests.Reaqtive.Core.csproj
+++ b/Reaqtive/Core/Tests.Reaqtive.Core/Tests.Reaqtive.Core.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net472;net50</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net472;net6.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Reaqtive/Core/Tests.Reaqtive.Linq/Tests.Reaqtive.Linq.csproj
+++ b/Reaqtive/Core/Tests.Reaqtive.Linq/Tests.Reaqtive.Linq.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net472;net50</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net472;net6.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Reaqtive/Core/Tests.Reaqtive.Quotation/Tests.Reaqtive.Quotation.csproj
+++ b/Reaqtive/Core/Tests.Reaqtive.Quotation/Tests.Reaqtive.Quotation.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net472;net50</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net472;net6.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Reaqtive/Core/Tests.Reaqtive.Scheduler/Tests.Reaqtive.Scheduler.csproj
+++ b/Reaqtive/Core/Tests.Reaqtive.Scheduler/Tests.Reaqtive.Scheduler.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net472;net50</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net472;net6.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Reaqtive/Pearls/Rxcel/Reaqtive.Pearls.Rxcel.csproj
+++ b/Reaqtive/Pearls/Rxcel/Reaqtive.Pearls.Rxcel.csproj
@@ -1,12 +1,12 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup Condition="$(NETCoreSdkRuntimeIdentifier.StartsWith('win'))">
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net5.0-windows</TargetFramework>
+    <TargetFramework>net6.0-windows</TargetFramework>
     <UseWindowsForms>true</UseWindowsForms>
   </PropertyGroup>
   <PropertyGroup Condition="!$(NETCoreSdkRuntimeIdentifier.StartsWith('win'))">
     <OutputType>Exe</OutputType>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <DefineConstants>$(DefineConstants);NO_UI</DefineConstants>
   </PropertyGroup>
   <PropertyGroup>

--- a/Reaqtor/Core/Client/Reaqtor.Client.Core/Reaqtor.Client.Core.csproj
+++ b/Reaqtor/Core/Client/Reaqtor.Client.Core/Reaqtor.Client.Core.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netstandard2.1;net472;net50</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;net472;net6.0</TargetFrameworks>
     <Description>Provides base classes and utilities for building clients of reactive event processing services.</Description>
   </PropertyGroup>
 

--- a/Reaqtor/Core/Client/Reaqtor.Client.Model/Reaqtor.Client.Model.csproj
+++ b/Reaqtor/Core/Client/Reaqtor.Client.Model/Reaqtor.Client.Model.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netstandard2.1;net472;net50</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;net472;net6.0</TargetFrameworks>
     <Description>Provides interfaces used by clients of reactive event processing services.</Description>
   </PropertyGroup>
 

--- a/Reaqtor/Core/Client/Reaqtor.Client/Reaqtor.Client.csproj
+++ b/Reaqtor/Core/Client/Reaqtor.Client/Reaqtor.Client.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netstandard2.1;net472;net50</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;net472;net6.0</TargetFrameworks>
     <Description>Provides abstractions used by clients of reactive event processing services.</Description>
   </PropertyGroup>
 

--- a/Reaqtor/Core/Client/Tests.Reaqtor.Client.Core/Tests.Reaqtor.Client.Core.csproj
+++ b/Reaqtor/Core/Client/Tests.Reaqtor.Client.Core/Tests.Reaqtor.Client.Core.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net472;net50</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net472;net6.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Reaqtor/Core/Client/Tests.Reaqtor.Client/ReactiveClientContextHigherArityTests.cs
+++ b/Reaqtor/Core/Client/Tests.Reaqtor.Client/ReactiveClientContextHigherArityTests.cs
@@ -8172,7 +8172,7 @@ namespace Tests.Reaqtor.Client
                     Assert.ThrowsException<ArgumentNullException>(() => ((IAsyncReactiveSubscriptionFactory<string, string>)factory).CreateAsync(subscriptionUri: null, "factory_parameter_1", "factory_parameter_2", state: null).Wait());
                     Assert.ThrowsException<ArgumentNullException>(() => ((IAsyncReactiveSubscriptionFactory<string, string>)factory).CreateAsync(subscriptionUri: null, "factory_parameter_1", "factory_parameter_2", state: null, CancellationToken.None).Wait());
 
-#if NET5_0 || NETCOREAPP3_1 // Suppresses CA2012
+#if NET6_0 || NETCOREAPP3_1 // Suppresses CA2012
                     sub.DisposeAsync().AsTask().Wait();
 #else
                     sub.DisposeAsync().Wait();
@@ -8210,7 +8210,7 @@ namespace Tests.Reaqtor.Client
                     Assert.ThrowsException<ArgumentNullException>(() => ((IAsyncReactiveSubscriptionFactory<string, string, string>)factory).CreateAsync(subscriptionUri: null, "factory_parameter_1", "factory_parameter_2", "factory_parameter_3", state: null).Wait());
                     Assert.ThrowsException<ArgumentNullException>(() => ((IAsyncReactiveSubscriptionFactory<string, string, string>)factory).CreateAsync(subscriptionUri: null, "factory_parameter_1", "factory_parameter_2", "factory_parameter_3", state: null, CancellationToken.None).Wait());
 
-#if NET5_0 || NETCOREAPP3_1 // Suppresses CA2012
+#if NET6_0 || NETCOREAPP3_1 // Suppresses CA2012
                     sub.DisposeAsync().AsTask().Wait();
 #else
                     sub.DisposeAsync().Wait();
@@ -8249,7 +8249,7 @@ namespace Tests.Reaqtor.Client
                     Assert.ThrowsException<ArgumentNullException>(() => ((IAsyncReactiveSubscriptionFactory<string, string, string, string>)factory).CreateAsync(subscriptionUri: null, "factory_parameter_1", "factory_parameter_2", "factory_parameter_3", "factory_parameter_4", state: null).Wait());
                     Assert.ThrowsException<ArgumentNullException>(() => ((IAsyncReactiveSubscriptionFactory<string, string, string, string>)factory).CreateAsync(subscriptionUri: null, "factory_parameter_1", "factory_parameter_2", "factory_parameter_3", "factory_parameter_4", state: null, CancellationToken.None).Wait());
 
-#if NET5_0 || NETCOREAPP3_1 // Suppresses CA2012
+#if NET6_0 || NETCOREAPP3_1 // Suppresses CA2012
                     sub.DisposeAsync().AsTask().Wait();
 #else
                     sub.DisposeAsync().Wait();
@@ -8289,7 +8289,7 @@ namespace Tests.Reaqtor.Client
                     Assert.ThrowsException<ArgumentNullException>(() => ((IAsyncReactiveSubscriptionFactory<string, string, string, string, string>)factory).CreateAsync(subscriptionUri: null, "factory_parameter_1", "factory_parameter_2", "factory_parameter_3", "factory_parameter_4", "factory_parameter_5", state: null).Wait());
                     Assert.ThrowsException<ArgumentNullException>(() => ((IAsyncReactiveSubscriptionFactory<string, string, string, string, string>)factory).CreateAsync(subscriptionUri: null, "factory_parameter_1", "factory_parameter_2", "factory_parameter_3", "factory_parameter_4", "factory_parameter_5", state: null, CancellationToken.None).Wait());
 
-#if NET5_0 || NETCOREAPP3_1 // Suppresses CA2012
+#if NET6_0 || NETCOREAPP3_1 // Suppresses CA2012
                     sub.DisposeAsync().AsTask().Wait();
 #else
                     sub.DisposeAsync().Wait();
@@ -8330,7 +8330,7 @@ namespace Tests.Reaqtor.Client
                     Assert.ThrowsException<ArgumentNullException>(() => ((IAsyncReactiveSubscriptionFactory<string, string, string, string, string, string>)factory).CreateAsync(subscriptionUri: null, "factory_parameter_1", "factory_parameter_2", "factory_parameter_3", "factory_parameter_4", "factory_parameter_5", "factory_parameter_6", state: null).Wait());
                     Assert.ThrowsException<ArgumentNullException>(() => ((IAsyncReactiveSubscriptionFactory<string, string, string, string, string, string>)factory).CreateAsync(subscriptionUri: null, "factory_parameter_1", "factory_parameter_2", "factory_parameter_3", "factory_parameter_4", "factory_parameter_5", "factory_parameter_6", state: null, CancellationToken.None).Wait());
 
-#if NET5_0 || NETCOREAPP3_1 // Suppresses CA2012
+#if NET6_0 || NETCOREAPP3_1 // Suppresses CA2012
                     sub.DisposeAsync().AsTask().Wait();
 #else
                     sub.DisposeAsync().Wait();
@@ -8372,7 +8372,7 @@ namespace Tests.Reaqtor.Client
                     Assert.ThrowsException<ArgumentNullException>(() => ((IAsyncReactiveSubscriptionFactory<string, string, string, string, string, string, string>)factory).CreateAsync(subscriptionUri: null, "factory_parameter_1", "factory_parameter_2", "factory_parameter_3", "factory_parameter_4", "factory_parameter_5", "factory_parameter_6", "factory_parameter_7", state: null).Wait());
                     Assert.ThrowsException<ArgumentNullException>(() => ((IAsyncReactiveSubscriptionFactory<string, string, string, string, string, string, string>)factory).CreateAsync(subscriptionUri: null, "factory_parameter_1", "factory_parameter_2", "factory_parameter_3", "factory_parameter_4", "factory_parameter_5", "factory_parameter_6", "factory_parameter_7", state: null, CancellationToken.None).Wait());
 
-#if NET5_0 || NETCOREAPP3_1 // Suppresses CA2012
+#if NET6_0 || NETCOREAPP3_1 // Suppresses CA2012
                     sub.DisposeAsync().AsTask().Wait();
 #else
                     sub.DisposeAsync().Wait();
@@ -8415,7 +8415,7 @@ namespace Tests.Reaqtor.Client
                     Assert.ThrowsException<ArgumentNullException>(() => ((IAsyncReactiveSubscriptionFactory<string, string, string, string, string, string, string, string>)factory).CreateAsync(subscriptionUri: null, "factory_parameter_1", "factory_parameter_2", "factory_parameter_3", "factory_parameter_4", "factory_parameter_5", "factory_parameter_6", "factory_parameter_7", "factory_parameter_8", state: null).Wait());
                     Assert.ThrowsException<ArgumentNullException>(() => ((IAsyncReactiveSubscriptionFactory<string, string, string, string, string, string, string, string>)factory).CreateAsync(subscriptionUri: null, "factory_parameter_1", "factory_parameter_2", "factory_parameter_3", "factory_parameter_4", "factory_parameter_5", "factory_parameter_6", "factory_parameter_7", "factory_parameter_8", state: null, CancellationToken.None).Wait());
 
-#if NET5_0 || NETCOREAPP3_1 // Suppresses CA2012
+#if NET6_0 || NETCOREAPP3_1 // Suppresses CA2012
                     sub.DisposeAsync().AsTask().Wait();
 #else
                     sub.DisposeAsync().Wait();
@@ -8459,7 +8459,7 @@ namespace Tests.Reaqtor.Client
                     Assert.ThrowsException<ArgumentNullException>(() => ((IAsyncReactiveSubscriptionFactory<string, string, string, string, string, string, string, string, string>)factory).CreateAsync(subscriptionUri: null, "factory_parameter_1", "factory_parameter_2", "factory_parameter_3", "factory_parameter_4", "factory_parameter_5", "factory_parameter_6", "factory_parameter_7", "factory_parameter_8", "factory_parameter_9", state: null).Wait());
                     Assert.ThrowsException<ArgumentNullException>(() => ((IAsyncReactiveSubscriptionFactory<string, string, string, string, string, string, string, string, string>)factory).CreateAsync(subscriptionUri: null, "factory_parameter_1", "factory_parameter_2", "factory_parameter_3", "factory_parameter_4", "factory_parameter_5", "factory_parameter_6", "factory_parameter_7", "factory_parameter_8", "factory_parameter_9", state: null, CancellationToken.None).Wait());
 
-#if NET5_0 || NETCOREAPP3_1 // Suppresses CA2012
+#if NET6_0 || NETCOREAPP3_1 // Suppresses CA2012
                     sub.DisposeAsync().AsTask().Wait();
 #else
                     sub.DisposeAsync().Wait();
@@ -8504,7 +8504,7 @@ namespace Tests.Reaqtor.Client
                     Assert.ThrowsException<ArgumentNullException>(() => ((IAsyncReactiveSubscriptionFactory<string, string, string, string, string, string, string, string, string, string>)factory).CreateAsync(subscriptionUri: null, "factory_parameter_1", "factory_parameter_2", "factory_parameter_3", "factory_parameter_4", "factory_parameter_5", "factory_parameter_6", "factory_parameter_7", "factory_parameter_8", "factory_parameter_9", "factory_parameter_10", state: null).Wait());
                     Assert.ThrowsException<ArgumentNullException>(() => ((IAsyncReactiveSubscriptionFactory<string, string, string, string, string, string, string, string, string, string>)factory).CreateAsync(subscriptionUri: null, "factory_parameter_1", "factory_parameter_2", "factory_parameter_3", "factory_parameter_4", "factory_parameter_5", "factory_parameter_6", "factory_parameter_7", "factory_parameter_8", "factory_parameter_9", "factory_parameter_10", state: null, CancellationToken.None).Wait());
 
-#if NET5_0 || NETCOREAPP3_1 // Suppresses CA2012
+#if NET6_0 || NETCOREAPP3_1 // Suppresses CA2012
                     sub.DisposeAsync().AsTask().Wait();
 #else
                     sub.DisposeAsync().Wait();
@@ -8550,7 +8550,7 @@ namespace Tests.Reaqtor.Client
                     Assert.ThrowsException<ArgumentNullException>(() => ((IAsyncReactiveSubscriptionFactory<string, string, string, string, string, string, string, string, string, string, string>)factory).CreateAsync(subscriptionUri: null, "factory_parameter_1", "factory_parameter_2", "factory_parameter_3", "factory_parameter_4", "factory_parameter_5", "factory_parameter_6", "factory_parameter_7", "factory_parameter_8", "factory_parameter_9", "factory_parameter_10", "factory_parameter_11", state: null).Wait());
                     Assert.ThrowsException<ArgumentNullException>(() => ((IAsyncReactiveSubscriptionFactory<string, string, string, string, string, string, string, string, string, string, string>)factory).CreateAsync(subscriptionUri: null, "factory_parameter_1", "factory_parameter_2", "factory_parameter_3", "factory_parameter_4", "factory_parameter_5", "factory_parameter_6", "factory_parameter_7", "factory_parameter_8", "factory_parameter_9", "factory_parameter_10", "factory_parameter_11", state: null, CancellationToken.None).Wait());
 
-#if NET5_0 || NETCOREAPP3_1 // Suppresses CA2012
+#if NET6_0 || NETCOREAPP3_1 // Suppresses CA2012
                     sub.DisposeAsync().AsTask().Wait();
 #else
                     sub.DisposeAsync().Wait();
@@ -8597,7 +8597,7 @@ namespace Tests.Reaqtor.Client
                     Assert.ThrowsException<ArgumentNullException>(() => ((IAsyncReactiveSubscriptionFactory<string, string, string, string, string, string, string, string, string, string, string, string>)factory).CreateAsync(subscriptionUri: null, "factory_parameter_1", "factory_parameter_2", "factory_parameter_3", "factory_parameter_4", "factory_parameter_5", "factory_parameter_6", "factory_parameter_7", "factory_parameter_8", "factory_parameter_9", "factory_parameter_10", "factory_parameter_11", "factory_parameter_12", state: null).Wait());
                     Assert.ThrowsException<ArgumentNullException>(() => ((IAsyncReactiveSubscriptionFactory<string, string, string, string, string, string, string, string, string, string, string, string>)factory).CreateAsync(subscriptionUri: null, "factory_parameter_1", "factory_parameter_2", "factory_parameter_3", "factory_parameter_4", "factory_parameter_5", "factory_parameter_6", "factory_parameter_7", "factory_parameter_8", "factory_parameter_9", "factory_parameter_10", "factory_parameter_11", "factory_parameter_12", state: null, CancellationToken.None).Wait());
 
-#if NET5_0 || NETCOREAPP3_1 // Suppresses CA2012
+#if NET6_0 || NETCOREAPP3_1 // Suppresses CA2012
                     sub.DisposeAsync().AsTask().Wait();
 #else
                     sub.DisposeAsync().Wait();
@@ -8645,7 +8645,7 @@ namespace Tests.Reaqtor.Client
                     Assert.ThrowsException<ArgumentNullException>(() => ((IAsyncReactiveSubscriptionFactory<string, string, string, string, string, string, string, string, string, string, string, string, string>)factory).CreateAsync(subscriptionUri: null, "factory_parameter_1", "factory_parameter_2", "factory_parameter_3", "factory_parameter_4", "factory_parameter_5", "factory_parameter_6", "factory_parameter_7", "factory_parameter_8", "factory_parameter_9", "factory_parameter_10", "factory_parameter_11", "factory_parameter_12", "factory_parameter_13", state: null).Wait());
                     Assert.ThrowsException<ArgumentNullException>(() => ((IAsyncReactiveSubscriptionFactory<string, string, string, string, string, string, string, string, string, string, string, string, string>)factory).CreateAsync(subscriptionUri: null, "factory_parameter_1", "factory_parameter_2", "factory_parameter_3", "factory_parameter_4", "factory_parameter_5", "factory_parameter_6", "factory_parameter_7", "factory_parameter_8", "factory_parameter_9", "factory_parameter_10", "factory_parameter_11", "factory_parameter_12", "factory_parameter_13", state: null, CancellationToken.None).Wait());
 
-#if NET5_0 || NETCOREAPP3_1 // Suppresses CA2012
+#if NET6_0 || NETCOREAPP3_1 // Suppresses CA2012
                     sub.DisposeAsync().AsTask().Wait();
 #else
                     sub.DisposeAsync().Wait();
@@ -8694,7 +8694,7 @@ namespace Tests.Reaqtor.Client
                     Assert.ThrowsException<ArgumentNullException>(() => ((IAsyncReactiveSubscriptionFactory<string, string, string, string, string, string, string, string, string, string, string, string, string, string>)factory).CreateAsync(subscriptionUri: null, "factory_parameter_1", "factory_parameter_2", "factory_parameter_3", "factory_parameter_4", "factory_parameter_5", "factory_parameter_6", "factory_parameter_7", "factory_parameter_8", "factory_parameter_9", "factory_parameter_10", "factory_parameter_11", "factory_parameter_12", "factory_parameter_13", "factory_parameter_14", state: null).Wait());
                     Assert.ThrowsException<ArgumentNullException>(() => ((IAsyncReactiveSubscriptionFactory<string, string, string, string, string, string, string, string, string, string, string, string, string, string>)factory).CreateAsync(subscriptionUri: null, "factory_parameter_1", "factory_parameter_2", "factory_parameter_3", "factory_parameter_4", "factory_parameter_5", "factory_parameter_6", "factory_parameter_7", "factory_parameter_8", "factory_parameter_9", "factory_parameter_10", "factory_parameter_11", "factory_parameter_12", "factory_parameter_13", "factory_parameter_14", state: null, CancellationToken.None).Wait());
 
-#if NET5_0 || NETCOREAPP3_1 // Suppresses CA2012
+#if NET6_0 || NETCOREAPP3_1 // Suppresses CA2012
                     sub.DisposeAsync().AsTask().Wait();
 #else
                     sub.DisposeAsync().Wait();
@@ -8744,7 +8744,7 @@ namespace Tests.Reaqtor.Client
                     Assert.ThrowsException<ArgumentNullException>(() => ((IAsyncReactiveSubscriptionFactory<string, string, string, string, string, string, string, string, string, string, string, string, string, string, string>)factory).CreateAsync(subscriptionUri: null, "factory_parameter_1", "factory_parameter_2", "factory_parameter_3", "factory_parameter_4", "factory_parameter_5", "factory_parameter_6", "factory_parameter_7", "factory_parameter_8", "factory_parameter_9", "factory_parameter_10", "factory_parameter_11", "factory_parameter_12", "factory_parameter_13", "factory_parameter_14", "factory_parameter_15", state: null).Wait());
                     Assert.ThrowsException<ArgumentNullException>(() => ((IAsyncReactiveSubscriptionFactory<string, string, string, string, string, string, string, string, string, string, string, string, string, string, string>)factory).CreateAsync(subscriptionUri: null, "factory_parameter_1", "factory_parameter_2", "factory_parameter_3", "factory_parameter_4", "factory_parameter_5", "factory_parameter_6", "factory_parameter_7", "factory_parameter_8", "factory_parameter_9", "factory_parameter_10", "factory_parameter_11", "factory_parameter_12", "factory_parameter_13", "factory_parameter_14", "factory_parameter_15", state: null, CancellationToken.None).Wait());
 
-#if NET5_0 || NETCOREAPP3_1 // Suppresses CA2012
+#if NET6_0 || NETCOREAPP3_1 // Suppresses CA2012
                     sub.DisposeAsync().AsTask().Wait();
 #else
                     sub.DisposeAsync().Wait();

--- a/Reaqtor/Core/Client/Tests.Reaqtor.Client/ReactiveClientContextHigherArityTests.tt
+++ b/Reaqtor/Core/Client/Tests.Reaqtor.Client/ReactiveClientContextHigherArityTests.tt
@@ -932,7 +932,7 @@ for (int i = 2; i<=highestSupportedArity; i++) {
                     Assert.ThrowsException<ArgumentNullException>(() => ((IAsyncReactiveSubscriptionFactory<<#=string.Join(", ", Enumerable.Repeat("string", i).ToArray())#>>)factory).CreateAsync(subscriptionUri: null, <#=args#>, state: null).Wait());
                     Assert.ThrowsException<ArgumentNullException>(() => ((IAsyncReactiveSubscriptionFactory<<#=string.Join(", ", Enumerable.Repeat("string", i).ToArray())#>>)factory).CreateAsync(subscriptionUri: null, <#=args#>, state: null, CancellationToken.None).Wait());
 
-#if NET5_0 || NETCOREAPP3_1 // Suppresses CA2012
+#if NET6_0 || NETCOREAPP3_1 // Suppresses CA2012
                     sub.DisposeAsync().AsTask().Wait();
 #else
                     sub.DisposeAsync().Wait();

--- a/Reaqtor/Core/Client/Tests.Reaqtor.Client/ReactiveClientContextTests.cs
+++ b/Reaqtor/Core/Client/Tests.Reaqtor.Client/ReactiveClientContextTests.cs
@@ -75,7 +75,7 @@ namespace Tests.Reaqtor.Client
         [TestMethod]
         public void ReactiveClientContext_Qubscription_ArgumentChecking()
         {
-#if !NET5_0 && !NETCOREAPP3_1
+#if !NET6_0 && !NETCOREAPP3_1
             Assert.ThrowsException<ArgumentNullException>(() => ((IAsyncReactiveQubscription)null).DisposeAsync());
 #endif
             Assert.ThrowsException<ArgumentNullException>(() => ((IAsyncReactiveQubscription)null).AsDisposable());
@@ -886,7 +886,7 @@ namespace Tests.Reaqtor.Client
                     var s1 = ctx.GetSubscription(new Uri(Constants.Subscription.SUB2));
                     var s2 = ctx.GetSubscription(new Uri(Constants.Subscription.SUB3));
 
-#if NET5_0 || NETCOREAPP3_1 // Suppresses CA2012
+#if NET6_0 || NETCOREAPP3_1 // Suppresses CA2012
                     s.DisposeAsync(CancellationToken.None).AsTask();
                     s1.DisposeAsync().AsTask();
 #else
@@ -923,7 +923,7 @@ namespace Tests.Reaqtor.Client
                     qubject.SubscribeAsync(ctx.GetObserver<int>(new Uri(Constants.Observer.OB)), new Uri(Constants.Subscription.SUB), null, CancellationToken.None);
 
                     ctx.GetStream<int, int>(new Uri(Constants.Stream.FOO)).DisposeAsync()
-#if NET5_0 || NETCOREAPP3_1
+#if NET6_0 || NETCOREAPP3_1
                         .AsTask()
 #endif
                         .Wait();
@@ -995,7 +995,7 @@ namespace Tests.Reaqtor.Client
                     factory.CreateAsync(new Uri(Constants.Subscription.SUB1), null).Wait();
 
                     ctx.GetSubscription(new Uri(Constants.Subscription.SUB1)).DisposeAsync()
-#if NET5_0 || NETCOREAPP3_1
+#if NET6_0 || NETCOREAPP3_1
                         .AsTask()
 #endif
                         .Wait();

--- a/Reaqtor/Core/Client/Tests.Reaqtor.Client/Tests.Reaqtor.Client.csproj
+++ b/Reaqtor/Core/Client/Tests.Reaqtor.Client/Tests.Reaqtor.Client.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net472;net50</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net472;net6.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Reaqtor/Core/Engine/Reaqtor.Engine.Contracts/Reaqtor.Engine.Contracts.csproj
+++ b/Reaqtor/Core/Engine/Reaqtor.Engine.Contracts/Reaqtor.Engine.Contracts.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netstandard2.1;net472;net50</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;net472;net6.0</TargetFrameworks>
     <Description>Provides a set of interfaces used to host query engines in reactive event processing services.</Description>
   </PropertyGroup>
 

--- a/Reaqtor/Core/Engine/Reaqtor.QueryEngine.Interfaces/Reaqtor.QueryEngine.Interfaces.csproj
+++ b/Reaqtor/Core/Engine/Reaqtor.QueryEngine.Interfaces/Reaqtor.QueryEngine.Interfaces.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netstandard2.1;net472;net50</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;net472;net6.0</TargetFrameworks>
     <Description>Interfaces describing a Reaqtor query engine.</Description>
   </PropertyGroup>
 

--- a/Reaqtor/Core/Engine/Reaqtor.QueryEngine.KeyValueStore.InMemory/InMemoryKeyValueStore.cs
+++ b/Reaqtor/Core/Engine/Reaqtor.QueryEngine.KeyValueStore.InMemory/InMemoryKeyValueStore.cs
@@ -269,7 +269,7 @@ namespace Reaqtor.QueryEngine.KeyValueStore.InMemory
                     new ProjectingEnumerator<KeyValuePair<string, byte[]>, KeyValuePair<string, byte[]>>(
                         (IEnumerator<KeyValuePair<string, byte[]>>)res.Result,
                         kvp => new KeyValuePair<string, byte[]>(
-#if NET5_0 || NETSTANDARD2_1
+#if NET6_0 || NETSTANDARD2_1
                             kvp.Key[len..],
 #else
                             kvp.Key.Substring(len),

--- a/Reaqtor/Core/Engine/Reaqtor.QueryEngine.KeyValueStore.InMemory/InMemoryStateStore.cs
+++ b/Reaqtor/Core/Engine/Reaqtor.QueryEngine.KeyValueStore.InMemory/InMemoryStateStore.cs
@@ -353,7 +353,7 @@ namespace Reaqtor.QueryEngine.KeyValueStore.InMemory
                         foreach (var chunk in kv2.Value.Buffer(40))
                         {
                             var bytes = BitConverter.ToString(chunk)
-#if NET5_0 || NETSTANDARD2_1
+#if NET6_0 || NETSTANDARD2_1
                                 .Replace("-", " ", StringComparison.Ordinal)
 #else
                                 .Replace("-", " ")

--- a/Reaqtor/Core/Engine/Reaqtor.QueryEngine.KeyValueStore.InMemory/Reaqtor.QueryEngine.KeyValueStore.InMemory.csproj
+++ b/Reaqtor/Core/Engine/Reaqtor.QueryEngine.KeyValueStore.InMemory/Reaqtor.QueryEngine.KeyValueStore.InMemory.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netstandard2.1;net472;net50</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;net472;net6.0</TargetFrameworks>
     <Description>In-memory key/value store implementation for the Reaqtor query engine.</Description>
     <!-- TODODOC -->
     <GenerateDocumentationFile>false</GenerateDocumentationFile>

--- a/Reaqtor/Core/Engine/Reaqtor.QueryEngine.Mocks/Reaqtor.QueryEngine.Mocks.csproj
+++ b/Reaqtor/Core/Engine/Reaqtor.QueryEngine.Mocks/Reaqtor.QueryEngine.Mocks.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netstandard2.1;net472;net50</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;net472;net6.0</TargetFrameworks>
     <Description>Mocks for extensibility points in the Reaqtor query engine.</Description>
     <!-- TODODOC -->
     <GenerateDocumentationFile>false</GenerateDocumentationFile>

--- a/Reaqtor/Core/Engine/Reaqtor.QueryEngine.ReificationFramework/Reaqtor.QueryEngine.ReificationFramework.csproj
+++ b/Reaqtor/Core/Engine/Reaqtor.QueryEngine.ReificationFramework/Reaqtor.QueryEngine.ReificationFramework.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netstandard2.1;net472;net50</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;net472;net6.0</TargetFrameworks>
     <Description>Reified representations of operations performed by the Reaqtor query engine.</Description>
     <!-- TODODOC -->
     <GenerateDocumentationFile>false</GenerateDocumentationFile>

--- a/Reaqtor/Core/Engine/Reaqtor.QueryEngine.Serialization.DataModel/Reaqtor.QueryEngine.Serialization.DataModel.csproj
+++ b/Reaqtor/Core/Engine/Reaqtor.QueryEngine.Serialization.DataModel/Reaqtor.QueryEngine.Serialization.DataModel.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netstandard2.1;net472;net50</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;net472;net6.0</TargetFrameworks>
     <Description>Implementation of query engine state persistence using the Nuqleon DataModel serialization framework.</Description>
   </PropertyGroup>
 

--- a/Reaqtor/Core/Engine/Reaqtor.QueryEngine/Reaqtor.QueryEngine.csproj
+++ b/Reaqtor/Core/Engine/Reaqtor.QueryEngine/Reaqtor.QueryEngine.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netstandard2.1;net472;net50</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;net472;net6.0</TargetFrameworks>
     <Description>Provides a query engine implementation used to host reactive event processing computations with checkpointing support.</Description>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>

--- a/Reaqtor/Core/Engine/Reaqtor.QueryEngine/Reaqtor/QueryEngine/CheckpointingQueryEngine.cs
+++ b/Reaqtor/Core/Engine/Reaqtor.QueryEngine/Reaqtor/QueryEngine/CheckpointingQueryEngine.cs
@@ -286,7 +286,7 @@ namespace Reaqtor.QueryEngine
 #pragma warning disable IDE0079 // Remove unnecessary suppressions.
 #pragma warning disable CA1816 // Dispose methods should call SuppressFinalize. (Analyzer does not yet know about IAsyncDisposable.)
 
-#if NET5_0 || NETSTANDARD2_1
+#if NET6_0 || NETSTANDARD2_1
         /// <summary>
         /// Disposes resources asynchronously.
         /// </summary>
@@ -314,7 +314,7 @@ namespace Reaqtor.QueryEngine
         /// Disposes resources asynchronously.
         /// </summary>
         /// <returns>A task to await the completion of the dispose operation.</returns>
-#if NET5_0 || NETSTANDARD2_1
+#if NET6_0 || NETSTANDARD2_1
         protected virtual async ValueTask DisposeAsyncCore()
 #else
         protected virtual async Task DisposeAsyncCore()
@@ -359,7 +359,7 @@ namespace Reaqtor.QueryEngine
 
                     UnloadAsync().Wait();
                     _tracker.DisposeAsync()
-#if NET5_0 || NETSTANDARD2_1
+#if NET6_0 || NETSTANDARD2_1
                         .AsTask()
 #endif
                         .Wait();

--- a/Reaqtor/Core/Engine/Reaqtor.QueryEngine/Reaqtor/QueryEngine/OperationTracker.cs
+++ b/Reaqtor/Core/Engine/Reaqtor.QueryEngine/Reaqtor/QueryEngine/OperationTracker.cs
@@ -79,7 +79,7 @@ namespace Reaqtor.QueryEngine
         /// Disposes the component by draining the remaining work. This call blocks until all work has
         /// completed.
         /// </summary>
-#if NET5_0 || NETSTANDARD2_1
+#if NET6_0 || NETSTANDARD2_1
         public async ValueTask DisposeAsync()
 #else
         public async Task DisposeAsync(CancellationToken token)

--- a/Reaqtor/Core/Engine/Reaqtor.QueryEngine/Reaqtor/QueryEngine/Registry/InvertedDefinitionEntityComparer.cs
+++ b/Reaqtor/Core/Engine/Reaqtor.QueryEngine/Reaqtor/QueryEngine/Registry/InvertedDefinitionEntityComparer.cs
@@ -50,7 +50,7 @@ namespace Reaqtor.QueryEngine
             protected override int GetHashCodeGlobalParameter(ParameterExpression obj)
             {
                 var hash = obj.Name != null
-#if NET5_0 || NETSTANDARD2_1
+#if NET6_0 || NETSTANDARD2_1
                     ? obj.Name.GetHashCode(System.StringComparison.Ordinal)
 #else
                     ? obj.Name.GetHashCode()

--- a/Reaqtor/Core/Engine/Reaqtor.QueryEngine/Reaqtor/QueryEngine/Registry/RegistryQueryProvider.cs
+++ b/Reaqtor/Core/Engine/Reaqtor.QueryEngine/Reaqtor/QueryEngine/Registry/RegistryQueryProvider.cs
@@ -299,7 +299,7 @@ namespace Reaqtor.QueryEngine
 
             public DateTimeOffset CreationTime => throw new NotImplementedException();
 
-#if NET5_0 || NETSTANDARD2_1
+#if NET6_0 || NETSTANDARD2_1
             public ValueTask DisposeAsync() => throw new NotImplementedException();
 #else
             public Task DisposeAsync(System.Threading.CancellationToken token) => throw new NotImplementedException();

--- a/Reaqtor/Core/Engine/Tests.Reaqtor.QueryEngine/ExceptionTests.cs
+++ b/Reaqtor/Core/Engine/Tests.Reaqtor.QueryEngine/ExceptionTests.cs
@@ -5,7 +5,7 @@
 
 using System;
 
-#if !NET5_0
+#if !NET6_0
 using System.IO;
 using System.Runtime.Serialization.Formatters.Binary;
 #endif
@@ -66,7 +66,7 @@ namespace Tests.Reaqtor.QueryEngine
             Assert.AreSame(inner, ex.InnerException);
         }
 
-#if !NET5_0 // https://aka.ms/binaryformatter
+#if !NET6_0 // https://aka.ms/binaryformatter
         [TestMethod]
         public void EntityAlreadyExistsException_Serialization()
         {
@@ -141,7 +141,7 @@ namespace Tests.Reaqtor.QueryEngine
             Assert.AreSame(inner, ex.InnerException);
         }
 
-#if !NET5_0 // https://aka.ms/binaryformatter
+#if !NET6_0 // https://aka.ms/binaryformatter
         [TestMethod]
         public void EntityNotFoundException_Serialization()
         {
@@ -207,7 +207,7 @@ namespace Tests.Reaqtor.QueryEngine
             Assert.AreSame(inner, ex.InnerException);
         }
 
-#if !NET5_0 // https://aka.ms/binaryformatter
+#if !NET6_0 // https://aka.ms/binaryformatter
         [TestMethod]
         public void EntityLoadFailedException_Serialization()
         {
@@ -269,7 +269,7 @@ namespace Tests.Reaqtor.QueryEngine
             Assert.AreSame(inner, ex.InnerException);
         }
 
-#if !NET5_0 // https://aka.ms/binaryformatter
+#if !NET6_0 // https://aka.ms/binaryformatter
         [TestMethod]
         public void EntitySaveFailedException_Serialization()
         {
@@ -331,7 +331,7 @@ namespace Tests.Reaqtor.QueryEngine
             Assert.AreEqual("foo", ex.Message);
         }
 
-#if !NET5_0 // https://aka.ms/binaryformatter
+#if !NET6_0 // https://aka.ms/binaryformatter
         [TestMethod]
         public void EngineUnloadedException_Serialize()
         {

--- a/Reaqtor/Core/Engine/Tests.Reaqtor.QueryEngine/OneQueryEngineSanityTests.cs
+++ b/Reaqtor/Core/Engine/Tests.Reaqtor.QueryEngine/OneQueryEngineSanityTests.cs
@@ -103,7 +103,7 @@ namespace Tests.Reaqtor.QueryEngine
         [TestMethod]
         public async Task DefineUndefineObservableAsync()
         {
-#if NET5_0 || NETCOREAPP3_1 // NB: Only using ValueTask-based DisposeAsync in .NET Standard 2.1 and beyond at the moment.
+#if NET6_0 || NETCOREAPP3_1 // NB: Only using ValueTask-based DisposeAsync in .NET Standard 2.1 and beyond at the moment.
             await
 #endif
             using var qe = CreateQueryEngine();
@@ -147,7 +147,7 @@ namespace Tests.Reaqtor.QueryEngine
         [TestMethod]
         public async Task DefineUndefineObserverAsync()
         {
-#if NET5_0 || NETCOREAPP3_1 // NB: Only using ValueTask-based DisposeAsync in .NET Standard 2.1 and beyond at the moment.
+#if NET6_0 || NETCOREAPP3_1 // NB: Only using ValueTask-based DisposeAsync in .NET Standard 2.1 and beyond at the moment.
             await
 #endif
             using var qe = CreateQueryEngine();
@@ -191,7 +191,7 @@ namespace Tests.Reaqtor.QueryEngine
         [TestMethod]
         public async Task DefineUndefineStreamFactoryAsync()
         {
-#if NET5_0 || NETCOREAPP3_1 // NB: Only using ValueTask-based DisposeAsync in .NET Standard 2.1 and beyond at the moment.
+#if NET6_0 || NETCOREAPP3_1 // NB: Only using ValueTask-based DisposeAsync in .NET Standard 2.1 and beyond at the moment.
             await
 #endif
             using var qe = CreateQueryEngine();
@@ -298,7 +298,7 @@ namespace Tests.Reaqtor.QueryEngine
         [TestMethod]
         public async Task SubscriptionLifecycleAsync()
         {
-#if NET5_0 || NETCOREAPP3_1 // NB: Only using ValueTask-based DisposeAsync in .NET Standard 2.1 and beyond at the moment.
+#if NET6_0 || NETCOREAPP3_1 // NB: Only using ValueTask-based DisposeAsync in .NET Standard 2.1 and beyond at the moment.
             await
 #endif
             using var qe = CreateQueryEngine();
@@ -534,7 +534,7 @@ namespace Tests.Reaqtor.QueryEngine
             }
 
             sub.DisposeAsync(CancellationToken.None)
-#if NET5_0 || NETCOREAPP3_1
+#if NET6_0 || NETCOREAPP3_1
                 .AsTask()
 #endif
                 .Wait();
@@ -1099,7 +1099,7 @@ namespace Tests.Reaqtor.QueryEngine
         {
             var kvs = new InMemoryKeyValueStore();
 
-#if NET5_0 || NETCOREAPP3_1 // NB: Only using ValueTask-based DisposeAsync in .NET Standard 2.1 and beyond at the moment.
+#if NET6_0 || NETCOREAPP3_1 // NB: Only using ValueTask-based DisposeAsync in .NET Standard 2.1 and beyond at the moment.
             await
 #endif
             using (var qe1 = CreateQueryEngine(kvs))
@@ -1114,7 +1114,7 @@ namespace Tests.Reaqtor.QueryEngine
                 Crash();
             }
 
-#if NET5_0 || NETCOREAPP3_1 // NB: Only using ValueTask-based DisposeAsync in .NET Standard 2.1 and beyond at the moment.
+#if NET6_0 || NETCOREAPP3_1 // NB: Only using ValueTask-based DisposeAsync in .NET Standard 2.1 and beyond at the moment.
             await
 #endif
             using (var qe2 = CreateQueryEngine(kvs))
@@ -1134,7 +1134,7 @@ namespace Tests.Reaqtor.QueryEngine
 
             InMemoryStateStore state;
 
-#if NET5_0 || NETCOREAPP3_1 // NB: Only using ValueTask-based DisposeAsync in .NET Standard 2.1 and beyond at the moment.
+#if NET6_0 || NETCOREAPP3_1 // NB: Only using ValueTask-based DisposeAsync in .NET Standard 2.1 and beyond at the moment.
             await
 #endif
             using (var qe1 = CreateQueryEngine(kvs))
@@ -1153,7 +1153,7 @@ namespace Tests.Reaqtor.QueryEngine
                 Crash();
             }
 
-#if NET5_0 || NETCOREAPP3_1 // NB: Only using ValueTask-based DisposeAsync in .NET Standard 2.1 and beyond at the moment.
+#if NET6_0 || NETCOREAPP3_1 // NB: Only using ValueTask-based DisposeAsync in .NET Standard 2.1 and beyond at the moment.
             await
 #endif
             using (var qe2 = CreateQueryEngine(kvs))
@@ -1171,7 +1171,7 @@ namespace Tests.Reaqtor.QueryEngine
         {
             var kvs = new InMemoryKeyValueStore();
 
-#if NET5_0 || NETCOREAPP3_1 // NB: Only using ValueTask-based DisposeAsync in .NET Standard 2.1 and beyond at the moment.
+#if NET6_0 || NETCOREAPP3_1 // NB: Only using ValueTask-based DisposeAsync in .NET Standard 2.1 and beyond at the moment.
             await
 #endif
             using (var qe1 = CreateQueryEngine(kvs))
@@ -1186,7 +1186,7 @@ namespace Tests.Reaqtor.QueryEngine
                 Crash();
             }
 
-#if NET5_0 || NETCOREAPP3_1 // NB: Only using ValueTask-based DisposeAsync in .NET Standard 2.1 and beyond at the moment.
+#if NET6_0 || NETCOREAPP3_1 // NB: Only using ValueTask-based DisposeAsync in .NET Standard 2.1 and beyond at the moment.
             await
 #endif
             using (var qe2 = CreateQueryEngine(kvs))
@@ -1200,7 +1200,7 @@ namespace Tests.Reaqtor.QueryEngine
                 Crash();
             }
 
-#if NET5_0 || NETCOREAPP3_1 // NB: Only using ValueTask-based DisposeAsync in .NET Standard 2.1 and beyond at the moment.
+#if NET6_0 || NETCOREAPP3_1 // NB: Only using ValueTask-based DisposeAsync in .NET Standard 2.1 and beyond at the moment.
             await
 #endif
             using (var qe3 = CreateQueryEngine(kvs))
@@ -1211,7 +1211,7 @@ namespace Tests.Reaqtor.QueryEngine
 
                 await Assert.ThrowsExceptionAsync<EntityNotFoundException>(() =>
                     ctx3.GetSubscription(new Uri("test://sub1")).DisposeAsync(CancellationToken.None)
-#if NET5_0 || NETCOREAPP3_1
+#if NET6_0 || NETCOREAPP3_1
                         .AsTask()
 #endif
                 );
@@ -1223,7 +1223,7 @@ namespace Tests.Reaqtor.QueryEngine
         {
             var kvs = new InMemoryKeyValueStore();
 
-#if NET5_0 || NETCOREAPP3_1 // NB: Only using ValueTask-based DisposeAsync in .NET Standard 2.1 and beyond at the moment.
+#if NET6_0 || NETCOREAPP3_1 // NB: Only using ValueTask-based DisposeAsync in .NET Standard 2.1 and beyond at the moment.
             await
 #endif
             using (var qe1 = CreateQueryEngine(kvs))
@@ -1238,7 +1238,7 @@ namespace Tests.Reaqtor.QueryEngine
                 Crash();
             }
 
-#if NET5_0 || NETCOREAPP3_1 // NB: Only using ValueTask-based DisposeAsync in .NET Standard 2.1 and beyond at the moment.
+#if NET6_0 || NETCOREAPP3_1 // NB: Only using ValueTask-based DisposeAsync in .NET Standard 2.1 and beyond at the moment.
             await
 #endif
             using (var qe2 = CreateQueryEngine(kvs))
@@ -1256,7 +1256,7 @@ namespace Tests.Reaqtor.QueryEngine
                 Crash();
             }
 
-#if NET5_0 || NETCOREAPP3_1 // NB: Only using ValueTask-based DisposeAsync in .NET Standard 2.1 and beyond at the moment.
+#if NET6_0 || NETCOREAPP3_1 // NB: Only using ValueTask-based DisposeAsync in .NET Standard 2.1 and beyond at the moment.
             await
 #endif
             using (var qe3 = CreateQueryEngine(kvs))
@@ -1276,7 +1276,7 @@ namespace Tests.Reaqtor.QueryEngine
 
             InMemoryStateStore state;
 
-#if NET5_0 || NETCOREAPP3_1 // NB: Only using ValueTask-based DisposeAsync in .NET Standard 2.1 and beyond at the moment.
+#if NET6_0 || NETCOREAPP3_1 // NB: Only using ValueTask-based DisposeAsync in .NET Standard 2.1 and beyond at the moment.
             await
 #endif
             using (var qe1 = CreateQueryEngine(kvs))
@@ -1293,7 +1293,7 @@ namespace Tests.Reaqtor.QueryEngine
                 Crash();
             }
 
-#if NET5_0 || NETCOREAPP3_1 // NB: Only using ValueTask-based DisposeAsync in .NET Standard 2.1 and beyond at the moment.
+#if NET6_0 || NETCOREAPP3_1 // NB: Only using ValueTask-based DisposeAsync in .NET Standard 2.1 and beyond at the moment.
             await
 #endif
             using (var qe2 = CreateQueryEngine(kvs))
@@ -1311,7 +1311,7 @@ namespace Tests.Reaqtor.QueryEngine
                 Crash();
             }
 
-#if NET5_0 || NETCOREAPP3_1 // NB: Only using ValueTask-based DisposeAsync in .NET Standard 2.1 and beyond at the moment.
+#if NET6_0 || NETCOREAPP3_1 // NB: Only using ValueTask-based DisposeAsync in .NET Standard 2.1 and beyond at the moment.
             await
 #endif
             using (var qe3 = CreateQueryEngine(kvs))
@@ -1337,7 +1337,7 @@ namespace Tests.Reaqtor.QueryEngine
             var deleteCreate_delete_id = new Uri("test://sub4");
             var deleteCreate_deleteCreate_id = new Uri("test://sub5");
 
-#if NET5_0 || NETCOREAPP3_1 // NB: Only using ValueTask-based DisposeAsync in .NET Standard 2.1 and beyond at the moment.
+#if NET6_0 || NETCOREAPP3_1 // NB: Only using ValueTask-based DisposeAsync in .NET Standard 2.1 and beyond at the moment.
             await
 #endif
             using (var qe1 = CreateQueryEngine(kvs))
@@ -1381,7 +1381,7 @@ namespace Tests.Reaqtor.QueryEngine
                 Crash();
             }
 
-#if NET5_0 || NETCOREAPP3_1 // NB: Only using ValueTask-based DisposeAsync in .NET Standard 2.1 and beyond at the moment.
+#if NET6_0 || NETCOREAPP3_1 // NB: Only using ValueTask-based DisposeAsync in .NET Standard 2.1 and beyond at the moment.
             await
 #endif
             using (var qe2 = CreateQueryEngine(kvs))
@@ -1411,7 +1411,7 @@ namespace Tests.Reaqtor.QueryEngine
                 Crash();
             }
 
-#if NET5_0 || NETCOREAPP3_1 // NB: Only using ValueTask-based DisposeAsync in .NET Standard 2.1 and beyond at the moment.
+#if NET6_0 || NETCOREAPP3_1 // NB: Only using ValueTask-based DisposeAsync in .NET Standard 2.1 and beyond at the moment.
             await
 #endif
             using (var qe3 = CreateQueryEngine(kvs))
@@ -1434,7 +1434,7 @@ namespace Tests.Reaqtor.QueryEngine
                 // First create an engine persist a subscription creation in the state store
                 var kvs1 = new InMemoryKeyValueStore();
 
-#if NET5_0 || NETCOREAPP3_1 // NB: Only using ValueTask-based DisposeAsync in .NET Standard 2.1 and beyond at the moment.
+#if NET6_0 || NETCOREAPP3_1 // NB: Only using ValueTask-based DisposeAsync in .NET Standard 2.1 and beyond at the moment.
                 await
 #endif
                 using (var qe1 = CreateQueryEngine(kvs1))
@@ -1455,7 +1455,7 @@ namespace Tests.Reaqtor.QueryEngine
 
                 var kvs2 = new InMemoryKeyValueStore();
 
-#if NET5_0 || NETCOREAPP3_1 // NB: Only using ValueTask-based DisposeAsync in .NET Standard 2.1 and beyond at the moment.
+#if NET6_0 || NETCOREAPP3_1 // NB: Only using ValueTask-based DisposeAsync in .NET Standard 2.1 and beyond at the moment.
                 await
 #endif
                 using (var qe2 = CreateQueryEngine(kvs2))
@@ -1472,7 +1472,7 @@ namespace Tests.Reaqtor.QueryEngine
 
                 // Now create engine with first state store (the one that has sub) and second kvs (also has sub)
 
-#if NET5_0 || NETCOREAPP3_1 // NB: Only using ValueTask-based DisposeAsync in .NET Standard 2.1 and beyond at the moment.
+#if NET6_0 || NETCOREAPP3_1 // NB: Only using ValueTask-based DisposeAsync in .NET Standard 2.1 and beyond at the moment.
                 await
 #endif
                 using (var qe3 = CreateQueryEngine(kvs2))
@@ -1488,7 +1488,7 @@ namespace Tests.Reaqtor.QueryEngine
 
                 // Do it again but handle the exception
 
-#if NET5_0 || NETCOREAPP3_1 // NB: Only using ValueTask-based DisposeAsync in .NET Standard 2.1 and beyond at the moment.
+#if NET6_0 || NETCOREAPP3_1 // NB: Only using ValueTask-based DisposeAsync in .NET Standard 2.1 and beyond at the moment.
                 await
 #endif
                 using (var qe4 = CreateQueryEngine(kvs2))
@@ -1516,7 +1516,7 @@ namespace Tests.Reaqtor.QueryEngine
 
                 var kvs = new InMemoryKeyValueStore();
 
-#if NET5_0 || NETCOREAPP3_1 // NB: Only using ValueTask-based DisposeAsync in .NET Standard 2.1 and beyond at the moment.
+#if NET6_0 || NETCOREAPP3_1 // NB: Only using ValueTask-based DisposeAsync in .NET Standard 2.1 and beyond at the moment.
                 await
 #endif
                 using (var qe1 = CreateQueryEngine(kvs))
@@ -1530,7 +1530,7 @@ namespace Tests.Reaqtor.QueryEngine
                     await o1.SubscribeAsync(v1, testId, null, CancellationToken.None);
                 }
 
-#if NET5_0 || NETCOREAPP3_1 // NB: Only using ValueTask-based DisposeAsync in .NET Standard 2.1 and beyond at the moment.
+#if NET6_0 || NETCOREAPP3_1 // NB: Only using ValueTask-based DisposeAsync in .NET Standard 2.1 and beyond at the moment.
                 await
 #endif
                 using (var qe2 = CreateQueryEngine(kvs))
@@ -1545,7 +1545,7 @@ namespace Tests.Reaqtor.QueryEngine
 
                 // Unhandled
 
-#if NET5_0 || NETCOREAPP3_1 // NB: Only using ValueTask-based DisposeAsync in .NET Standard 2.1 and beyond at the moment.
+#if NET6_0 || NETCOREAPP3_1 // NB: Only using ValueTask-based DisposeAsync in .NET Standard 2.1 and beyond at the moment.
                 await
 #endif
                 using (var qe3 = CreateQueryEngine(kvs))
@@ -1561,7 +1561,7 @@ namespace Tests.Reaqtor.QueryEngine
 
                 // Handled
 
-#if NET5_0 || NETCOREAPP3_1 // NB: Only using ValueTask-based DisposeAsync in .NET Standard 2.1 and beyond at the moment.
+#if NET6_0 || NETCOREAPP3_1 // NB: Only using ValueTask-based DisposeAsync in .NET Standard 2.1 and beyond at the moment.
                 await
 #endif
                 using (var qe4 = CreateQueryEngine(kvs))
@@ -1593,7 +1593,7 @@ namespace Tests.Reaqtor.QueryEngine
 
             InMemoryStateStore state;
 
-#if NET5_0 || NETCOREAPP3_1 // NB: Only using ValueTask-based DisposeAsync in .NET Standard 2.1 and beyond at the moment.
+#if NET6_0 || NETCOREAPP3_1 // NB: Only using ValueTask-based DisposeAsync in .NET Standard 2.1 and beyond at the moment.
             await
 #endif
             using (var qe1 = CreateQueryEngine(kvs))
@@ -1615,7 +1615,7 @@ namespace Tests.Reaqtor.QueryEngine
                 Crash();
             }
 
-#if NET5_0 || NETCOREAPP3_1 // NB: Only using ValueTask-based DisposeAsync in .NET Standard 2.1 and beyond at the moment.
+#if NET6_0 || NETCOREAPP3_1 // NB: Only using ValueTask-based DisposeAsync in .NET Standard 2.1 and beyond at the moment.
             await
 #endif
             using (var qe2 = CreateQueryEngine(kvs))
@@ -1633,7 +1633,7 @@ namespace Tests.Reaqtor.QueryEngine
         {
             var kvs = new InMemoryKeyValueStore();
 
-#if NET5_0 || NETCOREAPP3_1 // NB: Only using ValueTask-based DisposeAsync in .NET Standard 2.1 and beyond at the moment.
+#if NET6_0 || NETCOREAPP3_1 // NB: Only using ValueTask-based DisposeAsync in .NET Standard 2.1 and beyond at the moment.
             await
 #endif
             using (var qe = CreateQueryEngine(kvs))
@@ -1652,7 +1652,7 @@ namespace Tests.Reaqtor.QueryEngine
                 kvs.StartingOperation += fail;
                 await AssertEx.ThrowsExceptionAsync<MyException>(() =>
                     test.DisposeAsync(CancellationToken.None)
-#if NET5_0 || NETCOREAPP3_1
+#if NET6_0 || NETCOREAPP3_1
                         .AsTask()
 #endif
                     ,
@@ -2233,13 +2233,13 @@ namespace Tests.Reaqtor.QueryEngine
             Assert.IsTrue(actx.Streams.TryGetValue(streamUri, out p));
 
             sub.DisposeAsync(CancellationToken.None)
-#if NET5_0 || NETCOREAPP3_1
+#if NET6_0 || NETCOREAPP3_1
                 .AsTask()
 #endif
                 .Wait();
 
             actx.GetStream<string, string>(streamUri).DisposeAsync(CancellationToken.None)
-#if NET5_0 || NETCOREAPP3_1
+#if NET6_0 || NETCOREAPP3_1
                 .AsTask()
 #endif
                 .Wait();
@@ -2485,7 +2485,7 @@ namespace Tests.Reaqtor.QueryEngine
         {
             var kvs = new InMemoryKeyValueStore();
 
-#if NET5_0 || NETCOREAPP3_1 // NB: Only using ValueTask-based DisposeAsync in .NET Standard 2.1 and beyond at the moment.
+#if NET6_0 || NETCOREAPP3_1 // NB: Only using ValueTask-based DisposeAsync in .NET Standard 2.1 and beyond at the moment.
             await
 #endif
             using var qe = CreateQueryEngine(kvs);

--- a/Reaqtor/Core/Engine/Tests.Reaqtor.QueryEngine/OperationTrackerTests.cs
+++ b/Reaqtor/Core/Engine/Tests.Reaqtor.QueryEngine/OperationTrackerTests.cs
@@ -38,7 +38,7 @@ namespace Tests.Reaqtor.QueryEngine
             //
 
             var d = o.DisposeAsync()
-#if NET5_0 || NETCOREAPP3_1
+#if NET6_0 || NETCOREAPP3_1
                 .AsTask()
 #endif
                 ;
@@ -87,7 +87,7 @@ namespace Tests.Reaqtor.QueryEngine
             //
 
             var d1 = o.DisposeAsync()
-#if NET5_0 || NETCOREAPP3_1
+#if NET6_0 || NETCOREAPP3_1
                 .AsTask()
 #endif
                 ;
@@ -105,7 +105,7 @@ namespace Tests.Reaqtor.QueryEngine
             //
 
             var d2 = o.DisposeAsync()
-#if NET5_0 || NETCOREAPP3_1
+#if NET6_0 || NETCOREAPP3_1
                 .AsTask()
 #endif
                 ;
@@ -151,7 +151,7 @@ namespace Tests.Reaqtor.QueryEngine
             //
 
             o.DisposeAsync()
-#if NET5_0 || NETCOREAPP3_1
+#if NET6_0 || NETCOREAPP3_1
                 .AsTask()
 #endif
                 .Wait();
@@ -212,7 +212,7 @@ namespace Tests.Reaqtor.QueryEngine
             //
 
             t.DisposeAsync()
-#if NET5_0 || NETCOREAPP3_1
+#if NET6_0 || NETCOREAPP3_1
                 .AsTask()
 #endif
                 .Wait();

--- a/Reaqtor/Core/Engine/Tests.Reaqtor.QueryEngine/Tests.Reaqtor.QueryEngine.csproj
+++ b/Reaqtor/Core/Engine/Tests.Reaqtor.QueryEngine/Tests.Reaqtor.QueryEngine.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net472;net50</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net472;net6.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Reaqtor/Core/Expressions/Reaqtor.Expressions.Binding/Reaqtor.Expressions.Binding.csproj
+++ b/Reaqtor/Core/Expressions/Reaqtor.Expressions.Binding/Reaqtor.Expressions.Binding.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netstandard2.1;net472;net50</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;net472;net6.0</TargetFrameworks>
     <Description>Provides a set of utilities to perform binding of artifacts in reactive expressions.</Description>
   </PropertyGroup>
 

--- a/Reaqtor/Core/Expressions/Reaqtor.Expressions.Core/Reaqtor.Expressions.Core.csproj
+++ b/Reaqtor/Core/Expressions/Reaqtor.Expressions.Core/Reaqtor.Expressions.Core.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netstandard2.1;net472;net50</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;net472;net6.0</TargetFrameworks>
     <Description>Provides base classes and utilities to represent quoted reactive artifacts.</Description>
   </PropertyGroup>
 

--- a/Reaqtor/Core/Expressions/Reaqtor.Expressions.Model/Reaqtor.Expressions.Model.csproj
+++ b/Reaqtor/Core/Expressions/Reaqtor.Expressions.Model/Reaqtor.Expressions.Model.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netstandard2.1;net472;net50</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;net472;net6.0</TargetFrameworks>
     <Description>Provides interfaces to represent quoted reactive artifacts.</Description>
   </PropertyGroup>
 

--- a/Reaqtor/Core/Expressions/Tests.Reaqtor.Expressions.Core/Tests.Reaqtor.Expressions.Core.csproj
+++ b/Reaqtor/Core/Expressions/Tests.Reaqtor.Expressions.Core/Tests.Reaqtor.Expressions.Core.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net472;net50</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net472;net6.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Reaqtor/Core/Hosting/Reaqtor.Hosting.Service/Reaqtor.Hosting.Service.csproj
+++ b/Reaqtor/Core/Hosting/Reaqtor.Hosting.Service/Reaqtor.Hosting.Service.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netstandard2.1;net472;net50</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;net472;net6.0</TargetFrameworks>
     <Description>Provides a set of helpers to implement Reaqtor services.</Description>
   </PropertyGroup>
 

--- a/Reaqtor/Core/Hosting/Reaqtor.Hosting.Shared/Reaqtor.Hosting.Shared.csproj
+++ b/Reaqtor/Core/Hosting/Reaqtor.Hosting.Shared/Reaqtor.Hosting.Shared.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netstandard2.1;net472;net50</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;net472;net6.0</TargetFrameworks>
     <Description>Provides a set of helpers to implement Reaqtor services and clients.</Description>
   </PropertyGroup>
 

--- a/Reaqtor/Core/Hosting/Reaqtor.Hosting.Shared/Serialization/ReactiveResourceConverter.cs
+++ b/Reaqtor/Core/Hosting/Reaqtor.Hosting.Shared/Serialization/ReactiveResourceConverter.cs
@@ -238,7 +238,7 @@ namespace Reaqtor.Hosting.Shared.Serialization
 
             public DateTimeOffset CreationTime => throw new NotImplementedException();
 
-#if NET5_0 || NETSTANDARD2_1
+#if NET6_0 || NETSTANDARD2_1
             public ValueTask DisposeAsync() => throw new NotImplementedException();
 #else
             public Task DisposeAsync(System.Threading.CancellationToken token) => throw new NotImplementedException();

--- a/Reaqtor/Core/Hosting/Reaqtor.Hosting.Shared/Tools/ReactiveEntityTypeExtensions.cs
+++ b/Reaqtor/Core/Hosting/Reaqtor.Hosting.Shared/Tools/ReactiveEntityTypeExtensions.cs
@@ -132,7 +132,7 @@ namespace Reaqtor.Hosting.Shared.Tools
                 {
                     var args = type.GenericTypeArguments;
 
-#if NET5_0 || NETSTANDARD2_1
+#if NET6_0 || NETSTANDARD2_1
                     var lastArg = args[^1];
 #else
                     var lastArg = args[args.Length - 1];

--- a/Reaqtor/Core/Hosting/Tests.Reaqtor.Hosting.Service/Tests.Reaqtor.Hosting.Service.csproj
+++ b/Reaqtor/Core/Hosting/Tests.Reaqtor.Hosting.Service/Tests.Reaqtor.Hosting.Service.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net472;net50</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net472;net6.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Reaqtor/Core/Hosting/Tests.Reaqtor.Hosting.Shared/Serialization/ReactiveResourceConverterTests.cs
+++ b/Reaqtor/Core/Hosting/Tests.Reaqtor.Hosting.Shared/Serialization/ReactiveResourceConverterTests.cs
@@ -298,7 +298,7 @@ namespace Tests.Microsoft.Hosting.Shared.Serialization
 
             public DateTimeOffset CreationTime => DateTimeOffset.Now;
 
-#if NET5_0 || NETCOREAPP3_1
+#if NET6_0 || NETCOREAPP3_1
             public ValueTask DisposeAsync() => throw new NotImplementedException();
 #else
             public Task DisposeAsync(System.Threading.CancellationToken token) => throw new NotImplementedException();

--- a/Reaqtor/Core/Hosting/Tests.Reaqtor.Hosting.Shared/Tests.Reaqtor.Hosting.Shared.csproj
+++ b/Reaqtor/Core/Hosting/Tests.Reaqtor.Hosting.Shared/Tests.Reaqtor.Hosting.Shared.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net472;net50</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net472;net6.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Reaqtor/Core/Local/Reaqtor.Local.Core/Reaqtor.Local.Core.csproj
+++ b/Reaqtor/Core/Local/Reaqtor.Local.Core/Reaqtor.Local.Core.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netstandard2.1;net472;net50</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;net472;net6.0</TargetFrameworks>
     <Description>Provides base classes and utilities for local evaluation of reactive computations.</Description>
   </PropertyGroup>
 

--- a/Reaqtor/Core/Local/Reaqtor.Local.Core/System/AsyncDisposableBase.cs
+++ b/Reaqtor/Core/Local/Reaqtor.Local.Core/System/AsyncDisposableBase.cs
@@ -21,7 +21,7 @@ namespace System
 #pragma warning disable IDE0079 // Remove unnecessary suppressions.
 #pragma warning disable CA1816 // Dispose methods should call SuppressFinalize. (Analyzer does not know about pre-netstandard2.1 IAsyncDisposable.)
 
-#if !NET5_0 && !NETSTANDARD2_1
+#if !NET6_0 && !NETSTANDARD2_1
         /// <summary>
         /// Disposes the resource asynchronously.
         /// </summary>

--- a/Reaqtor/Core/Local/Reaqtor.Local.Core/System/AsyncDisposableExtensions.cs
+++ b/Reaqtor/Core/Local/Reaqtor.Local.Core/System/AsyncDisposableExtensions.cs
@@ -18,7 +18,7 @@ namespace System
     /// </summary>
     public static class AsyncDisposableExtensions
     {
-#if !NET5_0 && !NETSTANDARD2_1
+#if !NET6_0 && !NETSTANDARD2_1
         /// <summary>
         /// Disposes the resource asynchronously.
         /// </summary>
@@ -74,7 +74,7 @@ namespace System
                 // No idempotency enforcement. Left to the underlying IAsyncDisposable implementation.
                 //
                 _disposable.DisposeAsync(CancellationToken.None)
-#if NET5_0 || NETSTANDARD2_1
+#if NET6_0 || NETSTANDARD2_1
                     .AsTask()
 #endif
                     .Wait();

--- a/Reaqtor/Core/Local/Reaqtor.Local.Model/Reaqtor.Local.Model.csproj
+++ b/Reaqtor/Core/Local/Reaqtor.Local.Model/Reaqtor.Local.Model.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netstandard2.1;net472;net50</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;net472;net6.0</TargetFrameworks>
     <Description>Provides interfaces for local evaluation of reactive computations.</Description>
   </PropertyGroup>
 

--- a/Reaqtor/Core/Local/Reaqtor.Local.Model/System/IAsyncDisposable.cs
+++ b/Reaqtor/Core/Local/Reaqtor.Local.Model/System/IAsyncDisposable.cs
@@ -8,7 +8,7 @@
 // BD - June 2013 - Created this file.
 //
 
-#if !NET5_0 && !NETSTANDARD2_1
+#if !NET6_0 && !NETSTANDARD2_1
 
 using System.Threading;
 using System.Threading.Tasks;

--- a/Reaqtor/Core/Local/Tests.Reaqtor.Local.Core/Async/AsyncReactiveSubjectBaseTests.cs
+++ b/Reaqtor/Core/Local/Tests.Reaqtor.Local.Core/Async/AsyncReactiveSubjectBaseTests.cs
@@ -114,7 +114,7 @@ namespace Tests
             var disposed = false;
             s.DisposeImpl = async (ct) => { disposed = true; await Task.Yield(); };
 
-#if NET5_0 || NETCOREAPP3_1
+#if NET6_0 || NETCOREAPP3_1
             s.DisposeAsync().AsTask().Wait();
 #else
             s.DisposeAsync().Wait();

--- a/Reaqtor/Core/Local/Tests.Reaqtor.Local.Core/Async/AsyncReactiveSubscriptionBaseTests.cs
+++ b/Reaqtor/Core/Local/Tests.Reaqtor.Local.Core/Async/AsyncReactiveSubscriptionBaseTests.cs
@@ -23,7 +23,7 @@ namespace Tests
             var disposed = false;
             s.DisposeAsyncImpl = (token) => { disposed = true; return Task.CompletedTask; };
 
-#if !NET5_0 && !NETCOREAPP3_1
+#if !NET6_0 && !NETCOREAPP3_1
             s.DisposeAsync().Wait();
 #else
             s.DisposeAsync().AsTask().Wait();

--- a/Reaqtor/Core/Local/Tests.Reaqtor.Local.Core/Tests.Reaqtor.Local.Core.csproj
+++ b/Reaqtor/Core/Local/Tests.Reaqtor.Local.Core/Tests.Reaqtor.Local.Core.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net472;net50</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net472;net6.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Reaqtor/Core/Metadata/Reaqtor.Metadata.Model/Reaqtor.Metadata.Model.csproj
+++ b/Reaqtor/Core/Metadata/Reaqtor.Metadata.Model/Reaqtor.Metadata.Model.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netstandard2.1;net472;net50</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;net472;net6.0</TargetFrameworks>
     <Description>Provides a set of interfaces used for metadata discovery of reactive artifacts.</Description>
   </PropertyGroup>
 

--- a/Reaqtor/Core/Reactive/Reaqtor.Reactive.HigherOrder/Reaqtor.Reactive.HigherOrder.csproj
+++ b/Reaqtor/Core/Reactive/Reaqtor.Reactive.HigherOrder/Reaqtor.Reactive.HigherOrder.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netstandard2.1;net472;net50</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;net472;net6.0</TargetFrameworks>
     <Description>Provides support for higher-order query operators when hosted in a query engine.</Description>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>

--- a/Reaqtor/Core/Reactive/Tests.Reaqtor.Reactive.HigherOrder/Tests.Reaqtor.Reactive.HigherOrder.csproj
+++ b/Reaqtor/Core/Reactive/Tests.Reaqtor.Reactive.HigherOrder/Tests.Reaqtor.Reactive.HigherOrder.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net472;net50</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net472;net6.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Reaqtor/Core/Reactive/Tests.Reaqtor.Reactive.Linq.Hosted/Tests.Reaqtor.Reactive.Linq.Hosted.csproj
+++ b/Reaqtor/Core/Reactive/Tests.Reaqtor.Reactive.Linq.Hosted/Tests.Reaqtor.Reactive.Linq.Hosted.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net472;net50</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net472;net6.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Reaqtor/Core/Reliable/Reaqtor.Reliable.Model/Reaqtor.Reliable.Model.csproj
+++ b/Reaqtor/Core/Reliable/Reaqtor.Reliable.Model/Reaqtor.Reliable.Model.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netstandard2.1;net472;net50</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;net472;net6.0</TargetFrameworks>
     <Description>Provides variants of Rx interfaces that support reliability for event delivery using sequence numbers.</Description>
     <!-- TODODOC -->
     <GenerateDocumentationFile>false</GenerateDocumentationFile>

--- a/Reaqtor/Core/Reliable/Reaqtor.Reliable/Reaqtor.Reliable.csproj
+++ b/Reaqtor/Core/Reliable/Reaqtor.Reliable/Reaqtor.Reliable.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netstandard2.1;net472;net50</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;net472;net6.0</TargetFrameworks>
     <Description>Provides base classes and utilities to support reliable event delivery using sequence numbers.</Description>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <!-- TODODOC -->

--- a/Reaqtor/Core/Reliable/Tests.Reaqtor.Reliable/Tests.Reaqtor.Reliable.csproj
+++ b/Reaqtor/Core/Reliable/Tests.Reaqtor.Reliable/Tests.Reaqtor.Reliable.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net472;net50</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net472;net6.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Reaqtor/Core/Service/Reaqtor.Service.Contracts/Reaqtor.Service.Contracts.csproj
+++ b/Reaqtor/Core/Service/Reaqtor.Service.Contracts/Reaqtor.Service.Contracts.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netstandard2.1;net472;net50</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;net472;net6.0</TargetFrameworks>
     <Description>Provides a set of interfaces used for the communication between reactive event processing clients and services.</Description>
   </PropertyGroup>
 

--- a/Reaqtor/Core/Service/Reaqtor.Service.Core/Reaqtor.Service.Core.csproj
+++ b/Reaqtor/Core/Service/Reaqtor.Service.Core/Reaqtor.Service.Core.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netstandard2.1;net472;net50</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;net472;net6.0</TargetFrameworks>
     <Description>Provides base classes and utilities for implementing reactive event processing services.</Description>
   </PropertyGroup>
 

--- a/Reaqtor/Core/Service/Reaqtor.Service.Model/Reaqtor.Service.Model.csproj
+++ b/Reaqtor/Core/Service/Reaqtor.Service.Model/Reaqtor.Service.Model.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netstandard2.1;net472;net50</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;net472;net6.0</TargetFrameworks>
     <Description>Provides interfaces used by reactive event processing services.</Description>
   </PropertyGroup>
 

--- a/Reaqtor/Core/Service/Reaqtor.Service/Reaqtor.Service.csproj
+++ b/Reaqtor/Core/Service/Reaqtor.Service/Reaqtor.Service.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netstandard2.1;net472;net50</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;net472;net6.0</TargetFrameworks>
     <Description>Provides abstractions used by implementations of reactive event processing services.</Description>
   </PropertyGroup>
 

--- a/Reaqtor/Core/Service/Tests.Reaqtor.Service.Core/Tests.Reaqtor.Service.Core.csproj
+++ b/Reaqtor/Core/Service/Tests.Reaqtor.Service.Core/Tests.Reaqtor.Service.Core.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net472;net50</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net472;net6.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Reaqtor/Core/Service/Tests.Reaqtor.Service/Tests.Reaqtor.Service.csproj
+++ b/Reaqtor/Core/Service/Tests.Reaqtor.Service/Tests.Reaqtor.Service.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net472;net50</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net472;net6.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Reaqtor/Core/Shared/Reaqtor.Shared.Core/Reaqtor.Shared.Core.csproj
+++ b/Reaqtor/Core/Shared/Reaqtor.Shared.Core/Reaqtor.Shared.Core.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netstandard2.1;net472;net50</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;net472;net6.0</TargetFrameworks>
     <Description>Provides base classes and utilities used by reactive event processing services and clients.</Description>
   </PropertyGroup>
 

--- a/Reaqtor/Core/Shared/Reaqtor.Shared.Model/Reaqtor.Shared.Model.csproj
+++ b/Reaqtor/Core/Shared/Reaqtor.Shared.Model/Reaqtor.Shared.Model.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netstandard2.1;net472;net50</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;net472;net6.0</TargetFrameworks>
     <Description>Provides a common set of interfaces shared by reactive event processing services and clients.</Description>
   </PropertyGroup>
 

--- a/Reaqtor/Core/Shared/Tests.Reaqtor.Shared.Core/Tests.Reaqtor.Shared.Core.csproj
+++ b/Reaqtor/Core/Shared/Tests.Reaqtor.Shared.Core/Tests.Reaqtor.Shared.Core.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net472;net50</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net472;net6.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Reaqtor/Core/Testing/Reaqtor.ReificationFramework/Binder/ReactiveProxyServiceOperationBinder.cs
+++ b/Reaqtor/Core/Testing/Reaqtor.ReificationFramework/Binder/ReactiveProxyServiceOperationBinder.cs
@@ -22,7 +22,7 @@ namespace Reaqtor.ReificationFramework
         private static readonly Expression<Func<Uri, IReactiveProxy, Task>> s_undefineStreamFactoryExpr = (uri, ctx) => ctx.UndefineStreamFactoryAsync(uri, CancellationToken.None);
         private static readonly Expression<Func<Uri, IReactiveProxy, Task>> s_undefineSubscriptionFactoryExpr = (uri, ctx) => ctx.UndefineSubscriptionFactoryAsync(uri, CancellationToken.None);
 
-#if NET5_0 || NETSTANDARD2_1
+#if NET6_0 || NETSTANDARD2_1
         private static readonly Expression<Func<Uri, IReactiveProxy, Task>> s_disposeStreamExpr = (uri, ctx) => ctx.GetStream<T1, T2>(uri).DisposeAsync().AsTask();
         private static readonly Expression<Func<Uri, IReactiveProxy, Task>> s_disposeSubscriptionExpr = (uri, ctx) => ctx.GetSubscription(uri).DisposeAsync().AsTask();
 #else

--- a/Reaqtor/Core/Testing/Reaqtor.ReificationFramework/Operations/ReifiedOperationExtensions.cs
+++ b/Reaqtor/Core/Testing/Reaqtor.ReificationFramework/Operations/ReifiedOperationExtensions.cs
@@ -466,7 +466,7 @@ namespace Reaqtor.ReificationFramework
 
                 protected override int GetHashCodeGlobalParameter(ParameterExpression obj)
                 {
-#if NET5_0 || NETSTANDARD2_1
+#if NET6_0 || NETSTANDARD2_1
                     var hash = obj.Name.GetHashCode(StringComparison.Ordinal);
 #else
                     var hash = obj.Name.GetHashCode();

--- a/Reaqtor/Core/Testing/Reaqtor.ReificationFramework/Reaqtor.ReificationFramework.csproj
+++ b/Reaqtor/Core/Testing/Reaqtor.ReificationFramework/Reaqtor.ReificationFramework.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netstandard2.1;net472;net50</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;net472;net6.0</TargetFrameworks>
     <Description>Reified operations for the Reaqtor query operator library.</Description>
   </PropertyGroup>
 

--- a/Reaqtor/Core/Testing/Reaqtor.ReifiedOperations/Reaqtor.ReifiedOperations.csproj
+++ b/Reaqtor/Core/Testing/Reaqtor.ReifiedOperations/Reaqtor.ReifiedOperations.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netstandard2.1;net472;net50</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;net472;net6.0</TargetFrameworks>
     <Description>Reified operations for Reaqtor interfaces.</Description>
     <!-- TODODOC -->
     <GenerateDocumentationFile>false</GenerateDocumentationFile>

--- a/Reaqtor/Core/Testing/Reaqtor.TestingFramework.Engine/Reaqtor.TestingFramework.Engine.csproj
+++ b/Reaqtor/Core/Testing/Reaqtor.TestingFramework.Engine/Reaqtor.TestingFramework.Engine.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netstandard2.1;net472;net50</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;net472;net6.0</TargetFrameworks>
     <Description>Reaqtor testing framework for reactive event processing query engines.</Description>
     <!-- TODODOC -->
     <GenerateDocumentationFile>false</GenerateDocumentationFile>

--- a/Reaqtor/Core/Testing/Reaqtor.TestingFramework.Hosted/Reaqtor.TestingFramework.Hosted.csproj
+++ b/Reaqtor/Core/Testing/Reaqtor.TestingFramework.Hosted/Reaqtor.TestingFramework.Hosted.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netstandard2.1;net472;net50</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;net472;net6.0</TargetFrameworks>
     <Description>Reaqtor testing framework for service hosting.</Description>
     <!-- TODODOC -->
     <GenerateDocumentationFile>false</GenerateDocumentationFile>

--- a/Reaqtor/Core/Testing/Reaqtor.TestingFramework.Reliable/Reaqtor.TestingFramework.Reliable.csproj
+++ b/Reaqtor/Core/Testing/Reaqtor.TestingFramework.Reliable/Reaqtor.TestingFramework.Reliable.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netstandard2.1;net472;net50</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;net472;net6.0</TargetFrameworks>
     <Description>Reaqtor testing framework for reliable event delivery.</Description>
     <!-- TODODOC -->
     <GenerateDocumentationFile>false</GenerateDocumentationFile>

--- a/Reaqtor/Core/Testing/Reaqtor.TestingFramework.Service/Reaqtor.TestingFramework.Service.csproj
+++ b/Reaqtor/Core/Testing/Reaqtor.TestingFramework.Service/Reaqtor.TestingFramework.Service.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netstandard2.1;net472;net50</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;net472;net6.0</TargetFrameworks>
     <Description>Reaqtor testing framework for reactive event processing services.</Description>
     <!-- TODODOC -->
     <GenerateDocumentationFile>false</GenerateDocumentationFile>

--- a/Reaqtor/Pearls/CSE/Reaqtor.Pearls.CommonSubexpressionElimination.csproj
+++ b/Reaqtor/Pearls/CSE/Reaqtor.Pearls.CommonSubexpressionElimination.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
   </PropertyGroup>

--- a/Reaqtor/Pearls/DelegatingBinder/Reaqtor.Pearls.DelegatingBinder.csproj
+++ b/Reaqtor/Pearls/DelegatingBinder/Reaqtor.Pearls.DelegatingBinder.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
   </PropertyGroup>

--- a/Reaqtor/Pearls/PartitionedSubject/Reaqtor.Pearls.PartitionedSubject.csproj
+++ b/Reaqtor/Pearls/PartitionedSubject/Reaqtor.Pearls.PartitionedSubject.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
   </PropertyGroup>

--- a/Reaqtor/Samples/IoT/Reaqtor.IoT/GettingStarted.ipynb
+++ b/Reaqtor/Samples/IoT/Reaqtor.IoT/GettingStarted.ipynb
@@ -28,7 +28,7 @@
       },
       "outputs": [],
       "source": [
-        "#r \"bin/Debug/net50/Reaqtor.IoT.dll\""
+        "#r \"bin/Debug/net6.0/Reaqtor.IoT.dll\""
       ]
     },
     {

--- a/Reaqtor/Samples/IoT/Reaqtor.IoT/IoT-House.ipynb
+++ b/Reaqtor/Samples/IoT/Reaqtor.IoT/IoT-House.ipynb
@@ -28,7 +28,7 @@
       },
       "outputs": [],
       "source": [
-        "#r \"bin/Debug/net50/Reaqtor.IoT.dll\""
+        "#r \"bin/Debug/net6.0/Reaqtor.IoT.dll\""
       ]
     },
     {

--- a/Reaqtor/Samples/IoT/Reaqtor.IoT/Reaqtor.IoT.csproj
+++ b/Reaqtor/Samples/IoT/Reaqtor.IoT/Reaqtor.IoT.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net472;net50</TargetFrameworks>
+    <TargetFrameworks>net472;net6.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <Description>Stand-alone sample of Reaqtor in an IoT edge context.</Description>
     <IsPackable>false</IsPackable>

--- a/Reaqtor/Samples/Shebang/Reaqtor.Shebang.App/Reaqtor.Shebang.App.csproj
+++ b/Reaqtor/Samples/Shebang/Reaqtor.Shebang.App/Reaqtor.Shebang.App.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net6.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 


### PR DESCRIPTION
WIP. Warning: does not compile due to obsolete reflection methods.

Current errors:

```
'Uri.EscapeUriString(string)' is obsolete: 'Uri.EscapeUriString can corrupt the Uri string in some cases. Consider using Uri.EscapeDataString for query string components.'	
Nuqleon.Linq.Expressions.Optimizers	
reaqtor\Nuqleon\Core\LINQ\Nuqleon.Linq.Expressions.Optimizers\System\Linq\Expressions\PureMemberCatalog.cs	
745	
'Type.ReflectionOnlyGetType(string, bool, bool)' is obsolete: 'ReflectionOnly loading is not supported and throws PlatformNotSupportedException.'	
Nuqleon.Reflection.Virtualization (net6.0)	
reaqtor\Nuqleon\Core\BCL\Nuqleon.Reflection.Virtualization\System\Reflection\Virtualization\DefaultReflectionProvider.cs
147
'Type.ReflectionOnlyGetType(string, bool, bool)' is obsolete: 'ReflectionOnly loading is not supported and throws PlatformNotSupportedException.'	
Nuqleon.Reflection.Virtualization	
reaqtor\Nuqleon\Core\BCL\Nuqleon.Reflection.Virtualization\System\Reflection\Virtualization\DefaultReflectionProvider.cs
147	
'Assembly.ReflectionOnlyLoadFrom(string)' is obsolete: 'ReflectionOnly loading is not supported and throws PlatformNotSupportedException.'	
Nuqleon.Reflection.Virtualization (net6.0)	
reaqtor\Nuqleon\Core\BCL\Nuqleon.Reflection.Virtualization\System\Reflection\Virtualization\DefaultReflectionProvider.cs
101
'Assembly.ReflectionOnlyLoadFrom(string)' is obsolete: 'ReflectionOnly loading is not supported and throws PlatformNotSupportedException.'	
Nuqleon.Reflection.Virtualization	
reaqtor\Nuqleon\Core\BCL\Nuqleon.Reflection.Virtualization\System\Reflection\Virtualization\DefaultReflectionProvider.cs
101	
'Assembly.ReflectionOnlyLoad(string)' is obsolete: 'ReflectionOnly loading is not supported and throws PlatformNotSupportedException.'	
Nuqleon.Reflection.Virtualization (net6.0)	
reaqtor\Nuqleon\Core\BCL\Nuqleon.Reflection.Virtualization\System\Reflection\Virtualization\DefaultReflectionProvider.cs
87
'Assembly.ReflectionOnlyLoad(string)' is obsolete: 'ReflectionOnly loading is not supported and throws PlatformNotSupportedException.'	
Nuqleon.Reflection.Virtualization	
reaqtor\Nuqleon\Core\BCL\Nuqleon.Reflection.Virtualization\System\Reflection\Virtualization\DefaultReflectionProvider.cs
87	
'Assembly.ReflectionOnlyLoad(byte[])' is obsolete: 'ReflectionOnly loading is not supported and throws PlatformNotSupportedException.'	
Nuqleon.Reflection.Virtualization (net6.0)	
reaqtor\Nuqleon\Core\BCL\Nuqleon.Reflection.Virtualization\System\Reflection\Virtualization\DefaultReflectionProvider.cs
94
'Assembly.ReflectionOnlyLoad(byte[])' is obsolete: 'ReflectionOnly loading is not supported and throws PlatformNotSupportedException.'	
Nuqleon.Reflection.Virtualization	
reaqtor\Nuqleon\Core\BCL\Nuqleon.Reflection.Virtualization\System\Reflection\Virtualization\DefaultReflectionProvider.cs
94
```