### PR TITLE
Temporarily squelch warnings that appear on .NET 8.0 SDK

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -5,6 +5,11 @@
     <EnableNETAnalyzers>true</EnableNETAnalyzers>
     <CodeAnalysisTreatWarningsAsErrors>true</CodeAnalysisTreatWarningsAsErrors>
     <AnalysisLevel>7.0</AnalysisLevel>
+    <!--
+    Apparently setting AnalysisLevel isn't quite enough to avoid the new warnings we get in .NET SDK 8.0.
+    This NoWarn line should be removed when we do https://github.com/reaqtive/reaqtor/issues/143 -->
+    <NoWarn>$(NoWarn);IDE0079;IDE0090;CA1305;CA1822;CA1854</NoWarn>
+    
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
 
     <PublishRepositoryUrl>true</PublishRepositoryUrl>

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -30,9 +30,9 @@ stages:
 
     steps:
     - task: UseDotNet@2
-      displayName: Use .NET Core 7.x SDK
+      displayName: Use .NET Core 8.x SDK
       inputs:
-        version: 7.x
+        version: 8.x
         performMultiLevelLookup: true
 
     - powershell: |
@@ -89,9 +89,9 @@ stages:
 
     steps:
     - task: UseDotNet@2
-      displayName: Use .NET Core 7.x SDK
+      displayName: Use .NET Core 8.x SDK
       inputs:
-        version: 7.x
+        version: 8.x
         performMultiLevelLookup: true
 
     - task: DotNetCoreCLI@2
@@ -113,9 +113,9 @@ stages:
 
     steps:
     - task: UseDotNet@2
-      displayName: Use .NET Core 7.x SDK
+      displayName: Use .NET Core 8.x SDK
       inputs:
-        version: 7.x
+        version: 8.x
         performMultiLevelLookup: true
 
     - powershell: |


### PR DESCRIPTION
This will be fixed properly in #143