### PR TITLE
Added deserialization example to Bonsai serialization sample

### DIFF
--- a/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Bonsai.Serialization/GettingStarted.ipynb
+++ b/Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Bonsai.Serialization/GettingStarted.ipynb
@@ -275,6 +275,41 @@
         "\r\n",
         "Finally, the last array slow in the member lookup node is `[\"$\", 0, 0]`, which is a variable reference denoted by `$`. The indexes `0` and `0` refer to the scope and the index of the variable in that scope. In this case, the immediately surrounding scope is the lambda, whose first parameter is `string s`, so this expression node refers to that variable."
       ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Expression Deserialization using Bonsai\n",
+        "\n",
+        "Expression trees can be deserialized from the JSON-based Bonsai format using the `BonsaiExpressionSerializer` class. Building off one of the earlier examples, we'll create a simple expression tree, convert it to the `ExpressionSlim` representation and serialize it to a string. Then we'll look at how to deserialize it from that string to expression, compile that expression to a delegate we can pass arguments into and then compute a result using our deserialized expression."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 2,
+      "metadata": {
+        "dotnet_interactive": {
+          "language": "csharp"
+        }
+      },
+      "source": [
+        "using System.Linq.Expressions.Bonsai.Serialization;\n",
+        "\n",
+        "var ser = new BonsaiExpressionSerializer();\n",
+        "\n",
+        "//Serialize the expression below\n",
+        "Expression<Func<List<int>, int>> expr = x => x.Max();\n",
+        "var slim = expr.ToExpressionSlim();\n",
+        "var json = ser.Serialize(slim);\n",
+        "\n",
+        "//Deserialize and calculate a result\n",
+        "var deserializedSlim = ser.Deserialize(json);\n",
+        "var deserializedExpression = (Expression<Func<List<int>, int>>)deseralizedSlim.ToExpression();\n",
+        "var exprDelegate = deserializedExpression.Compile();\n",
+        "var data = new List<int>{1, 2, 3, 4, 5};\n",
+        "var result = exprDelegate(data); // 5"
+      ]
     }
   ],
   "metadata": {


### PR DESCRIPTION
There's a really robust example with explanation about how to use Bonsai for expression serialization, but it ends without an explainer of how to deserialize the expression to use on the other side. Added a brief example at the bottom to illustrate this.There's a really robust example with explanation about how to use Bonsai for expression serialization, but it ends without an explainer of how to deserialize the expression to use on the other side. Added a brief example at the bottom to illustrate this.