### PR TITLE
Package updates 2023 10

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -56,7 +56,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All"/>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All"/>
     <PackageReference Include="Nerdbank.GitVersioning" Version="3.3.37" PrivateAssets="all" />
   </ItemGroup>
 

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -71,7 +71,7 @@
           properly to the test project output folder, which then causes the test runner to treat the project
           as a "self-contained app".
     -->
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.10.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
     <PackageReference Include="MSTest.TestAdapter" Version="2.2.4" />
     <PackageReference Include="MSTest.TestFramework" Version="2.2.4" />
     <PackageReference Include="coverlet.collector" Version="6.0.0" PrivateAssets="all" />

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -74,7 +74,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.10.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="2.2.4" />
     <PackageReference Include="MSTest.TestFramework" Version="2.2.4" />
-    <PackageReference Include="coverlet.collector" Version="3.0.3" PrivateAssets="all" />
+    <PackageReference Include="coverlet.collector" Version="6.0.0" PrivateAssets="all" />
     <Compile Include="$(MSBuildThisFileDirectory)\Common\TestUtilities\AssertEx.cs" Link="AssertEx.cs" />
   </ItemGroup>
 

--- a/Nuqleon/Core/DataModel/Nuqleon.DataModel.Serialization.Json/Nuqleon.DataModel.Serialization.Json.csproj
+++ b/Nuqleon/Core/DataModel/Nuqleon.DataModel.Serialization.Json/Nuqleon.DataModel.Serialization.Json.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="System.Buffers" Version="4.5.1" />
   </ItemGroup>
 

--- a/Nuqleon/Core/JSON/Nuqleon.Json.Interop.Newtonsoft/Nuqleon.Json.Interop.Newtonsoft.csproj
+++ b/Nuqleon/Core/JSON/Nuqleon.Json.Interop.Newtonsoft/Nuqleon.Json.Interop.Newtonsoft.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Nuqleon/Core/JSON/Perf.Nuqleon.Json.Serialization/Perf.Nuqleon.Json.Serialization.csproj
+++ b/Nuqleon/Core/JSON/Perf.Nuqleon.Json.Serialization/Perf.Nuqleon.Json.Serialization.csproj
@@ -15,8 +15,8 @@
     <LangVersion>9.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="BenchmarkDotNet" Version="0.12.1" />
-    <PackageReference Include="BenchmarkDotNet.Diagnostics.Windows" Version="0.12.1" />
+    <PackageReference Include="BenchmarkDotNet" Version="0.13.9" />
+    <PackageReference Include="BenchmarkDotNet.Diagnostics.Windows" Version="0.13.9" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
   </ItemGroup>
   <ItemGroup>

--- a/Nuqleon/Core/JSON/Perf.Nuqleon.Json.Serialization/Perf.Nuqleon.Json.Serialization.csproj
+++ b/Nuqleon/Core/JSON/Perf.Nuqleon.Json.Serialization/Perf.Nuqleon.Json.Serialization.csproj
@@ -17,7 +17,7 @@
   <ItemGroup>
     <PackageReference Include="BenchmarkDotNet" Version="0.13.9" />
     <PackageReference Include="BenchmarkDotNet.Diagnostics.Windows" Version="0.13.9" />
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Nuqleon.Json.Serialization\Nuqleon.Json.Serialization.csproj" />

--- a/Nuqleon/Pearls/LINQ/BinaryExpressionSerialization/BinaryExpressionSerialization/Nuqleon.Pearls.Linq.Expressions.Bonsai.Serialization.Binary.Perf.csproj
+++ b/Nuqleon/Pearls/LINQ/BinaryExpressionSerialization/BinaryExpressionSerialization/Nuqleon.Pearls.Linq.Expressions.Bonsai.Serialization.Binary.Perf.csproj
@@ -22,8 +22,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="BenchmarkDotNet" Version="0.12.1" />
-    <PackageReference Include="BenchmarkDotNet.Diagnostics.Windows" Version="0.12.1" />
+    <PackageReference Include="BenchmarkDotNet" Version="0.13.9" />
+    <PackageReference Include="BenchmarkDotNet.Diagnostics.Windows" Version="0.13.9" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
   </ItemGroup>
 

--- a/Nuqleon/Pearls/LINQ/BinaryExpressionSerialization/BinaryExpressionSerialization/Nuqleon.Pearls.Linq.Expressions.Bonsai.Serialization.Binary.Perf.csproj
+++ b/Nuqleon/Pearls/LINQ/BinaryExpressionSerialization/BinaryExpressionSerialization/Nuqleon.Pearls.Linq.Expressions.Bonsai.Serialization.Binary.Perf.csproj
@@ -24,7 +24,7 @@
   <ItemGroup>
     <PackageReference Include="BenchmarkDotNet" Version="0.13.9" />
     <PackageReference Include="BenchmarkDotNet.Diagnostics.Windows" Version="0.13.9" />
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Reaqtive/Pearls/Rxcel/Reaqtive.Pearls.Rxcel.csproj
+++ b/Reaqtive/Pearls/Rxcel/Reaqtive.Pearls.Rxcel.csproj
@@ -15,7 +15,7 @@
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="System.Reactive" Version="5.0.0" />
+    <PackageReference Include="System.Reactive" Version="6.0.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\Nuqleon\Core\LINQ\Nuqleon.Linq.Expressions.Bonsai.Serialization\Nuqleon.Linq.Expressions.Bonsai.Serialization.csproj" />

--- a/Reaqtor/Core/Engine/Reaqtor.QueryEngine.KeyValueStore.InMemory/Reaqtor.QueryEngine.KeyValueStore.InMemory.csproj
+++ b/Reaqtor/Core/Engine/Reaqtor.QueryEngine.KeyValueStore.InMemory/Reaqtor.QueryEngine.KeyValueStore.InMemory.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Collections.Immutable" Version="6.0.0" />
+    <PackageReference Include="System.Collections.Immutable" Version="7.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Reaqtor/Core/Engine/Reaqtor.QueryEngine.KeyValueStore.InMemory/Reaqtor.QueryEngine.KeyValueStore.InMemory.csproj
+++ b/Reaqtor/Core/Engine/Reaqtor.QueryEngine.KeyValueStore.InMemory/Reaqtor.QueryEngine.KeyValueStore.InMemory.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Collections.Immutable" Version="5.0.0" />
+    <PackageReference Include="System.Collections.Immutable" Version="6.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Reaqtor/Core/Engine/Reaqtor.QueryEngine.Mocks/Reaqtor.QueryEngine.Mocks.csproj
+++ b/Reaqtor/Core/Engine/Reaqtor.QueryEngine.Mocks/Reaqtor.QueryEngine.Mocks.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Collections.Immutable" Version="6.0.0" />
+    <PackageReference Include="System.Collections.Immutable" Version="7.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Reaqtor/Core/Engine/Reaqtor.QueryEngine.Mocks/Reaqtor.QueryEngine.Mocks.csproj
+++ b/Reaqtor/Core/Engine/Reaqtor.QueryEngine.Mocks/Reaqtor.QueryEngine.Mocks.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Collections.Immutable" Version="5.0.0" />
+    <PackageReference Include="System.Collections.Immutable" Version="6.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Reaqtor/Core/Engine/Tests.Reaqtor.QueryEngine/Tests.Reaqtor.QueryEngine.csproj
+++ b/Reaqtor/Core/Engine/Tests.Reaqtor.QueryEngine/Tests.Reaqtor.QueryEngine.csproj
@@ -15,7 +15,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Collections.Immutable" Version="5.0.0" />
+    <PackageReference Include="System.Collections.Immutable" Version="6.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Reaqtor/Core/Engine/Tests.Reaqtor.QueryEngine/Tests.Reaqtor.QueryEngine.csproj
+++ b/Reaqtor/Core/Engine/Tests.Reaqtor.QueryEngine/Tests.Reaqtor.QueryEngine.csproj
@@ -15,7 +15,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Collections.Immutable" Version="6.0.0" />
+    <PackageReference Include="System.Collections.Immutable" Version="7.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Reaqtor/Pearls/CSE/Reaqtor.Pearls.CommonSubexpressionElimination.csproj
+++ b/Reaqtor/Pearls/CSE/Reaqtor.Pearls.CommonSubexpressionElimination.csproj
@@ -6,7 +6,7 @@
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="System.Reactive" Version="5.0.0" />
+    <PackageReference Include="System.Reactive" Version="6.0.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\Nuqleon\Core\LINQ\Nuqleon.Linq.CompilerServices\Nuqleon.Linq.CompilerServices.csproj" />

--- a/Reaqtor/Pearls/DelegatingBinder/Reaqtor.Pearls.DelegatingBinder.csproj
+++ b/Reaqtor/Pearls/DelegatingBinder/Reaqtor.Pearls.DelegatingBinder.csproj
@@ -6,7 +6,7 @@
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="System.Reactive" Version="5.0.0" />
+    <PackageReference Include="System.Reactive" Version="6.0.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\Nuqleon\Core\LINQ\Nuqleon.Linq.CompilerServices\Nuqleon.Linq.CompilerServices.csproj" />

--- a/Reaqtor/Pearls/OperatorFusion/OperatorFusion/Reaqtor.Pearls.Reactive.Fusion.Playground.csproj
+++ b/Reaqtor/Pearls/OperatorFusion/OperatorFusion/Reaqtor.Pearls.Reactive.Fusion.Playground.csproj
@@ -6,7 +6,7 @@
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="System.Reactive" Version="5.0.0" />
+    <PackageReference Include="System.Reactive" Version="6.0.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\RuntimeLib\Reaqtor.Pearls.Reactive.Fusion.csproj" />

--- a/Reaqtor/Pearls/OperatorLocalStorage/OperatorLocalStorage/Reaqtive.Storage.Playground.csproj
+++ b/Reaqtor/Pearls/OperatorLocalStorage/OperatorLocalStorage/Reaqtive.Storage.Playground.csproj
@@ -5,7 +5,7 @@
     <IsPackable>false</IsPackable>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="System.Reactive" Version="5.0.0" />
+    <PackageReference Include="System.Reactive" Version="6.0.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Engine\Engine.csproj" />

--- a/Reaqtor/Pearls/OperatorLocalStorage/Utilities/Reaqtive.Storage.Utils.csproj
+++ b/Reaqtor/Pearls/OperatorLocalStorage/Utilities/Reaqtive.Storage.Utils.csproj
@@ -13,7 +13,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Collections.Immutable" Version="5.0.0" />
+    <PackageReference Include="System.Collections.Immutable" Version="6.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Reaqtor/Pearls/OperatorLocalStorage/Utilities/Reaqtive.Storage.Utils.csproj
+++ b/Reaqtor/Pearls/OperatorLocalStorage/Utilities/Reaqtive.Storage.Utils.csproj
@@ -13,7 +13,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Collections.Immutable" Version="6.0.0" />
+    <PackageReference Include="System.Collections.Immutable" Version="7.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Reaqtor/Pearls/PartitionedSubject/Reaqtor.Pearls.PartitionedSubject.csproj
+++ b/Reaqtor/Pearls/PartitionedSubject/Reaqtor.Pearls.PartitionedSubject.csproj
@@ -6,6 +6,6 @@
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="System.Reactive" Version="5.0.0" />
+    <PackageReference Include="System.Reactive" Version="6.0.0" />
   </ItemGroup>
 </Project>

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Deployable/Reaqtor.Remoting.Deployable.csproj
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Deployable/Reaqtor.Remoting.Deployable.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Reactive" Version="5.0.0" />
+    <PackageReference Include="System.Reactive" Version="6.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.KeyValueStore/Reaqtor.Remoting.KeyValueStore.csproj
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.KeyValueStore/Reaqtor.Remoting.KeyValueStore.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Collections.Immutable" Version="5.0.0" />
+    <PackageReference Include="System.Collections.Immutable" Version="6.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.KeyValueStore/Reaqtor.Remoting.KeyValueStore.csproj
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.KeyValueStore/Reaqtor.Remoting.KeyValueStore.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Collections.Immutable" Version="6.0.0" />
+    <PackageReference Include="System.Collections.Immutable" Version="7.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Reactor.Client.Library/Reaqtor.Remoting.Reactor.Client.Library.csproj
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Reactor.Client.Library/Reaqtor.Remoting.Reactor.Client.Library.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.StateStore/Reaqtor.Remoting.StateStore.csproj
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.StateStore/Reaqtor.Remoting.StateStore.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Collections.Immutable" Version="5.0.0" />
+    <PackageReference Include="System.Collections.Immutable" Version="6.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Reaqtor/Samples/Remoting/Reaqtor.Remoting.StateStore/Reaqtor.Remoting.StateStore.csproj
+++ b/Reaqtor/Samples/Remoting/Reaqtor.Remoting.StateStore/Reaqtor.Remoting.StateStore.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Collections.Immutable" Version="6.0.0" />
+    <PackageReference Include="System.Collections.Immutable" Version="7.0.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Updating:

`MSTest.TestFramework` to 3.1.1 causes errors in:

```
Tests.Nuqleon.Memory C:\reaqtive\reaqtor\Nuqleon\Core\BCL\Tests.Nuqleon.Memory\System\TupletTests.Generated.cs
Tests.Nuqleon.Linq.CompilerServices C:\reaqtive\reaqtor\Nuqleon\Core\LINQ\Tests.Nuqleon.Linq.CompilerServices\Collections\IndexedTests.cs
Tests.Nuqleon.Linq.Expressions.Bonsai C:\reaqtive\reaqtor\Nuqleon\Core\LINQ\Tests.Nuqleon.Linq.Expressions.Bonsai\System\Reflection\TypeSlim.cs
```

Updating:

`Nerdbank.GitVersioning` to 3.6.133 causes the following error:

```
Visual Basic 11.0 does not support warning directives.	
Tests.VisualBasic C:\reaqtive\reaqtor\Nuqleon\Core\LINQ\Tests.VisualBasic\obj\Debug\netstandard2.0\Tests.VisualBasic.Version.vb
```