### PR TITLE
Remove netcoreapp3.1 as target framework

### DIFF
--- a/Nuqleon/Core/BCL/Tests.Nuqleon.Collections.Specialized/Tests.Nuqleon.Collections.Specialized.csproj
+++ b/Nuqleon/Core/BCL/Tests.Nuqleon.Collections.Specialized/Tests.Nuqleon.Collections.Specialized.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net472;net6.0</TargetFrameworks>
+    <TargetFrameworks>net472;net6.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Nuqleon/Core/BCL/Tests.Nuqleon.IO.StreamSegment/Tests.Nuqleon.IO.StreamSegment.csproj
+++ b/Nuqleon/Core/BCL/Tests.Nuqleon.IO.StreamSegment/Tests.Nuqleon.IO.StreamSegment.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net472;net6.0</TargetFrameworks>
+    <TargetFrameworks>net472;net6.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Nuqleon/Core/BCL/Tests.Nuqleon.Memory/Tests.Nuqleon.Memory.csproj
+++ b/Nuqleon/Core/BCL/Tests.Nuqleon.Memory/Tests.Nuqleon.Memory.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net472;net6.0</TargetFrameworks>
+    <TargetFrameworks>net472;net6.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Nuqleon/Core/BCL/Tests.Nuqleon.Reflection.Virtualization/Tests.Nuqleon.Reflection.Virtualization.csproj
+++ b/Nuqleon/Core/BCL/Tests.Nuqleon.Reflection.Virtualization/Tests.Nuqleon.Reflection.Virtualization.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net472;net6.0</TargetFrameworks>
+    <TargetFrameworks>net472;net6.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Nuqleon/Core/BCL/Tests.Nuqleon.Time/Tests.Nuqleon.Time.csproj
+++ b/Nuqleon/Core/BCL/Tests.Nuqleon.Time/Tests.Nuqleon.Time.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net472;net6.0</TargetFrameworks>
+    <TargetFrameworks>net472;net6.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Nuqleon/Core/DataModel/Tests.Nuqleon.DataModel.CompilerServices/Bonsai/EntitySubstitution/ExpressionSlimEntityTypeRecordizerTests.More.cs
+++ b/Nuqleon/Core/DataModel/Tests.Nuqleon.DataModel.CompilerServices/Bonsai/EntitySubstitution/ExpressionSlimEntityTypeRecordizerTests.More.cs
@@ -23,6 +23,7 @@ using Nuqleon.DataModel.CompilerServices;
 #if NETFRAMEWORK
 using System.IO;
 using System.Reflection.Emit;
+
 using Nuqleon.DataModel.CompilerServices.Bonsai;
 #endif
 

--- a/Nuqleon/Core/DataModel/Tests.Nuqleon.DataModel.CompilerServices/Tests.Nuqleon.DataModel.CompilerServices.csproj
+++ b/Nuqleon/Core/DataModel/Tests.Nuqleon.DataModel.CompilerServices/Tests.Nuqleon.DataModel.CompilerServices.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net472;net6.0</TargetFrameworks>
+    <TargetFrameworks>net472;net6.0</TargetFrameworks>
 
     <!-- JSON002 Probable JSON string detected. We don't really want the JSON string literal support because the oddities in the JSON in this project are deliberate. -->
     <NoWarn>$(NoWarn);JSON002</NoWarn>

--- a/Nuqleon/Core/DataModel/Tests.Nuqleon.DataModel.Serialization.Binary/Tests.Nuqleon.DataModel.Serialization.Binary.csproj
+++ b/Nuqleon/Core/DataModel/Tests.Nuqleon.DataModel.Serialization.Binary/Tests.Nuqleon.DataModel.Serialization.Binary.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net472;net6.0</TargetFrameworks>
+    <TargetFrameworks>net472;net6.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Nuqleon/Core/DataModel/Tests.Nuqleon.DataModel.Serialization.Json/Tests.Nuqleon.DataModel.Serialization.Json.csproj
+++ b/Nuqleon/Core/DataModel/Tests.Nuqleon.DataModel.Serialization.Json/Tests.Nuqleon.DataModel.Serialization.Json.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net472;net6.0</TargetFrameworks>
+    <TargetFrameworks>net472;net6.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Nuqleon/Core/DataModel/Tests.Nuqleon.DataModel/Tests.Nuqleon.DataModel.csproj
+++ b/Nuqleon/Core/DataModel/Tests.Nuqleon.DataModel/Tests.Nuqleon.DataModel.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net472;net6.0</TargetFrameworks>
+    <TargetFrameworks>net472;net6.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Nuqleon/Core/JSON/Perf.Nuqleon.Json.Serialization/Perf.Nuqleon.Json.Serialization.csproj
+++ b/Nuqleon/Core/JSON/Perf.Nuqleon.Json.Serialization/Perf.Nuqleon.Json.Serialization.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net6.0</TargetFrameworks>
+    <TargetFrameworks>net6.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
   </PropertyGroup>
   <PropertyGroup>

--- a/Nuqleon/Core/JSON/Tests.Nuqleon.Json.Interop.Newtonsoft/Tests.Nuqleon.Json.Interop.Newtonsoft.csproj
+++ b/Nuqleon/Core/JSON/Tests.Nuqleon.Json.Interop.Newtonsoft/Tests.Nuqleon.Json.Interop.Newtonsoft.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net472;net6.0</TargetFrameworks>
+    <TargetFrameworks>net472;net6.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Nuqleon/Core/JSON/Tests.Nuqleon.Json.Serialization/Tests.Nuqleon.Json.Serialization.csproj
+++ b/Nuqleon/Core/JSON/Tests.Nuqleon.Json.Serialization/Tests.Nuqleon.Json.Serialization.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net472;net6.0</TargetFrameworks>
+    <TargetFrameworks>net472;net6.0</TargetFrameworks>
 
     <!-- JSON002 Probable JSON string detected. We don't really want the JSON string literal support because the oddities in the JSON in this project are deliberate. -->
     <NoWarn>$(NoWarn);JSON002</NoWarn>

--- a/Nuqleon/Core/JSON/Tests.Nuqleon.Json/Tests.Nuqleon.Json.csproj
+++ b/Nuqleon/Core/JSON/Tests.Nuqleon.Json/Tests.Nuqleon.Json.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net472;net6.0</TargetFrameworks>
+    <TargetFrameworks>net472;net6.0</TargetFrameworks>
     
     <!-- JSON002 Probable JSON string detected. We don't really want the JSON string literal support because the oddities in the JSON in this project are deliberate. -->
     <NoWarn>$(NoWarn);JSON002</NoWarn>

--- a/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.CompilerServices.Optimizers/Tests.Nuqleon.Linq.CompilerServices.Optimizers.csproj
+++ b/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.CompilerServices.Optimizers/Tests.Nuqleon.Linq.CompilerServices.Optimizers.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net472;net6.0</TargetFrameworks>
+    <TargetFrameworks>net472;net6.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.CompilerServices/Evaluation/EvaluationTests.cs
+++ b/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.CompilerServices/Evaluation/EvaluationTests.cs
@@ -338,7 +338,7 @@ namespace Tests.System.Linq.CompilerServices
         [TestMethod]
         public void CachedLambdaCompiler_TooManyConstantsForLCGTypes()
         {
-#if NETCOREAPP2_1 || NETCOREAPP3_1 || NET6_0
+#if NET6_0
             var asm = AssemblyBuilder.DefineDynamicAssembly(new AssemblyName("EvalTests_foo"), AssemblyBuilderAccess.RunAndCollect);
 #else
             var asm = AppDomain.CurrentDomain.DefineDynamicAssembly(new AssemblyName("EvalTests_foo"), AssemblyBuilderAccess.RunAndCollect);

--- a/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.CompilerServices/Tests.Nuqleon.Linq.CompilerServices.csproj
+++ b/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.CompilerServices/Tests.Nuqleon.Linq.CompilerServices.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net472;net6.0</TargetFrameworks>
+    <TargetFrameworks>net472;net6.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.Expressions.Bonsai.Hashing/Tests.Nuqleon.Linq.Expressions.Bonsai.Hashing.csproj
+++ b/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.Expressions.Bonsai.Hashing/Tests.Nuqleon.Linq.Expressions.Bonsai.Hashing.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net472;net6.0</TargetFrameworks>
+    <TargetFrameworks>net472;net6.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.Expressions.Bonsai.Serialization/Tests.Nuqleon.Linq.Expressions.Bonsai.Serialization.csproj
+++ b/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.Expressions.Bonsai.Serialization/Tests.Nuqleon.Linq.Expressions.Bonsai.Serialization.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net472;net6.0</TargetFrameworks>
+    <TargetFrameworks>net472;net6.0</TargetFrameworks>
 
     <!-- JSON002 Probable JSON string detected. We don't really want the JSON string literal support because the oddities in the JSON in this project are deliberate. -->
     <NoWarn>$(NoWarn);JSON002</NoWarn>

--- a/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.Expressions.Bonsai/System/Reflection/TypeSlimEqualityComparer.cs
+++ b/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.Expressions.Bonsai/System/Reflection/TypeSlimEqualityComparer.cs
@@ -234,7 +234,7 @@ namespace Tests.System.Reflection
             Assert.IsTrue(true);
         }
 
-#if NET6_0 || NETCOREAPP3_1
+#if NET6_0
         [Ignore] // See NB comment below; the implementation detail changed in .NET Core 3.1 and above.
 #endif
         [TestMethod]

--- a/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.Expressions.Bonsai/System/Reflection/TypeSlimVisitor.cs
+++ b/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.Expressions.Bonsai/System/Reflection/TypeSlimVisitor.cs
@@ -330,7 +330,7 @@ namespace Tests.System.Reflection
             {
                 if (type.Name.StartsWith("System.Func`"))
                 {
-#if NET6_0 || NETCOREAPP3_1
+#if NET6_0
                     var action = "System.Action`" + type.Name["System.Func`".Length..];
 #else
                     var action = "System.Action`" + type.Name.Substring("System.Func`".Length);

--- a/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.Expressions.Bonsai/Tests.Nuqleon.Linq.Expressions.Bonsai.csproj
+++ b/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.Expressions.Bonsai/Tests.Nuqleon.Linq.Expressions.Bonsai.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net472;net6.0</TargetFrameworks>
+    <TargetFrameworks>net472;net6.0</TargetFrameworks>
     <DefineConstants>$(DefineConstants);USE_SLIM</DefineConstants>
   </PropertyGroup>
 

--- a/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.Expressions.Optimizers/PureMemberCatalogTests.cs
+++ b/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.Expressions.Optimizers/PureMemberCatalogTests.cs
@@ -64,12 +64,10 @@ namespace Tests.System.Linq.Expressions.Optimizers
 
             { typeof(Array), new HashSet<object> { Array.Empty<int>(), Array.Empty<string>(), new int[] { 1 }, new int[] { 1, 2, 3, 4, 5 } } }, // TODO: Add multi-dimensional arrays
 
-#if NET6_0 || NETCOREAPP3_1
+#if NET6_0
             { typeof(Index), new HashSet<object> { (Index)0, ^0, (Index)1, ^2 } },
             { typeof(Range), new HashSet<object> { .., 0.., ..0, 1.., ..1, ^1.., ..^1, 1..2, ^2..^1 } },
-#endif
 
-#if NET6_0
             { typeof(Half), new HashSet<object> { (Half)0.0, (Half)1.0, Half.PositiveInfinity } },
 #endif
         };

--- a/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.Expressions.Optimizers/Tests.Nuqleon.Linq.Expressions.Optimizers.csproj
+++ b/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.Expressions.Optimizers/Tests.Nuqleon.Linq.Expressions.Optimizers.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net472;net6.0</TargetFrameworks>
+    <TargetFrameworks>net472;net6.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Nuqleon/Museum/Tests.Nuqleon.Serialization/Tests.Nuqleon.Serialization.csproj
+++ b/Nuqleon/Museum/Tests.Nuqleon.Serialization/Tests.Nuqleon.Serialization.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net472</TargetFrameworks>
+    <TargetFrameworks>net472</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Nuqleon/Museum/Tests.Nuqleon.StringSegment/Tests.Nuqleon.StringSegment.csproj
+++ b/Nuqleon/Museum/Tests.Nuqleon.StringSegment/Tests.Nuqleon.StringSegment.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net472</TargetFrameworks>
+    <TargetFrameworks>net472</TargetFrameworks>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/Nuqleon/Pearls/LINQ/BinaryExpressionSerialization/Tests/Tests.Nuqleon.Pearls.Linq.Expressions.Bonsai.Serialization.Binary.csproj
+++ b/Nuqleon/Pearls/LINQ/BinaryExpressionSerialization/Tests/Tests.Nuqleon.Pearls.Linq.Expressions.Bonsai.Serialization.Binary.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net472;net6.0</TargetFrameworks>
+    <TargetFrameworks>net472;net6.0</TargetFrameworks>
     <!-- NB: Also supports non-slim expressions. Currently not enabled in build. -->
     <DefineConstants>$(DefineConstants);USE_SLIM</DefineConstants>
   </PropertyGroup>

--- a/Nuqleon/Pearls/LINQ/PartialExpressionEvaluator/Test/Tests.Nuqleon.Pearls.PartialExpressionTreeEvaluator.csproj
+++ b/Nuqleon/Pearls/LINQ/PartialExpressionEvaluator/Test/Tests.Nuqleon.Pearls.PartialExpressionTreeEvaluator.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net472;net6.0</TargetFrameworks>
+    <TargetFrameworks>net472;net6.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Reaqtive/Core/Tests.Reaqtive.Core/Tests.Reaqtive.Core.csproj
+++ b/Reaqtive/Core/Tests.Reaqtive.Core/Tests.Reaqtive.Core.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net472;net6.0</TargetFrameworks>
+    <TargetFrameworks>net472;net6.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Reaqtive/Core/Tests.Reaqtive.Linq/Tests.Reaqtive.Linq.csproj
+++ b/Reaqtive/Core/Tests.Reaqtive.Linq/Tests.Reaqtive.Linq.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net472;net6.0</TargetFrameworks>
+    <TargetFrameworks>net472;net6.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Reaqtive/Core/Tests.Reaqtive.Quotation/Tests.Reaqtive.Quotation.csproj
+++ b/Reaqtive/Core/Tests.Reaqtive.Quotation/Tests.Reaqtive.Quotation.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net472;net6.0</TargetFrameworks>
+    <TargetFrameworks>net472;net6.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Reaqtive/Core/Tests.Reaqtive.Scheduler/Tests.Reaqtive.Scheduler.csproj
+++ b/Reaqtive/Core/Tests.Reaqtive.Scheduler/Tests.Reaqtive.Scheduler.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net472;net6.0</TargetFrameworks>
+    <TargetFrameworks>net472;net6.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Reaqtor/Core/Client/Tests.Reaqtor.Client.Core/Tests.Reaqtor.Client.Core.csproj
+++ b/Reaqtor/Core/Client/Tests.Reaqtor.Client.Core/Tests.Reaqtor.Client.Core.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net472;net6.0</TargetFrameworks>
+    <TargetFrameworks>net472;net6.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Reaqtor/Core/Client/Tests.Reaqtor.Client/ReactiveClientContextHigherArityTests.cs
+++ b/Reaqtor/Core/Client/Tests.Reaqtor.Client/ReactiveClientContextHigherArityTests.cs
@@ -17,10 +17,10 @@ using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
 
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
 using Reaqtor;
 using Reaqtor.TestingFramework;
-
-using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Tests.Reaqtor.Client
 {

--- a/Reaqtor/Core/Client/Tests.Reaqtor.Client/ReactiveClientContextHigherArityTests.cs
+++ b/Reaqtor/Core/Client/Tests.Reaqtor.Client/ReactiveClientContextHigherArityTests.cs
@@ -17,10 +17,10 @@ using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
 
-using Microsoft.VisualStudio.TestTools.UnitTesting;
-
 using Reaqtor;
 using Reaqtor.TestingFramework;
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Tests.Reaqtor.Client
 {
@@ -8172,7 +8172,7 @@ namespace Tests.Reaqtor.Client
                     Assert.ThrowsException<ArgumentNullException>(() => ((IAsyncReactiveSubscriptionFactory<string, string>)factory).CreateAsync(subscriptionUri: null, "factory_parameter_1", "factory_parameter_2", state: null).Wait());
                     Assert.ThrowsException<ArgumentNullException>(() => ((IAsyncReactiveSubscriptionFactory<string, string>)factory).CreateAsync(subscriptionUri: null, "factory_parameter_1", "factory_parameter_2", state: null, CancellationToken.None).Wait());
 
-#if NET6_0 || NETCOREAPP3_1 // Suppresses CA2012
+#if NET6_0 // Suppresses CA2012
                     sub.DisposeAsync().AsTask().Wait();
 #else
                     sub.DisposeAsync().Wait();
@@ -8210,7 +8210,7 @@ namespace Tests.Reaqtor.Client
                     Assert.ThrowsException<ArgumentNullException>(() => ((IAsyncReactiveSubscriptionFactory<string, string, string>)factory).CreateAsync(subscriptionUri: null, "factory_parameter_1", "factory_parameter_2", "factory_parameter_3", state: null).Wait());
                     Assert.ThrowsException<ArgumentNullException>(() => ((IAsyncReactiveSubscriptionFactory<string, string, string>)factory).CreateAsync(subscriptionUri: null, "factory_parameter_1", "factory_parameter_2", "factory_parameter_3", state: null, CancellationToken.None).Wait());
 
-#if NET6_0 || NETCOREAPP3_1 // Suppresses CA2012
+#if NET6_0 // Suppresses CA2012
                     sub.DisposeAsync().AsTask().Wait();
 #else
                     sub.DisposeAsync().Wait();
@@ -8249,7 +8249,7 @@ namespace Tests.Reaqtor.Client
                     Assert.ThrowsException<ArgumentNullException>(() => ((IAsyncReactiveSubscriptionFactory<string, string, string, string>)factory).CreateAsync(subscriptionUri: null, "factory_parameter_1", "factory_parameter_2", "factory_parameter_3", "factory_parameter_4", state: null).Wait());
                     Assert.ThrowsException<ArgumentNullException>(() => ((IAsyncReactiveSubscriptionFactory<string, string, string, string>)factory).CreateAsync(subscriptionUri: null, "factory_parameter_1", "factory_parameter_2", "factory_parameter_3", "factory_parameter_4", state: null, CancellationToken.None).Wait());
 
-#if NET6_0 || NETCOREAPP3_1 // Suppresses CA2012
+#if NET6_0 // Suppresses CA2012
                     sub.DisposeAsync().AsTask().Wait();
 #else
                     sub.DisposeAsync().Wait();
@@ -8289,7 +8289,7 @@ namespace Tests.Reaqtor.Client
                     Assert.ThrowsException<ArgumentNullException>(() => ((IAsyncReactiveSubscriptionFactory<string, string, string, string, string>)factory).CreateAsync(subscriptionUri: null, "factory_parameter_1", "factory_parameter_2", "factory_parameter_3", "factory_parameter_4", "factory_parameter_5", state: null).Wait());
                     Assert.ThrowsException<ArgumentNullException>(() => ((IAsyncReactiveSubscriptionFactory<string, string, string, string, string>)factory).CreateAsync(subscriptionUri: null, "factory_parameter_1", "factory_parameter_2", "factory_parameter_3", "factory_parameter_4", "factory_parameter_5", state: null, CancellationToken.None).Wait());
 
-#if NET6_0 || NETCOREAPP3_1 // Suppresses CA2012
+#if NET6_0 // Suppresses CA2012
                     sub.DisposeAsync().AsTask().Wait();
 #else
                     sub.DisposeAsync().Wait();
@@ -8330,7 +8330,7 @@ namespace Tests.Reaqtor.Client
                     Assert.ThrowsException<ArgumentNullException>(() => ((IAsyncReactiveSubscriptionFactory<string, string, string, string, string, string>)factory).CreateAsync(subscriptionUri: null, "factory_parameter_1", "factory_parameter_2", "factory_parameter_3", "factory_parameter_4", "factory_parameter_5", "factory_parameter_6", state: null).Wait());
                     Assert.ThrowsException<ArgumentNullException>(() => ((IAsyncReactiveSubscriptionFactory<string, string, string, string, string, string>)factory).CreateAsync(subscriptionUri: null, "factory_parameter_1", "factory_parameter_2", "factory_parameter_3", "factory_parameter_4", "factory_parameter_5", "factory_parameter_6", state: null, CancellationToken.None).Wait());
 
-#if NET6_0 || NETCOREAPP3_1 // Suppresses CA2012
+#if NET6_0 // Suppresses CA2012
                     sub.DisposeAsync().AsTask().Wait();
 #else
                     sub.DisposeAsync().Wait();
@@ -8372,7 +8372,7 @@ namespace Tests.Reaqtor.Client
                     Assert.ThrowsException<ArgumentNullException>(() => ((IAsyncReactiveSubscriptionFactory<string, string, string, string, string, string, string>)factory).CreateAsync(subscriptionUri: null, "factory_parameter_1", "factory_parameter_2", "factory_parameter_3", "factory_parameter_4", "factory_parameter_5", "factory_parameter_6", "factory_parameter_7", state: null).Wait());
                     Assert.ThrowsException<ArgumentNullException>(() => ((IAsyncReactiveSubscriptionFactory<string, string, string, string, string, string, string>)factory).CreateAsync(subscriptionUri: null, "factory_parameter_1", "factory_parameter_2", "factory_parameter_3", "factory_parameter_4", "factory_parameter_5", "factory_parameter_6", "factory_parameter_7", state: null, CancellationToken.None).Wait());
 
-#if NET6_0 || NETCOREAPP3_1 // Suppresses CA2012
+#if NET6_0 // Suppresses CA2012
                     sub.DisposeAsync().AsTask().Wait();
 #else
                     sub.DisposeAsync().Wait();
@@ -8415,7 +8415,7 @@ namespace Tests.Reaqtor.Client
                     Assert.ThrowsException<ArgumentNullException>(() => ((IAsyncReactiveSubscriptionFactory<string, string, string, string, string, string, string, string>)factory).CreateAsync(subscriptionUri: null, "factory_parameter_1", "factory_parameter_2", "factory_parameter_3", "factory_parameter_4", "factory_parameter_5", "factory_parameter_6", "factory_parameter_7", "factory_parameter_8", state: null).Wait());
                     Assert.ThrowsException<ArgumentNullException>(() => ((IAsyncReactiveSubscriptionFactory<string, string, string, string, string, string, string, string>)factory).CreateAsync(subscriptionUri: null, "factory_parameter_1", "factory_parameter_2", "factory_parameter_3", "factory_parameter_4", "factory_parameter_5", "factory_parameter_6", "factory_parameter_7", "factory_parameter_8", state: null, CancellationToken.None).Wait());
 
-#if NET6_0 || NETCOREAPP3_1 // Suppresses CA2012
+#if NET6_0 // Suppresses CA2012
                     sub.DisposeAsync().AsTask().Wait();
 #else
                     sub.DisposeAsync().Wait();
@@ -8459,7 +8459,7 @@ namespace Tests.Reaqtor.Client
                     Assert.ThrowsException<ArgumentNullException>(() => ((IAsyncReactiveSubscriptionFactory<string, string, string, string, string, string, string, string, string>)factory).CreateAsync(subscriptionUri: null, "factory_parameter_1", "factory_parameter_2", "factory_parameter_3", "factory_parameter_4", "factory_parameter_5", "factory_parameter_6", "factory_parameter_7", "factory_parameter_8", "factory_parameter_9", state: null).Wait());
                     Assert.ThrowsException<ArgumentNullException>(() => ((IAsyncReactiveSubscriptionFactory<string, string, string, string, string, string, string, string, string>)factory).CreateAsync(subscriptionUri: null, "factory_parameter_1", "factory_parameter_2", "factory_parameter_3", "factory_parameter_4", "factory_parameter_5", "factory_parameter_6", "factory_parameter_7", "factory_parameter_8", "factory_parameter_9", state: null, CancellationToken.None).Wait());
 
-#if NET6_0 || NETCOREAPP3_1 // Suppresses CA2012
+#if NET6_0 // Suppresses CA2012
                     sub.DisposeAsync().AsTask().Wait();
 #else
                     sub.DisposeAsync().Wait();
@@ -8504,7 +8504,7 @@ namespace Tests.Reaqtor.Client
                     Assert.ThrowsException<ArgumentNullException>(() => ((IAsyncReactiveSubscriptionFactory<string, string, string, string, string, string, string, string, string, string>)factory).CreateAsync(subscriptionUri: null, "factory_parameter_1", "factory_parameter_2", "factory_parameter_3", "factory_parameter_4", "factory_parameter_5", "factory_parameter_6", "factory_parameter_7", "factory_parameter_8", "factory_parameter_9", "factory_parameter_10", state: null).Wait());
                     Assert.ThrowsException<ArgumentNullException>(() => ((IAsyncReactiveSubscriptionFactory<string, string, string, string, string, string, string, string, string, string>)factory).CreateAsync(subscriptionUri: null, "factory_parameter_1", "factory_parameter_2", "factory_parameter_3", "factory_parameter_4", "factory_parameter_5", "factory_parameter_6", "factory_parameter_7", "factory_parameter_8", "factory_parameter_9", "factory_parameter_10", state: null, CancellationToken.None).Wait());
 
-#if NET6_0 || NETCOREAPP3_1 // Suppresses CA2012
+#if NET6_0 // Suppresses CA2012
                     sub.DisposeAsync().AsTask().Wait();
 #else
                     sub.DisposeAsync().Wait();
@@ -8550,7 +8550,7 @@ namespace Tests.Reaqtor.Client
                     Assert.ThrowsException<ArgumentNullException>(() => ((IAsyncReactiveSubscriptionFactory<string, string, string, string, string, string, string, string, string, string, string>)factory).CreateAsync(subscriptionUri: null, "factory_parameter_1", "factory_parameter_2", "factory_parameter_3", "factory_parameter_4", "factory_parameter_5", "factory_parameter_6", "factory_parameter_7", "factory_parameter_8", "factory_parameter_9", "factory_parameter_10", "factory_parameter_11", state: null).Wait());
                     Assert.ThrowsException<ArgumentNullException>(() => ((IAsyncReactiveSubscriptionFactory<string, string, string, string, string, string, string, string, string, string, string>)factory).CreateAsync(subscriptionUri: null, "factory_parameter_1", "factory_parameter_2", "factory_parameter_3", "factory_parameter_4", "factory_parameter_5", "factory_parameter_6", "factory_parameter_7", "factory_parameter_8", "factory_parameter_9", "factory_parameter_10", "factory_parameter_11", state: null, CancellationToken.None).Wait());
 
-#if NET6_0 || NETCOREAPP3_1 // Suppresses CA2012
+#if NET6_0 // Suppresses CA2012
                     sub.DisposeAsync().AsTask().Wait();
 #else
                     sub.DisposeAsync().Wait();
@@ -8597,7 +8597,7 @@ namespace Tests.Reaqtor.Client
                     Assert.ThrowsException<ArgumentNullException>(() => ((IAsyncReactiveSubscriptionFactory<string, string, string, string, string, string, string, string, string, string, string, string>)factory).CreateAsync(subscriptionUri: null, "factory_parameter_1", "factory_parameter_2", "factory_parameter_3", "factory_parameter_4", "factory_parameter_5", "factory_parameter_6", "factory_parameter_7", "factory_parameter_8", "factory_parameter_9", "factory_parameter_10", "factory_parameter_11", "factory_parameter_12", state: null).Wait());
                     Assert.ThrowsException<ArgumentNullException>(() => ((IAsyncReactiveSubscriptionFactory<string, string, string, string, string, string, string, string, string, string, string, string>)factory).CreateAsync(subscriptionUri: null, "factory_parameter_1", "factory_parameter_2", "factory_parameter_3", "factory_parameter_4", "factory_parameter_5", "factory_parameter_6", "factory_parameter_7", "factory_parameter_8", "factory_parameter_9", "factory_parameter_10", "factory_parameter_11", "factory_parameter_12", state: null, CancellationToken.None).Wait());
 
-#if NET6_0 || NETCOREAPP3_1 // Suppresses CA2012
+#if NET6_0 // Suppresses CA2012
                     sub.DisposeAsync().AsTask().Wait();
 #else
                     sub.DisposeAsync().Wait();
@@ -8645,7 +8645,7 @@ namespace Tests.Reaqtor.Client
                     Assert.ThrowsException<ArgumentNullException>(() => ((IAsyncReactiveSubscriptionFactory<string, string, string, string, string, string, string, string, string, string, string, string, string>)factory).CreateAsync(subscriptionUri: null, "factory_parameter_1", "factory_parameter_2", "factory_parameter_3", "factory_parameter_4", "factory_parameter_5", "factory_parameter_6", "factory_parameter_7", "factory_parameter_8", "factory_parameter_9", "factory_parameter_10", "factory_parameter_11", "factory_parameter_12", "factory_parameter_13", state: null).Wait());
                     Assert.ThrowsException<ArgumentNullException>(() => ((IAsyncReactiveSubscriptionFactory<string, string, string, string, string, string, string, string, string, string, string, string, string>)factory).CreateAsync(subscriptionUri: null, "factory_parameter_1", "factory_parameter_2", "factory_parameter_3", "factory_parameter_4", "factory_parameter_5", "factory_parameter_6", "factory_parameter_7", "factory_parameter_8", "factory_parameter_9", "factory_parameter_10", "factory_parameter_11", "factory_parameter_12", "factory_parameter_13", state: null, CancellationToken.None).Wait());
 
-#if NET6_0 || NETCOREAPP3_1 // Suppresses CA2012
+#if NET6_0 // Suppresses CA2012
                     sub.DisposeAsync().AsTask().Wait();
 #else
                     sub.DisposeAsync().Wait();
@@ -8694,7 +8694,7 @@ namespace Tests.Reaqtor.Client
                     Assert.ThrowsException<ArgumentNullException>(() => ((IAsyncReactiveSubscriptionFactory<string, string, string, string, string, string, string, string, string, string, string, string, string, string>)factory).CreateAsync(subscriptionUri: null, "factory_parameter_1", "factory_parameter_2", "factory_parameter_3", "factory_parameter_4", "factory_parameter_5", "factory_parameter_6", "factory_parameter_7", "factory_parameter_8", "factory_parameter_9", "factory_parameter_10", "factory_parameter_11", "factory_parameter_12", "factory_parameter_13", "factory_parameter_14", state: null).Wait());
                     Assert.ThrowsException<ArgumentNullException>(() => ((IAsyncReactiveSubscriptionFactory<string, string, string, string, string, string, string, string, string, string, string, string, string, string>)factory).CreateAsync(subscriptionUri: null, "factory_parameter_1", "factory_parameter_2", "factory_parameter_3", "factory_parameter_4", "factory_parameter_5", "factory_parameter_6", "factory_parameter_7", "factory_parameter_8", "factory_parameter_9", "factory_parameter_10", "factory_parameter_11", "factory_parameter_12", "factory_parameter_13", "factory_parameter_14", state: null, CancellationToken.None).Wait());
 
-#if NET6_0 || NETCOREAPP3_1 // Suppresses CA2012
+#if NET6_0 // Suppresses CA2012
                     sub.DisposeAsync().AsTask().Wait();
 #else
                     sub.DisposeAsync().Wait();
@@ -8744,7 +8744,7 @@ namespace Tests.Reaqtor.Client
                     Assert.ThrowsException<ArgumentNullException>(() => ((IAsyncReactiveSubscriptionFactory<string, string, string, string, string, string, string, string, string, string, string, string, string, string, string>)factory).CreateAsync(subscriptionUri: null, "factory_parameter_1", "factory_parameter_2", "factory_parameter_3", "factory_parameter_4", "factory_parameter_5", "factory_parameter_6", "factory_parameter_7", "factory_parameter_8", "factory_parameter_9", "factory_parameter_10", "factory_parameter_11", "factory_parameter_12", "factory_parameter_13", "factory_parameter_14", "factory_parameter_15", state: null).Wait());
                     Assert.ThrowsException<ArgumentNullException>(() => ((IAsyncReactiveSubscriptionFactory<string, string, string, string, string, string, string, string, string, string, string, string, string, string, string>)factory).CreateAsync(subscriptionUri: null, "factory_parameter_1", "factory_parameter_2", "factory_parameter_3", "factory_parameter_4", "factory_parameter_5", "factory_parameter_6", "factory_parameter_7", "factory_parameter_8", "factory_parameter_9", "factory_parameter_10", "factory_parameter_11", "factory_parameter_12", "factory_parameter_13", "factory_parameter_14", "factory_parameter_15", state: null, CancellationToken.None).Wait());
 
-#if NET6_0 || NETCOREAPP3_1 // Suppresses CA2012
+#if NET6_0 // Suppresses CA2012
                     sub.DisposeAsync().AsTask().Wait();
 #else
                     sub.DisposeAsync().Wait();

--- a/Reaqtor/Core/Client/Tests.Reaqtor.Client/ReactiveClientContextHigherArityTests.tt
+++ b/Reaqtor/Core/Client/Tests.Reaqtor.Client/ReactiveClientContextHigherArityTests.tt
@@ -932,7 +932,7 @@ for (int i = 2; i<=highestSupportedArity; i++) {
                     Assert.ThrowsException<ArgumentNullException>(() => ((IAsyncReactiveSubscriptionFactory<<#=string.Join(", ", Enumerable.Repeat("string", i).ToArray())#>>)factory).CreateAsync(subscriptionUri: null, <#=args#>, state: null).Wait());
                     Assert.ThrowsException<ArgumentNullException>(() => ((IAsyncReactiveSubscriptionFactory<<#=string.Join(", ", Enumerable.Repeat("string", i).ToArray())#>>)factory).CreateAsync(subscriptionUri: null, <#=args#>, state: null, CancellationToken.None).Wait());
 
-#if NET6_0 || NETCOREAPP3_1 // Suppresses CA2012
+#if NET6_0 // Suppresses CA2012
                     sub.DisposeAsync().AsTask().Wait();
 #else
                     sub.DisposeAsync().Wait();

--- a/Reaqtor/Core/Client/Tests.Reaqtor.Client/ReactiveClientContextTests.cs
+++ b/Reaqtor/Core/Client/Tests.Reaqtor.Client/ReactiveClientContextTests.cs
@@ -75,7 +75,7 @@ namespace Tests.Reaqtor.Client
         [TestMethod]
         public void ReactiveClientContext_Qubscription_ArgumentChecking()
         {
-#if !NET6_0 && !NETCOREAPP3_1
+#if !NET6_0
             Assert.ThrowsException<ArgumentNullException>(() => ((IAsyncReactiveQubscription)null).DisposeAsync());
 #endif
             Assert.ThrowsException<ArgumentNullException>(() => ((IAsyncReactiveQubscription)null).AsDisposable());
@@ -886,7 +886,7 @@ namespace Tests.Reaqtor.Client
                     var s1 = ctx.GetSubscription(new Uri(Constants.Subscription.SUB2));
                     var s2 = ctx.GetSubscription(new Uri(Constants.Subscription.SUB3));
 
-#if NET6_0 || NETCOREAPP3_1 // Suppresses CA2012
+#if NET6_0 // Suppresses CA2012
                     s.DisposeAsync(CancellationToken.None).AsTask();
                     s1.DisposeAsync().AsTask();
 #else
@@ -923,7 +923,7 @@ namespace Tests.Reaqtor.Client
                     qubject.SubscribeAsync(ctx.GetObserver<int>(new Uri(Constants.Observer.OB)), new Uri(Constants.Subscription.SUB), null, CancellationToken.None);
 
                     ctx.GetStream<int, int>(new Uri(Constants.Stream.FOO)).DisposeAsync()
-#if NET6_0 || NETCOREAPP3_1
+#if NET6_0
                         .AsTask()
 #endif
                         .Wait();
@@ -995,7 +995,7 @@ namespace Tests.Reaqtor.Client
                     factory.CreateAsync(new Uri(Constants.Subscription.SUB1), null).Wait();
 
                     ctx.GetSubscription(new Uri(Constants.Subscription.SUB1)).DisposeAsync()
-#if NET6_0 || NETCOREAPP3_1
+#if NET6_0
                         .AsTask()
 #endif
                         .Wait();

--- a/Reaqtor/Core/Client/Tests.Reaqtor.Client/Tests.Reaqtor.Client.csproj
+++ b/Reaqtor/Core/Client/Tests.Reaqtor.Client/Tests.Reaqtor.Client.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net472;net6.0</TargetFrameworks>
+    <TargetFrameworks>net472;net6.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Reaqtor/Core/Engine/Tests.Reaqtor.QueryEngine/OneQueryEngineSanityTests.cs
+++ b/Reaqtor/Core/Engine/Tests.Reaqtor.QueryEngine/OneQueryEngineSanityTests.cs
@@ -103,7 +103,7 @@ namespace Tests.Reaqtor.QueryEngine
         [TestMethod]
         public async Task DefineUndefineObservableAsync()
         {
-#if NET6_0 || NETCOREAPP3_1 // NB: Only using ValueTask-based DisposeAsync in .NET Standard 2.1 and beyond at the moment.
+#if NET6_0 // NB: Only using ValueTask-based DisposeAsync in .NET Standard 2.1 and beyond at the moment.
             await
 #endif
             using var qe = CreateQueryEngine();
@@ -147,7 +147,7 @@ namespace Tests.Reaqtor.QueryEngine
         [TestMethod]
         public async Task DefineUndefineObserverAsync()
         {
-#if NET6_0 || NETCOREAPP3_1 // NB: Only using ValueTask-based DisposeAsync in .NET Standard 2.1 and beyond at the moment.
+#if NET6_0 // NB: Only using ValueTask-based DisposeAsync in .NET Standard 2.1 and beyond at the moment.
             await
 #endif
             using var qe = CreateQueryEngine();
@@ -191,7 +191,7 @@ namespace Tests.Reaqtor.QueryEngine
         [TestMethod]
         public async Task DefineUndefineStreamFactoryAsync()
         {
-#if NET6_0 || NETCOREAPP3_1 // NB: Only using ValueTask-based DisposeAsync in .NET Standard 2.1 and beyond at the moment.
+#if NET6_0 // NB: Only using ValueTask-based DisposeAsync in .NET Standard 2.1 and beyond at the moment.
             await
 #endif
             using var qe = CreateQueryEngine();
@@ -298,7 +298,7 @@ namespace Tests.Reaqtor.QueryEngine
         [TestMethod]
         public async Task SubscriptionLifecycleAsync()
         {
-#if NET6_0 || NETCOREAPP3_1 // NB: Only using ValueTask-based DisposeAsync in .NET Standard 2.1 and beyond at the moment.
+#if NET6_0 // NB: Only using ValueTask-based DisposeAsync in .NET Standard 2.1 and beyond at the moment.
             await
 #endif
             using var qe = CreateQueryEngine();
@@ -534,7 +534,7 @@ namespace Tests.Reaqtor.QueryEngine
             }
 
             sub.DisposeAsync(CancellationToken.None)
-#if NET6_0 || NETCOREAPP3_1
+#if NET6_0
                 .AsTask()
 #endif
                 .Wait();
@@ -1099,7 +1099,7 @@ namespace Tests.Reaqtor.QueryEngine
         {
             var kvs = new InMemoryKeyValueStore();
 
-#if NET6_0 || NETCOREAPP3_1 // NB: Only using ValueTask-based DisposeAsync in .NET Standard 2.1 and beyond at the moment.
+#if NET6_0 // NB: Only using ValueTask-based DisposeAsync in .NET Standard 2.1 and beyond at the moment.
             await
 #endif
             using (var qe1 = CreateQueryEngine(kvs))
@@ -1114,7 +1114,7 @@ namespace Tests.Reaqtor.QueryEngine
                 Crash();
             }
 
-#if NET6_0 || NETCOREAPP3_1 // NB: Only using ValueTask-based DisposeAsync in .NET Standard 2.1 and beyond at the moment.
+#if NET6_0 // NB: Only using ValueTask-based DisposeAsync in .NET Standard 2.1 and beyond at the moment.
             await
 #endif
             using (var qe2 = CreateQueryEngine(kvs))
@@ -1134,7 +1134,7 @@ namespace Tests.Reaqtor.QueryEngine
 
             InMemoryStateStore state;
 
-#if NET6_0 || NETCOREAPP3_1 // NB: Only using ValueTask-based DisposeAsync in .NET Standard 2.1 and beyond at the moment.
+#if NET6_0 // NB: Only using ValueTask-based DisposeAsync in .NET Standard 2.1 and beyond at the moment.
             await
 #endif
             using (var qe1 = CreateQueryEngine(kvs))
@@ -1153,7 +1153,7 @@ namespace Tests.Reaqtor.QueryEngine
                 Crash();
             }
 
-#if NET6_0 || NETCOREAPP3_1 // NB: Only using ValueTask-based DisposeAsync in .NET Standard 2.1 and beyond at the moment.
+#if NET6_0 // NB: Only using ValueTask-based DisposeAsync in .NET Standard 2.1 and beyond at the moment.
             await
 #endif
             using (var qe2 = CreateQueryEngine(kvs))
@@ -1171,7 +1171,7 @@ namespace Tests.Reaqtor.QueryEngine
         {
             var kvs = new InMemoryKeyValueStore();
 
-#if NET6_0 || NETCOREAPP3_1 // NB: Only using ValueTask-based DisposeAsync in .NET Standard 2.1 and beyond at the moment.
+#if NET6_0 // NB: Only using ValueTask-based DisposeAsync in .NET Standard 2.1 and beyond at the moment.
             await
 #endif
             using (var qe1 = CreateQueryEngine(kvs))
@@ -1186,7 +1186,7 @@ namespace Tests.Reaqtor.QueryEngine
                 Crash();
             }
 
-#if NET6_0 || NETCOREAPP3_1 // NB: Only using ValueTask-based DisposeAsync in .NET Standard 2.1 and beyond at the moment.
+#if NET6_0 // NB: Only using ValueTask-based DisposeAsync in .NET Standard 2.1 and beyond at the moment.
             await
 #endif
             using (var qe2 = CreateQueryEngine(kvs))
@@ -1200,7 +1200,7 @@ namespace Tests.Reaqtor.QueryEngine
                 Crash();
             }
 
-#if NET6_0 || NETCOREAPP3_1 // NB: Only using ValueTask-based DisposeAsync in .NET Standard 2.1 and beyond at the moment.
+#if NET6_0 // NB: Only using ValueTask-based DisposeAsync in .NET Standard 2.1 and beyond at the moment.
             await
 #endif
             using (var qe3 = CreateQueryEngine(kvs))
@@ -1211,7 +1211,7 @@ namespace Tests.Reaqtor.QueryEngine
 
                 await Assert.ThrowsExceptionAsync<EntityNotFoundException>(() =>
                     ctx3.GetSubscription(new Uri("test://sub1")).DisposeAsync(CancellationToken.None)
-#if NET6_0 || NETCOREAPP3_1
+#if NET6_0
                         .AsTask()
 #endif
                 );
@@ -1223,7 +1223,7 @@ namespace Tests.Reaqtor.QueryEngine
         {
             var kvs = new InMemoryKeyValueStore();
 
-#if NET6_0 || NETCOREAPP3_1 // NB: Only using ValueTask-based DisposeAsync in .NET Standard 2.1 and beyond at the moment.
+#if NET6_0 // NB: Only using ValueTask-based DisposeAsync in .NET Standard 2.1 and beyond at the moment.
             await
 #endif
             using (var qe1 = CreateQueryEngine(kvs))
@@ -1238,7 +1238,7 @@ namespace Tests.Reaqtor.QueryEngine
                 Crash();
             }
 
-#if NET6_0 || NETCOREAPP3_1 // NB: Only using ValueTask-based DisposeAsync in .NET Standard 2.1 and beyond at the moment.
+#if NET6_0 // NB: Only using ValueTask-based DisposeAsync in .NET Standard 2.1 and beyond at the moment.
             await
 #endif
             using (var qe2 = CreateQueryEngine(kvs))
@@ -1256,7 +1256,7 @@ namespace Tests.Reaqtor.QueryEngine
                 Crash();
             }
 
-#if NET6_0 || NETCOREAPP3_1 // NB: Only using ValueTask-based DisposeAsync in .NET Standard 2.1 and beyond at the moment.
+#if NET6_0 // NB: Only using ValueTask-based DisposeAsync in .NET Standard 2.1 and beyond at the moment.
             await
 #endif
             using (var qe3 = CreateQueryEngine(kvs))
@@ -1276,7 +1276,7 @@ namespace Tests.Reaqtor.QueryEngine
 
             InMemoryStateStore state;
 
-#if NET6_0 || NETCOREAPP3_1 // NB: Only using ValueTask-based DisposeAsync in .NET Standard 2.1 and beyond at the moment.
+#if NET6_0 // NB: Only using ValueTask-based DisposeAsync in .NET Standard 2.1 and beyond at the moment.
             await
 #endif
             using (var qe1 = CreateQueryEngine(kvs))
@@ -1293,7 +1293,7 @@ namespace Tests.Reaqtor.QueryEngine
                 Crash();
             }
 
-#if NET6_0 || NETCOREAPP3_1 // NB: Only using ValueTask-based DisposeAsync in .NET Standard 2.1 and beyond at the moment.
+#if NET6_0 // NB: Only using ValueTask-based DisposeAsync in .NET Standard 2.1 and beyond at the moment.
             await
 #endif
             using (var qe2 = CreateQueryEngine(kvs))
@@ -1311,7 +1311,7 @@ namespace Tests.Reaqtor.QueryEngine
                 Crash();
             }
 
-#if NET6_0 || NETCOREAPP3_1 // NB: Only using ValueTask-based DisposeAsync in .NET Standard 2.1 and beyond at the moment.
+#if NET6_0 // NB: Only using ValueTask-based DisposeAsync in .NET Standard 2.1 and beyond at the moment.
             await
 #endif
             using (var qe3 = CreateQueryEngine(kvs))
@@ -1337,7 +1337,7 @@ namespace Tests.Reaqtor.QueryEngine
             var deleteCreate_delete_id = new Uri("test://sub4");
             var deleteCreate_deleteCreate_id = new Uri("test://sub5");
 
-#if NET6_0 || NETCOREAPP3_1 // NB: Only using ValueTask-based DisposeAsync in .NET Standard 2.1 and beyond at the moment.
+#if NET6_0 // NB: Only using ValueTask-based DisposeAsync in .NET Standard 2.1 and beyond at the moment.
             await
 #endif
             using (var qe1 = CreateQueryEngine(kvs))
@@ -1381,7 +1381,7 @@ namespace Tests.Reaqtor.QueryEngine
                 Crash();
             }
 
-#if NET6_0 || NETCOREAPP3_1 // NB: Only using ValueTask-based DisposeAsync in .NET Standard 2.1 and beyond at the moment.
+#if NET6_0 // NB: Only using ValueTask-based DisposeAsync in .NET Standard 2.1 and beyond at the moment.
             await
 #endif
             using (var qe2 = CreateQueryEngine(kvs))
@@ -1411,7 +1411,7 @@ namespace Tests.Reaqtor.QueryEngine
                 Crash();
             }
 
-#if NET6_0 || NETCOREAPP3_1 // NB: Only using ValueTask-based DisposeAsync in .NET Standard 2.1 and beyond at the moment.
+#if NET6_0 // NB: Only using ValueTask-based DisposeAsync in .NET Standard 2.1 and beyond at the moment.
             await
 #endif
             using (var qe3 = CreateQueryEngine(kvs))
@@ -1434,7 +1434,7 @@ namespace Tests.Reaqtor.QueryEngine
                 // First create an engine persist a subscription creation in the state store
                 var kvs1 = new InMemoryKeyValueStore();
 
-#if NET6_0 || NETCOREAPP3_1 // NB: Only using ValueTask-based DisposeAsync in .NET Standard 2.1 and beyond at the moment.
+#if NET6_0 // NB: Only using ValueTask-based DisposeAsync in .NET Standard 2.1 and beyond at the moment.
                 await
 #endif
                 using (var qe1 = CreateQueryEngine(kvs1))
@@ -1455,7 +1455,7 @@ namespace Tests.Reaqtor.QueryEngine
 
                 var kvs2 = new InMemoryKeyValueStore();
 
-#if NET6_0 || NETCOREAPP3_1 // NB: Only using ValueTask-based DisposeAsync in .NET Standard 2.1 and beyond at the moment.
+#if NET6_0 // NB: Only using ValueTask-based DisposeAsync in .NET Standard 2.1 and beyond at the moment.
                 await
 #endif
                 using (var qe2 = CreateQueryEngine(kvs2))
@@ -1472,7 +1472,7 @@ namespace Tests.Reaqtor.QueryEngine
 
                 // Now create engine with first state store (the one that has sub) and second kvs (also has sub)
 
-#if NET6_0 || NETCOREAPP3_1 // NB: Only using ValueTask-based DisposeAsync in .NET Standard 2.1 and beyond at the moment.
+#if NET6_0 // NB: Only using ValueTask-based DisposeAsync in .NET Standard 2.1 and beyond at the moment.
                 await
 #endif
                 using (var qe3 = CreateQueryEngine(kvs2))
@@ -1488,7 +1488,7 @@ namespace Tests.Reaqtor.QueryEngine
 
                 // Do it again but handle the exception
 
-#if NET6_0 || NETCOREAPP3_1 // NB: Only using ValueTask-based DisposeAsync in .NET Standard 2.1 and beyond at the moment.
+#if NET6_0 // NB: Only using ValueTask-based DisposeAsync in .NET Standard 2.1 and beyond at the moment.
                 await
 #endif
                 using (var qe4 = CreateQueryEngine(kvs2))
@@ -1516,7 +1516,7 @@ namespace Tests.Reaqtor.QueryEngine
 
                 var kvs = new InMemoryKeyValueStore();
 
-#if NET6_0 || NETCOREAPP3_1 // NB: Only using ValueTask-based DisposeAsync in .NET Standard 2.1 and beyond at the moment.
+#if NET6_0 // NB: Only using ValueTask-based DisposeAsync in .NET Standard 2.1 and beyond at the moment.
                 await
 #endif
                 using (var qe1 = CreateQueryEngine(kvs))
@@ -1530,7 +1530,7 @@ namespace Tests.Reaqtor.QueryEngine
                     await o1.SubscribeAsync(v1, testId, null, CancellationToken.None);
                 }
 
-#if NET6_0 || NETCOREAPP3_1 // NB: Only using ValueTask-based DisposeAsync in .NET Standard 2.1 and beyond at the moment.
+#if NET6_0 // NB: Only using ValueTask-based DisposeAsync in .NET Standard 2.1 and beyond at the moment.
                 await
 #endif
                 using (var qe2 = CreateQueryEngine(kvs))
@@ -1545,7 +1545,7 @@ namespace Tests.Reaqtor.QueryEngine
 
                 // Unhandled
 
-#if NET6_0 || NETCOREAPP3_1 // NB: Only using ValueTask-based DisposeAsync in .NET Standard 2.1 and beyond at the moment.
+#if NET6_0 // NB: Only using ValueTask-based DisposeAsync in .NET Standard 2.1 and beyond at the moment.
                 await
 #endif
                 using (var qe3 = CreateQueryEngine(kvs))
@@ -1561,7 +1561,7 @@ namespace Tests.Reaqtor.QueryEngine
 
                 // Handled
 
-#if NET6_0 || NETCOREAPP3_1 // NB: Only using ValueTask-based DisposeAsync in .NET Standard 2.1 and beyond at the moment.
+#if NET6_0 // NB: Only using ValueTask-based DisposeAsync in .NET Standard 2.1 and beyond at the moment.
                 await
 #endif
                 using (var qe4 = CreateQueryEngine(kvs))
@@ -1593,7 +1593,7 @@ namespace Tests.Reaqtor.QueryEngine
 
             InMemoryStateStore state;
 
-#if NET6_0 || NETCOREAPP3_1 // NB: Only using ValueTask-based DisposeAsync in .NET Standard 2.1 and beyond at the moment.
+#if NET6_0 // NB: Only using ValueTask-based DisposeAsync in .NET Standard 2.1 and beyond at the moment.
             await
 #endif
             using (var qe1 = CreateQueryEngine(kvs))
@@ -1615,7 +1615,7 @@ namespace Tests.Reaqtor.QueryEngine
                 Crash();
             }
 
-#if NET6_0 || NETCOREAPP3_1 // NB: Only using ValueTask-based DisposeAsync in .NET Standard 2.1 and beyond at the moment.
+#if NET6_0 // NB: Only using ValueTask-based DisposeAsync in .NET Standard 2.1 and beyond at the moment.
             await
 #endif
             using (var qe2 = CreateQueryEngine(kvs))
@@ -1633,7 +1633,7 @@ namespace Tests.Reaqtor.QueryEngine
         {
             var kvs = new InMemoryKeyValueStore();
 
-#if NET6_0 || NETCOREAPP3_1 // NB: Only using ValueTask-based DisposeAsync in .NET Standard 2.1 and beyond at the moment.
+#if NET6_0 // NB: Only using ValueTask-based DisposeAsync in .NET Standard 2.1 and beyond at the moment.
             await
 #endif
             using (var qe = CreateQueryEngine(kvs))
@@ -1652,7 +1652,7 @@ namespace Tests.Reaqtor.QueryEngine
                 kvs.StartingOperation += fail;
                 await AssertEx.ThrowsExceptionAsync<MyException>(() =>
                     test.DisposeAsync(CancellationToken.None)
-#if NET6_0 || NETCOREAPP3_1
+#if NET6_0
                         .AsTask()
 #endif
                     ,
@@ -2233,13 +2233,13 @@ namespace Tests.Reaqtor.QueryEngine
             Assert.IsTrue(actx.Streams.TryGetValue(streamUri, out p));
 
             sub.DisposeAsync(CancellationToken.None)
-#if NET6_0 || NETCOREAPP3_1
+#if NET6_0
                 .AsTask()
 #endif
                 .Wait();
 
             actx.GetStream<string, string>(streamUri).DisposeAsync(CancellationToken.None)
-#if NET6_0 || NETCOREAPP3_1
+#if NET6_0
                 .AsTask()
 #endif
                 .Wait();
@@ -2485,7 +2485,7 @@ namespace Tests.Reaqtor.QueryEngine
         {
             var kvs = new InMemoryKeyValueStore();
 
-#if NET6_0 || NETCOREAPP3_1 // NB: Only using ValueTask-based DisposeAsync in .NET Standard 2.1 and beyond at the moment.
+#if NET6_0 // NB: Only using ValueTask-based DisposeAsync in .NET Standard 2.1 and beyond at the moment.
             await
 #endif
             using var qe = CreateQueryEngine(kvs);

--- a/Reaqtor/Core/Engine/Tests.Reaqtor.QueryEngine/OperationTrackerTests.cs
+++ b/Reaqtor/Core/Engine/Tests.Reaqtor.QueryEngine/OperationTrackerTests.cs
@@ -38,7 +38,7 @@ namespace Tests.Reaqtor.QueryEngine
             //
 
             var d = o.DisposeAsync()
-#if NET6_0 || NETCOREAPP3_1
+#if NET6_0
                 .AsTask()
 #endif
                 ;
@@ -87,7 +87,7 @@ namespace Tests.Reaqtor.QueryEngine
             //
 
             var d1 = o.DisposeAsync()
-#if NET6_0 || NETCOREAPP3_1
+#if NET6_0
                 .AsTask()
 #endif
                 ;
@@ -105,7 +105,7 @@ namespace Tests.Reaqtor.QueryEngine
             //
 
             var d2 = o.DisposeAsync()
-#if NET6_0 || NETCOREAPP3_1
+#if NET6_0
                 .AsTask()
 #endif
                 ;
@@ -151,7 +151,7 @@ namespace Tests.Reaqtor.QueryEngine
             //
 
             o.DisposeAsync()
-#if NET6_0 || NETCOREAPP3_1
+#if NET6_0
                 .AsTask()
 #endif
                 .Wait();
@@ -212,7 +212,7 @@ namespace Tests.Reaqtor.QueryEngine
             //
 
             t.DisposeAsync()
-#if NET6_0 || NETCOREAPP3_1
+#if NET6_0
                 .AsTask()
 #endif
                 .Wait();

--- a/Reaqtor/Core/Engine/Tests.Reaqtor.QueryEngine/Tests.Reaqtor.QueryEngine.csproj
+++ b/Reaqtor/Core/Engine/Tests.Reaqtor.QueryEngine/Tests.Reaqtor.QueryEngine.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net472;net6.0</TargetFrameworks>
+    <TargetFrameworks>net472;net6.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Reaqtor/Core/Expressions/Tests.Reaqtor.Expressions.Core/Tests.Reaqtor.Expressions.Core.csproj
+++ b/Reaqtor/Core/Expressions/Tests.Reaqtor.Expressions.Core/Tests.Reaqtor.Expressions.Core.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net472;net6.0</TargetFrameworks>
+    <TargetFrameworks>net472;net6.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Reaqtor/Core/Hosting/Tests.Reaqtor.Hosting.Service/Tests.Reaqtor.Hosting.Service.csproj
+++ b/Reaqtor/Core/Hosting/Tests.Reaqtor.Hosting.Service/Tests.Reaqtor.Hosting.Service.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net472;net6.0</TargetFrameworks>
+    <TargetFrameworks>net472;net6.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Reaqtor/Core/Hosting/Tests.Reaqtor.Hosting.Shared/Serialization/ReactiveResourceConverterTests.cs
+++ b/Reaqtor/Core/Hosting/Tests.Reaqtor.Hosting.Shared/Serialization/ReactiveResourceConverterTests.cs
@@ -298,7 +298,7 @@ namespace Tests.Microsoft.Hosting.Shared.Serialization
 
             public DateTimeOffset CreationTime => DateTimeOffset.Now;
 
-#if NET6_0 || NETCOREAPP3_1
+#if NET6_0
             public ValueTask DisposeAsync() => throw new NotImplementedException();
 #else
             public Task DisposeAsync(System.Threading.CancellationToken token) => throw new NotImplementedException();

--- a/Reaqtor/Core/Hosting/Tests.Reaqtor.Hosting.Shared/Tests.Reaqtor.Hosting.Shared.csproj
+++ b/Reaqtor/Core/Hosting/Tests.Reaqtor.Hosting.Shared/Tests.Reaqtor.Hosting.Shared.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net472;net6.0</TargetFrameworks>
+    <TargetFrameworks>net472;net6.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Reaqtor/Core/Local/Tests.Reaqtor.Local.Core/Async/AsyncReactiveSubjectBaseTests.cs
+++ b/Reaqtor/Core/Local/Tests.Reaqtor.Local.Core/Async/AsyncReactiveSubjectBaseTests.cs
@@ -114,7 +114,7 @@ namespace Tests
             var disposed = false;
             s.DisposeImpl = async (ct) => { disposed = true; await Task.Yield(); };
 
-#if NET6_0 || NETCOREAPP3_1
+#if NET6_0
             s.DisposeAsync().AsTask().Wait();
 #else
             s.DisposeAsync().Wait();

--- a/Reaqtor/Core/Local/Tests.Reaqtor.Local.Core/Async/AsyncReactiveSubscriptionBaseTests.cs
+++ b/Reaqtor/Core/Local/Tests.Reaqtor.Local.Core/Async/AsyncReactiveSubscriptionBaseTests.cs
@@ -23,7 +23,7 @@ namespace Tests
             var disposed = false;
             s.DisposeAsyncImpl = (token) => { disposed = true; return Task.CompletedTask; };
 
-#if !NET6_0 && !NETCOREAPP3_1
+#if !NET6_0
             s.DisposeAsync().Wait();
 #else
             s.DisposeAsync().AsTask().Wait();

--- a/Reaqtor/Core/Local/Tests.Reaqtor.Local.Core/Tests.Reaqtor.Local.Core.csproj
+++ b/Reaqtor/Core/Local/Tests.Reaqtor.Local.Core/Tests.Reaqtor.Local.Core.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net472;net6.0</TargetFrameworks>
+    <TargetFrameworks>net472;net6.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Reaqtor/Core/Reactive/Tests.Reaqtor.Reactive.HigherOrder/Tests.Reaqtor.Reactive.HigherOrder.csproj
+++ b/Reaqtor/Core/Reactive/Tests.Reaqtor.Reactive.HigherOrder/Tests.Reaqtor.Reactive.HigherOrder.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net472;net6.0</TargetFrameworks>
+    <TargetFrameworks>net472;net6.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Reaqtor/Core/Reactive/Tests.Reaqtor.Reactive.Linq.Hosted/Tests.Reaqtor.Reactive.Linq.Hosted.csproj
+++ b/Reaqtor/Core/Reactive/Tests.Reaqtor.Reactive.Linq.Hosted/Tests.Reaqtor.Reactive.Linq.Hosted.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net472;net6.0</TargetFrameworks>
+    <TargetFrameworks>net472;net6.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Reaqtor/Core/Reliable/Tests.Reaqtor.Reliable/Tests.Reaqtor.Reliable.csproj
+++ b/Reaqtor/Core/Reliable/Tests.Reaqtor.Reliable/Tests.Reaqtor.Reliable.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net472;net6.0</TargetFrameworks>
+    <TargetFrameworks>net472;net6.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Reaqtor/Core/Service/Tests.Reaqtor.Service.Core/Tests.Reaqtor.Service.Core.csproj
+++ b/Reaqtor/Core/Service/Tests.Reaqtor.Service.Core/Tests.Reaqtor.Service.Core.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net472;net6.0</TargetFrameworks>
+    <TargetFrameworks>net472;net6.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Reaqtor/Core/Service/Tests.Reaqtor.Service/Tests.Reaqtor.Service.csproj
+++ b/Reaqtor/Core/Service/Tests.Reaqtor.Service/Tests.Reaqtor.Service.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net472;net6.0</TargetFrameworks>
+    <TargetFrameworks>net472;net6.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Reaqtor/Core/Shared/Tests.Reaqtor.Shared.Core/Tests.Reaqtor.Shared.Core.csproj
+++ b/Reaqtor/Core/Shared/Tests.Reaqtor.Shared.Core/Tests.Reaqtor.Shared.Core.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net472;net6.0</TargetFrameworks>
+    <TargetFrameworks>net472;net6.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Reaqtor/Samples/Shebang/Reaqtor.Shebang.App/Reaqtor.Shebang.App.csproj
+++ b/Reaqtor/Samples/Shebang/Reaqtor.Shebang.App/Reaqtor.Shebang.App.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>netcoreapp3.1;net6.0</TargetFrameworks>
+    <TargetFrameworks>net6.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -94,7 +94,14 @@ stages:
         version: 7.x
         performMultiLevelLookup: true
 
-    - script: dotnet format --verify-no-changes All.sln
+    - task: DotNetCoreCLI@2
+      displayName: Restore
+      inputs:
+        command: custom
+        custom: restore
+        arguments: $(solutionDir) --configfile $(Build.SourcesDirectory)/src/NuGet.config /property:Configuration=$(buildConfiguration) 
+     
+    - script: dotnet format --no-restore --verify-no-changes  --verbosity diagnostic All.sln
       displayName: Run dotnet-format
 
   - job: Build_and_Pack

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -99,7 +99,7 @@ stages:
       inputs:
         command: custom
         custom: restore
-        arguments: $(solutionDir) --configfile $(Build.SourcesDirectory)/src/NuGet.config /property:Configuration=$(buildConfiguration) 
+        arguments: -c Release All.sln
      
     - script: dotnet format --no-restore --verify-no-changes  --verbosity diagnostic All.sln
       displayName: Run dotnet-format

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -82,26 +82,29 @@ stages:
       displayName: Publish Build Logs
       condition: always()
 
-  - job: Reaqtor_Dotnet_Format
-    displayName: Run dotnet-format checks
-    pool:
-      vmImage: windows-latest
+  # See https://github.com/reaqtive/reaqtor/issues/138
+  # The current implementation of IDE0001 runs extremely slowly, causing builds to fail,
+  # and we've been unable to find any workaround, so we have to disable this step for now.
+  # - job: Reaqtor_Dotnet_Format
+  #   displayName: Run dotnet-format checks
+  #   pool:
+  #     vmImage: windows-latest
 
-    steps:
-    - task: UseDotNet@2
-      displayName: Use .NET Core 7.x SDK
-      inputs:
-        version: 7.x
-        performMultiLevelLookup: true
+  #   steps:
+  #   - task: UseDotNet@2
+  #     displayName: Use .NET Core 7.x SDK
+  #     inputs:
+  #       version: 7.x
+  #       performMultiLevelLookup: true
 
-    - task: DotNetCoreCLI@2
-      displayName: Restore
-      inputs:
-        command: restore
-        projects: All.sln
+  #   - task: DotNetCoreCLI@2
+  #     displayName: Restore
+  #     inputs:
+  #       command: restore
+  #       projects: All.sln
      
-    - script: dotnet format --no-restore --verify-no-changes  --verbosity diagnostic All.sln
-      displayName: Run dotnet-format
+  #   - script: dotnet format --no-restore --verify-no-changes  --verbosity diagnostic All.sln
+  #     displayName: Run dotnet-format
 
   - job: Build_and_Pack
     pool:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -94,14 +94,7 @@ stages:
         version: 7.x
         performMultiLevelLookup: true
 
-    - task: DotNetCoreCLI@2
-      inputs:
-        command: custom
-        custom: tool
-        arguments: install -g dotnet-format
-      displayName: Install dotnet-format tool
-
-    - script: dotnet-format --check All.sln
+    - script: dotnet-format --verify-no-changes All.sln
       displayName: Run dotnet-format
 
   - job: Build_and_Pack

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -94,7 +94,7 @@ stages:
         version: 7.x
         performMultiLevelLookup: true
 
-    - script: dotnet-format --verify-no-changes All.sln
+    - script: dotnet format --verify-no-changes All.sln
       displayName: Run dotnet-format
 
   - job: Build_and_Pack

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -84,6 +84,7 @@ stages:
 
   - job: Reaqtor_Dotnet_Format
     displayName: Run dotnet-format checks
+    condition: eq(1,2) # disable this job
     pool:
       vmImage: windows-latest
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -97,9 +97,8 @@ stages:
     - task: DotNetCoreCLI@2
       displayName: Restore
       inputs:
-        command: custom
-        custom: restore
-        arguments: -c Release All.sln
+        command: restore
+        projects: All.sln
      
     - script: dotnet format --no-restore --verify-no-changes  --verbosity diagnostic All.sln
       displayName: Run dotnet-format

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -82,29 +82,30 @@ stages:
       displayName: Publish Build Logs
       condition: always()
 
-  # See https://github.com/reaqtive/reaqtor/issues/138
-  # The current implementation of IDE0001 runs extremely slowly, causing builds to fail,
-  # and we've been unable to find any workaround, so we have to disable this step for now.
-  # - job: Reaqtor_Dotnet_Format
-  #   displayName: Run dotnet-format checks
-  #   pool:
-  #     vmImage: windows-latest
+  - job: Reaqtor_Dotnet_Format
+    displayName: Run dotnet-format checks
+    pool:
+      vmImage: windows-latest
 
-  #   steps:
-  #   - task: UseDotNet@2
-  #     displayName: Use .NET Core 7.x SDK
-  #     inputs:
-  #       version: 7.x
-  #       performMultiLevelLookup: true
+    steps:
+    - task: UseDotNet@2
+      displayName: Use .NET Core 7.x SDK
+      inputs:
+        version: 7.x
+        performMultiLevelLookup: true
 
-  #   - task: DotNetCoreCLI@2
-  #     displayName: Restore
-  #     inputs:
-  #       command: restore
-  #       projects: All.sln
+    - task: DotNetCoreCLI@2
+      displayName: Restore
+      inputs:
+        command: restore
+        projects: All.sln
      
-  #   - script: dotnet format --no-restore --verify-no-changes  --verbosity diagnostic All.sln
-  #     displayName: Run dotnet-format
+    # See https://github.com/reaqtive/reaqtor/issues/138
+    # The current implementation of IDE0001 runs extremely slowly, causing builds to fail,
+    # and we've been unable to find any workaround, so we have to disable this for
+    # certain projects now.
+    - script: dotnet format --no-restore --verify-no-changes --exclude Nuqleon\Core\LINQ\Nuqleon.Linq.Expressions.Optimizers --verbosity diagnostic All.sln
+      displayName: Run dotnet-format
 
   - job: Build_and_Pack
     pool:


### PR DESCRIPTION
.NET Core 3.1 has been out of support for a while now, and its continued presence is starting to cause spurious diagnostic messages, so we're removing it.

We've also had to disable the `dotnet format` part of the build because the analyzers in the current SDK choke on one of the projects, causing analysis to take so long that the build times out. (Analysis does eventually complete given several hours, but we don't let the builds run that long, nor do we want to.) See #138 