### PR TITLE
Modernize info-severity analyzers after the .NET 10 / MSTest 4 migration

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -147,10 +147,14 @@ dotnet_diagnostic.CA1805.severity = none
 # CA1508: 'expr' is always 'bool'. Remove or refactor the condition(s) to avoid dead code. Many false positives due to bugs in the analyzer.
 dotnet_diagnostic.CA1508.severity = none
 
-# CA1859: Use concrete types when possible for improved performance. ~150 sites, each a judgment
+# CA1859: Use concrete types when possible for improved performance. ~220 sites, each a judgment
 # call about internal API shape (returning List<T> vs IEnumerable<T> etc.); deferred from the #143
-# analyzer-debt wave as churn without measured benefit - kept visible in the IDE as a suggestion.
-dotnet_diagnostic.CA1859.severity = suggestion
+# analyzer-debt wave as churn without measured benefit. Applying it wholesale would trade deliberate
+# interface-based abstraction for micro-optimizations no benchmark has shown to matter here, and even
+# as a suggestion it stays persistent IDE/scan noise that reviewers must re-triage every pass - so it
+# is excluded (severity none, like CA1805/CA1508 above). Re-enable per hot path if a measurement ever
+# justifies acting on a specific site.
+dotnet_diagnostic.CA1859.severity = none
 
 # IDE warnings (with suppression of some nuisances)
 dotnet_analyzer_diagnostic.category-Style.severity = warning

--- a/.editorconfig
+++ b/.editorconfig
@@ -156,6 +156,16 @@ dotnet_diagnostic.CA1508.severity = none
 # justifies acting on a specific site.
 dotnet_diagnostic.CA1859.severity = none
 
+# MSTEST0049: Flow TestContext cancellation token. ~596 sites, ~2/3 of them in T4-generated arity tests.
+# The shipped code fixer re-resolves overloads (it rewrote CheckpointAsync(sw) -> CheckpointAsync(sw,
+# token) - a *different* overload - silently changing traced behaviour and breaking two QueryEngine
+# tests), and a manual fix needs TestContext plumbing the base fixtures lack plus token-threading through
+# static helpers. The cancellation payoff on these fast, mostly-blocking test calls does not justify that
+# churn/risk, so the rule is excluded (severity none, like the CA rules above) pending a safe adoption.
+# Full analysis, the overload-switching hazard, and the adoption options are tracked in GitHub issue #164
+# (https://github.com/reaqtive/reaqtor/issues/164).
+dotnet_diagnostic.MSTEST0049.severity = none
+
 # IDE warnings (with suppression of some nuisances)
 dotnet_analyzer_diagnostic.category-Style.severity = warning
 dotnet_diagnostic.IDE0001.severity = none # `Name can be simplified.` often reduces clarity.

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -164,6 +164,19 @@
   </PropertyGroup>
 
   <!--
+    MSTest analyzers at their package default (MSTestAnalysisMode=Default) leave rules such as
+    MSTEST0001 at 'suggestion', which TreatWarningsAsErrors cannot promote. Several of those rules
+    also report at compilation level with no source span, so `dotnet format` cannot see them either
+    (that is how 40 MSTEST0001 diagnostics accumulated unnoticed, visible only in the IDE).
+    'Recommended' raises them to warning, and TreatWarningsAsErrors then makes them build errors, so
+    the tier cannot rot again. Verified: 0 warnings solution-wide at this mode. Do NOT use 'All' -
+    it reports 610 (MSTEST0004 x608, MSTEST0026 x2), a separate triage.
+  -->
+  <PropertyGroup Condition="'$(IsTestProject)' == 'true'">
+    <MSTestAnalysisMode>Recommended</MSTestAnalysisMode>
+  </PropertyGroup>
+
+  <!--
     CA1861 (prefer 'static readonly' fields over constant array arguments) targets hot-path performance;
     in unit test projects the constant arrays are one-shot test data, so the rule is noise there. It is
     excluded for test projects but stays active for shipping code, where hoisting is worth acting on.

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -73,6 +73,64 @@
     </AssemblyAttribute>
   </ItemGroup>
 
+  <!--
+    Every test assembly states its parallelization policy explicitly (MSTEST0001). Synthesized here
+    (WriteCodeFragment) rather than 40 hand-written [assembly:] lines, mirroring CLSCompliant above.
+
+    The default is DoNotParallelize because it encodes what MSTest already does today (its no-attribute
+    default is serial), so this is a zero-behaviour-change declaration rather than an aspiration.
+
+    Enabling parallelism would not pay here. Microsoft.Testing.Platform already runs test modules
+    concurrently (see global.json "test.runner", and the max-parallel-test-modules option on
+    `dotnet test`), so [Parallelize] would only add *intra*-assembly concurrency. That shrinks a run's
+    critical path but never its total CPU work, and on the 2-vCPU CI agents a solution's wall clock is
+    bounded below by (sum of module times / cores) - a floor [Parallelize] cannot cross. Worse, the
+    assemblies slow enough to be worth parallelizing are precisely those that cannot be, at all:
+
+      * Tests.Reaqtor.QueryEngine  - PhysicalTimeEngineTest holds a *static* PhysicalScheduler whose
+                                     ClassSetup() begins by disposing it (ClassCleanup()); six classes
+                                     drive it from [ClassInitialize]. TestableEntityFactory adds static
+                                     unsynchronized dictionaries and a static Scheduler nulled per test.
+      * Tests.Reaqtive.Scheduler   - installs a process-wide AppDomain.UnhandledException handler,
+                                     asserts on Environment.ProcessorCount, and creates a
+                                     PhysicalScheduler (ProcessorCount foreground threads) per test.
+      * Tests.Nuqleon.Memory       - asserts weak-reference reachability around GC.Collect(). The GC is
+                                     process-global; locking cannot make this safe.
+
+    Measured 2026-07-08 (all 40 modules, both configs, CI filter, no coverage). Per CI area solution,
+    with T = sum of module times and C = 2 agent cores, the most [Parallelize] could ever save is
+    max(0, slowest_module - T/C):
+
+      area      config    T        slowest module                     ceiling
+      Nuqleon   Release   129.9s   Tests.Nuqleon.Memory       50.6s   0.0s  (throughput-bound)
+      Nuqleon   Debug      69.1s   DataModel.Serialization.Binary 20.6s 0.0s  (throughput-bound)
+      Reaqtor   Debug      40.2s   Tests.Reaqtor.QueryEngine  31.5s  11.0s  (pole is unsafe)
+      Reaqtive  Debug      11.6s   Tests.Reaqtive.Scheduler    7.6s   2.0s  (pole is unsafe)
+
+    Nuqleon cannot benefit at any worker count; Reaqtor/Reaqtive could only benefit by parallelizing
+    the very assemblies listed above. Total repo test execution is ~169s against a 120-minute job
+    budget, so test-level parallelism is not the lever - the build and coverage instrumentation are.
+    Several assemblies are also already internally parallel (DataModel.Serialization.Binary uses ~12
+    cores unaided), so MSTest workers on a 2-vCPU agent would only oversubscribe.
+
+    A project opts in with <TestParallelization>Parallelize</TestParallelization>. The two ItemGroups
+    below are mutually exclusive on that property, so an assembly can never receive both attributes.
+    NB: MSTEST0059 (the "not both" rule) does NOT guard this - it reports at the attribute's location,
+    which lands in generated code and is therefore suppressed. Directory.Build.targets validates the
+    property value instead, since a typo would otherwise emit neither attribute in silence.
+  -->
+  <PropertyGroup Condition="'$(IsTestProject)' == 'true'">
+    <TestParallelization Condition="'$(TestParallelization)' == ''">DoNotParallelize</TestParallelization>
+  </PropertyGroup>
+
+  <ItemGroup Condition="'$(IsTestProject)' == 'true' And '$(TestParallelization)' == 'DoNotParallelize'">
+    <AssemblyAttribute Include="Microsoft.VisualStudio.TestTools.UnitTesting.DoNotParallelizeAttribute" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(IsTestProject)' == 'true' And '$(TestParallelization)' == 'Parallelize'">
+    <AssemblyAttribute Include="Microsoft.VisualStudio.TestTools.UnitTesting.ParallelizeAttribute" />
+  </ItemGroup>
+
   <PropertyGroup Condition="'$(IsTestProject)' == 'true' Or '$(IsPerfProject)' == 'true' Or '$(IsPlaygroundProject)' == 'true'">
     <AnalysisMode>Default</AnalysisMode>
     <IsPackable>false</IsPackable>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -105,6 +105,15 @@
     <OutputType>Exe</OutputType>
   </PropertyGroup>
 
+  <!--
+    CA1861 (prefer 'static readonly' fields over constant array arguments) targets hot-path performance;
+    in unit test projects the constant arrays are one-shot test data, so the rule is noise there. It is
+    excluded for test projects but stays active for shipping code, where hoisting is worth acting on.
+  -->
+  <PropertyGroup Condition="'$(IsTestProject)' == 'true'">
+    <NoWarn>$(NoWarn);CA1861</NoWarn>
+  </PropertyGroup>
+
   <ItemGroup Condition="'$(IsTestProject)' == 'true'">
     <!--
       NB: These belong here rather than in a ProjectReference'd .csproj. Cross-referencing test

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -6,4 +6,15 @@
   <PropertyGroup Condition="'$(GenerateDocumentationFile)' == 'false'">
     <NoWarn>$(NoWarn);IDE0005</NoWarn>
   </PropertyGroup>
+
+  <!--
+    A mistyped TestParallelization matches neither ItemGroup in Directory.Build.props, so the assembly
+    would silently get no parallelization attribute at all. MSTEST0001 is only a suggestion, so nothing
+    would go red. Fail loudly instead.
+  -->
+  <Target Name="ValidateTestParallelization" BeforeTargets="CoreGenerateAssemblyInfo"
+          Condition="'$(IsTestProject)' == 'true'">
+    <Error Condition="'$(TestParallelization)' != 'DoNotParallelize' And '$(TestParallelization)' != 'Parallelize'"
+           Text="TestParallelization must be 'DoNotParallelize' or 'Parallelize' (was '$(TestParallelization)')." />
+  </Target>
 </Project>

--- a/Nuqleon/Core/BCL/Tests.Nuqleon.Collections.Specialized/System/Collections/Specialized/BitArrayTests.cs
+++ b/Nuqleon/Core/BCL/Tests.Nuqleon.Collections.Specialized/System/Collections/Specialized/BitArrayTests.cs
@@ -135,14 +135,14 @@ public class BitArrayTests
 
                 for (var j = 0; j < capacity; j++)
                 {
-                    Assert.AreEqual(true, arr[j]);
+                    Assert.IsTrue(arr[j]);
                 }
 
                 arr.SetAll(false);
 
                 for (var j = 0; j < capacity; j++)
                 {
-                    Assert.AreEqual(false, arr[j]);
+                    Assert.IsFalse(arr[j]);
                 }
 
                 // The difference from above is that we set all to false first then set to true
@@ -151,14 +151,14 @@ public class BitArrayTests
 
                 for (var j = 0; j < capacity; j++)
                 {
-                    Assert.AreEqual(false, arr[j]);
+                    Assert.IsFalse(arr[j]);
                 }
 
                 arr.SetAll(true);
 
                 for (var j = 0; j < capacity; j++)
                 {
-                    Assert.AreEqual(true, arr[j]);
+                    Assert.IsTrue(arr[j]);
                 }
             }
         }

--- a/Nuqleon/Core/BCL/Tests.Nuqleon.Collections.Specialized/System/Collections/Specialized/EnumDictionaryFactoryTests.cs
+++ b/Nuqleon/Core/BCL/Tests.Nuqleon.Collections.Specialized/System/Collections/Specialized/EnumDictionaryFactoryTests.cs
@@ -18,45 +18,13 @@ public partial class EnumDictionaryFactoryTests
     [TestMethod]
     public void EnumDictionaryFactory_Parameter_Validation()
     {
-        try
-        {
-            EnumDictionary.Create<int, bool>();
-            Assert.Fail();
-        }
-        catch (ArgumentException e)
-        {
-            Assert.AreEqual("TKey", e.ParamName);
-        }
+        Assert.AreEqual("TKey", Assert.ThrowsExactly<ArgumentException>(() => EnumDictionary.Create<int, bool>()).ParamName);
 
-        try
-        {
-            EnumDictionary.Create<Foo, bool>();
-            Assert.Fail();
-        }
-        catch (ArgumentException e)
-        {
-            Assert.AreEqual("TKey", e.ParamName);
-        }
+        Assert.AreEqual("TKey", Assert.ThrowsExactly<ArgumentException>(() => EnumDictionary.Create<Foo, bool>()).ParamName);
 
-        try
-        {
-            EnumDictionary.Create<Bar, bool>();
-            Assert.Fail();
-        }
-        catch (ArgumentException e)
-        {
-            Assert.AreEqual("TKey", e.ParamName);
-        }
+        Assert.AreEqual("TKey", Assert.ThrowsExactly<ArgumentException>(() => EnumDictionary.Create<Bar, bool>()).ParamName);
 
-        try
-        {
-            EnumDictionary.Create<Baz, bool>();
-            Assert.Fail();
-        }
-        catch (ArgumentException e)
-        {
-            Assert.AreEqual("TKey", e.ParamName);
-        }
+        Assert.AreEqual("TKey", Assert.ThrowsExactly<ArgumentException>(() => EnumDictionary.Create<Baz, bool>()).ParamName);
     }
 
     private enum Foo : long

--- a/Nuqleon/Core/BCL/Tests.Nuqleon.Collections.Specialized/System/Collections/Specialized/EnumDictionaryTests.cs
+++ b/Nuqleon/Core/BCL/Tests.Nuqleon.Collections.Specialized/System/Collections/Specialized/EnumDictionaryTests.cs
@@ -173,7 +173,7 @@ public class EnumDictionaryTests
         {
             var key = (ExpressionType)rand.Next(values.Length);
 
-            if (systemDictionary.ContainsKey(key))
+            if (!systemDictionary.TryAdd(key, true))
             {
                 if (rand.Next(2) == 0)
                 {
@@ -188,7 +188,6 @@ public class EnumDictionaryTests
             }
             else
             {
-                systemDictionary.Add(key, true);
                 enumDictionary.Add(key, true);
             }
 

--- a/Nuqleon/Core/BCL/Tests.Nuqleon.Collections.Specialized/System/Collections/Specialized/EnumDictionaryTests.cs
+++ b/Nuqleon/Core/BCL/Tests.Nuqleon.Collections.Specialized/System/Collections/Specialized/EnumDictionaryTests.cs
@@ -335,11 +335,11 @@ public class EnumDictionaryTests
 
         enumDictionary.Clear();
 
-        Assert.AreEqual(0, enumDictionary.Count);
-        Assert.AreEqual(false, enumDictionary.Keys.Any());
-        Assert.AreEqual(false, enumDictionary.Values.Any());
-        Assert.AreEqual(false, enumDictionary.Any());
-        Assert.AreEqual(false, enumDictionary.Keys.Any());
+        Assert.IsEmpty(enumDictionary);
+        Assert.IsFalse(enumDictionary.Keys.Any());
+        Assert.IsFalse(enumDictionary.Values.Any());
+        Assert.IsFalse(enumDictionary.Any());
+        Assert.IsFalse(enumDictionary.Keys.Any());
     }
 
     [TestMethod]
@@ -380,7 +380,7 @@ public class EnumDictionaryTests
             foreach (var kvp in enumDictionary)
             {
                 count++;
-                Assert.IsTrue(systemDictionary.Contains(kvp));
+                Assert.Contains(kvp, systemDictionary);
             }
 
             Assert.AreEqual(systemDictionary.Count, count);
@@ -390,7 +390,7 @@ public class EnumDictionaryTests
             {
                 count++;
                 Assert.IsTrue(kvp is KeyValuePair<ExpressionType, bool>);
-                Assert.IsTrue(systemDictionary.Contains((KeyValuePair<ExpressionType, bool>)kvp));
+                Assert.Contains((KeyValuePair<ExpressionType, bool>)kvp, systemDictionary);
             }
 
             Assert.AreEqual(systemDictionary.Count, count);
@@ -567,8 +567,8 @@ public class EnumDictionaryTests
             foreach (var kvp in systemDictionary)
             {
                 count++;
-                Assert.IsTrue(enumDictionary.Contains(kvp));
-                Assert.IsFalse(enumDictionary.Contains(new KeyValuePair<ExpressionType, bool>(kvp.Key, !kvp.Value)));
+                Assert.Contains(kvp, enumDictionary);
+                Assert.DoesNotContain(new KeyValuePair<ExpressionType, bool>(kvp.Key, !kvp.Value), enumDictionary);
             }
 
             foreach (var value in values.Where(val => !systemDictionary.ContainsKey(val)))

--- a/Nuqleon/Core/BCL/Tests.Nuqleon.Collections.Specialized/System/Collections/Specialized/EnumDictionaryTests.cs
+++ b/Nuqleon/Core/BCL/Tests.Nuqleon.Collections.Specialized/System/Collections/Specialized/EnumDictionaryTests.cs
@@ -43,165 +43,37 @@ public class EnumDictionaryTests
         var enumDictionary = EnumDictionary.Create<ExpressionType, bool>();
         var values = Enum.GetValues(typeof(ExpressionType)).Cast<ExpressionType>().ToArray();
 
-        try
-        {
-            enumDictionary.Add((ExpressionType)(-1), true);
-            Assert.Fail();
-        }
-        catch (ArgumentOutOfRangeException e)
-        {
-            Assert.AreEqual("key", e.ParamName);
-        }
+        Assert.AreEqual("key", Assert.ThrowsExactly<ArgumentOutOfRangeException>(() => enumDictionary.Add((ExpressionType)(-1), true)).ParamName);
 
-        try
-        {
-            enumDictionary.Add((ExpressionType)(values.Length), true);
-            Assert.Fail();
-        }
-        catch (ArgumentOutOfRangeException e)
-        {
-            Assert.AreEqual("key", e.ParamName);
-        }
+        Assert.AreEqual("key", Assert.ThrowsExactly<ArgumentOutOfRangeException>(() => enumDictionary.Add((ExpressionType)(values.Length), true)).ParamName);
 
-        try
-        {
-            enumDictionary[(ExpressionType)(-1)] = true;
-            Assert.Fail();
-        }
-        catch (ArgumentOutOfRangeException e)
-        {
-            Assert.AreEqual("key", e.ParamName);
-        }
+        Assert.AreEqual("key", Assert.ThrowsExactly<ArgumentOutOfRangeException>(() => enumDictionary[(ExpressionType)(-1)] = true).ParamName);
 
-        try
-        {
-            enumDictionary[(ExpressionType)(values.Length)] = true;
-            Assert.Fail();
-        }
-        catch (ArgumentOutOfRangeException e)
-        {
-            Assert.AreEqual("key", e.ParamName);
-        }
+        Assert.AreEqual("key", Assert.ThrowsExactly<ArgumentOutOfRangeException>(() => enumDictionary[(ExpressionType)(values.Length)] = true).ParamName);
 
-        try
-        {
-            var dummy = enumDictionary[(ExpressionType)(-1)];
-            Assert.Fail();
-        }
-        catch (ArgumentOutOfRangeException e)
-        {
-            Assert.AreEqual("key", e.ParamName);
-        }
+        Assert.AreEqual("key", Assert.ThrowsExactly<ArgumentOutOfRangeException>(() => _ = enumDictionary[(ExpressionType)(-1)]).ParamName);
 
-        try
-        {
-            var dummy = enumDictionary[(ExpressionType)(values.Length)];
-            Assert.Fail();
-        }
-        catch (ArgumentOutOfRangeException e)
-        {
-            Assert.AreEqual("key", e.ParamName);
-        }
+        Assert.AreEqual("key", Assert.ThrowsExactly<ArgumentOutOfRangeException>(() => _ = enumDictionary[(ExpressionType)(values.Length)]).ParamName);
 
-        try
-        {
-            enumDictionary.ContainsKey((ExpressionType)(-1));
-            Assert.Fail();
-        }
-        catch (ArgumentOutOfRangeException e)
-        {
-            Assert.AreEqual("key", e.ParamName);
-        }
+        Assert.AreEqual("key", Assert.ThrowsExactly<ArgumentOutOfRangeException>(() => enumDictionary.ContainsKey((ExpressionType)(-1))).ParamName);
 
-        try
-        {
-            enumDictionary.ContainsKey((ExpressionType)(values.Length));
-            Assert.Fail();
-        }
-        catch (ArgumentOutOfRangeException e)
-        {
-            Assert.AreEqual("key", e.ParamName);
-        }
+        Assert.AreEqual("key", Assert.ThrowsExactly<ArgumentOutOfRangeException>(() => enumDictionary.ContainsKey((ExpressionType)(values.Length))).ParamName);
 
-        try
-        {
-            enumDictionary.Contains(new KeyValuePair<ExpressionType, bool>((ExpressionType)(-1), true));
-            Assert.Fail();
-        }
-        catch (ArgumentOutOfRangeException e)
-        {
-            Assert.AreEqual("item", e.ParamName);
-        }
+        Assert.AreEqual("item", Assert.ThrowsExactly<ArgumentOutOfRangeException>(() => enumDictionary.Contains(new KeyValuePair<ExpressionType, bool>((ExpressionType)(-1), true))).ParamName);
 
-        try
-        {
-            enumDictionary.Contains(new KeyValuePair<ExpressionType, bool>((ExpressionType)(values.Length), true));
-            Assert.Fail();
-        }
-        catch (ArgumentOutOfRangeException e)
-        {
-            Assert.AreEqual("item", e.ParamName);
-        }
+        Assert.AreEqual("item", Assert.ThrowsExactly<ArgumentOutOfRangeException>(() => enumDictionary.Contains(new KeyValuePair<ExpressionType, bool>((ExpressionType)(values.Length), true))).ParamName);
 
-        try
-        {
-            enumDictionary.Remove((ExpressionType)(-1));
-            Assert.Fail();
-        }
-        catch (ArgumentOutOfRangeException e)
-        {
-            Assert.AreEqual("key", e.ParamName);
-        }
+        Assert.AreEqual("key", Assert.ThrowsExactly<ArgumentOutOfRangeException>(() => enumDictionary.Remove((ExpressionType)(-1))).ParamName);
 
-        try
-        {
-            enumDictionary.Remove((ExpressionType)(values.Length));
-            Assert.Fail();
-        }
-        catch (ArgumentOutOfRangeException e)
-        {
-            Assert.AreEqual("key", e.ParamName);
-        }
+        Assert.AreEqual("key", Assert.ThrowsExactly<ArgumentOutOfRangeException>(() => enumDictionary.Remove((ExpressionType)(values.Length))).ParamName);
 
-        try
-        {
-            enumDictionary.Remove(new KeyValuePair<ExpressionType, bool>((ExpressionType)(-1), true));
-            Assert.Fail();
-        }
-        catch (ArgumentOutOfRangeException e)
-        {
-            Assert.AreEqual("item", e.ParamName);
-        }
+        Assert.AreEqual("item", Assert.ThrowsExactly<ArgumentOutOfRangeException>(() => enumDictionary.Remove(new KeyValuePair<ExpressionType, bool>((ExpressionType)(-1), true))).ParamName);
 
-        try
-        {
-            enumDictionary.Remove(new KeyValuePair<ExpressionType, bool>((ExpressionType)(values.Length), true));
-            Assert.Fail();
-        }
-        catch (ArgumentOutOfRangeException e)
-        {
-            Assert.AreEqual("item", e.ParamName);
-        }
+        Assert.AreEqual("item", Assert.ThrowsExactly<ArgumentOutOfRangeException>(() => enumDictionary.Remove(new KeyValuePair<ExpressionType, bool>((ExpressionType)(values.Length), true))).ParamName);
 
-        try
-        {
-            enumDictionary.CopyTo(array: null, -1);
-            Assert.Fail();
-        }
-        catch (ArgumentNullException e)
-        {
-            Assert.AreEqual("array", e.ParamName);
-        }
+        Assert.AreEqual("array", Assert.ThrowsExactly<ArgumentNullException>(() => enumDictionary.CopyTo(array: null, -1)).ParamName);
 
-        try
-        {
-            enumDictionary.CopyTo(new KeyValuePair<ExpressionType, bool>[1], -1);
-            Assert.Fail();
-        }
-        catch (ArgumentOutOfRangeException e)
-        {
-            Assert.AreEqual("index", e.ParamName);
-        }
+        Assert.AreEqual("index", Assert.ThrowsExactly<ArgumentOutOfRangeException>(() => enumDictionary.CopyTo(new KeyValuePair<ExpressionType, bool>[1], -1)).ParamName);
 
         enumDictionary = EnumDictionary.Create<ExpressionType, bool>();
 
@@ -210,30 +82,14 @@ public class EnumDictionaryTests
         // System.Collections.Generic.Dictionary<TKey, TValue>
         enumDictionary.CopyTo(new KeyValuePair<ExpressionType, bool>[1], 1);
 
-        try
-        {
-            enumDictionary.CopyTo(new KeyValuePair<ExpressionType, bool>[1], 3);
-            Assert.Fail();
-        }
-        catch (ArgumentOutOfRangeException e)
-        {
-            Assert.AreEqual("index", e.ParamName);
-        }
+        Assert.AreEqual("index", Assert.ThrowsExactly<ArgumentOutOfRangeException>(() => enumDictionary.CopyTo(new KeyValuePair<ExpressionType, bool>[1], 3)).ParamName);
 
         ExpressionType val0 = 0;
         ExpressionType val1 = (ExpressionType)1;
 
         enumDictionary.Add(val0, true);
         enumDictionary.Add(val1, true);
-        try
-        {
-            enumDictionary.CopyTo(new KeyValuePair<ExpressionType, bool>[1], 0);
-            Assert.Fail();
-        }
-        catch (ArgumentException e)
-        {
-            Assert.AreEqual(typeof(ArgumentException), e.GetType());
-        }
+        Assert.ThrowsExactly<ArgumentException>(() => enumDictionary.CopyTo(new KeyValuePair<ExpressionType, bool>[1], 0));
     }
 
     [TestMethod]
@@ -257,55 +113,15 @@ public class EnumDictionaryTests
     [TestMethod]
     public void EnumDictionary_Parameter_Validation()
     {
-        try
-        {
-            _ = new EnumDictionary<int, bool, BitArraySlim<ByteArray1>>(default);
-            Assert.Fail();
-        }
-        catch (ArgumentException e)
-        {
-            Assert.AreEqual("TKey", e.ParamName);
-        }
+        Assert.AreEqual("TKey", Assert.ThrowsExactly<ArgumentException>(() => _ = new EnumDictionary<int, bool, BitArraySlim<ByteArray1>>(default)).ParamName);
 
-        try
-        {
-            _ = new EnumDictionary<Foo, bool, BitArraySlim<ByteArray1>>(default);
-            Assert.Fail();
-        }
-        catch (ArgumentException e)
-        {
-            Assert.AreEqual("TKey", e.ParamName);
-        }
+        Assert.AreEqual("TKey", Assert.ThrowsExactly<ArgumentException>(() => _ = new EnumDictionary<Foo, bool, BitArraySlim<ByteArray1>>(default)).ParamName);
 
-        try
-        {
-            _ = new EnumDictionary<Bar, bool, BitArraySlim<ByteArray1>>(default);
-            Assert.Fail();
-        }
-        catch (ArgumentException e)
-        {
-            Assert.AreEqual("TKey", e.ParamName);
-        }
+        Assert.AreEqual("TKey", Assert.ThrowsExactly<ArgumentException>(() => _ = new EnumDictionary<Bar, bool, BitArraySlim<ByteArray1>>(default)).ParamName);
 
-        try
-        {
-            _ = new EnumDictionary<Baz, bool, BitArraySlim<ByteArray1>>(default);
-            Assert.Fail();
-        }
-        catch (ArgumentException e)
-        {
-            Assert.AreEqual("TKey", e.ParamName);
-        }
+        Assert.AreEqual("TKey", Assert.ThrowsExactly<ArgumentException>(() => _ = new EnumDictionary<Baz, bool, BitArraySlim<ByteArray1>>(default)).ParamName);
 
-        try
-        {
-            _ = new EnumDictionary<ExpressionType, bool, BitArraySlim<ByteArray1>>(default);
-            Assert.Fail();
-        }
-        catch (ArgumentException e)
-        {
-            Assert.AreEqual("bitArray", e.ParamName);
-        }
+        Assert.AreEqual("bitArray", Assert.ThrowsExactly<ArgumentException>(() => _ = new EnumDictionary<ExpressionType, bool, BitArraySlim<ByteArray1>>(default)).ParamName);
     }
 
     private enum Foo : long
@@ -403,15 +219,7 @@ public class EnumDictionaryTests
         var enumDictionary = EnumDictionary.Create<ExpressionType, bool>();
         enumDictionary.Add(ExpressionType.Add, true);
 
-        try
-        {
-            enumDictionary.Add(ExpressionType.Add, true);
-            Assert.Fail();
-        }
-        catch (ArgumentException e)
-        {
-            Assert.AreEqual(typeof(ArgumentException), e.GetType());
-        }
+        Assert.ThrowsExactly<ArgumentException>(() => enumDictionary.Add(ExpressionType.Add, true));
     }
 
     [TestMethod]

--- a/Nuqleon/Core/BCL/Tests.Nuqleon.Collections.Specialized/System/Collections/Specialized/EnumDictionaryTests.cs
+++ b/Nuqleon/Core/BCL/Tests.Nuqleon.Collections.Specialized/System/Collections/Specialized/EnumDictionaryTests.cs
@@ -152,10 +152,10 @@ public class EnumDictionaryTests
         enumDictionary.Clear();
 
         Assert.IsEmpty(enumDictionary);
-        Assert.IsFalse(enumDictionary.Keys.Any());
-        Assert.IsFalse(enumDictionary.Values.Any());
-        Assert.IsFalse(enumDictionary.Any());
-        Assert.IsFalse(enumDictionary.Keys.Any());
+        Assert.IsEmpty(enumDictionary.Keys);
+        Assert.IsEmpty(enumDictionary.Values);
+        Assert.IsEmpty(enumDictionary);
+        Assert.IsEmpty(enumDictionary.Keys);
     }
 
     [TestMethod]
@@ -381,8 +381,8 @@ public class EnumDictionaryTests
 
             foreach (var value in values.Where(val => !systemDictionary.ContainsKey(val)))
             {
-                Assert.IsFalse(enumDictionary.Contains(new KeyValuePair<ExpressionType, bool>(value, true)));
-                Assert.IsFalse(enumDictionary.Contains(new KeyValuePair<ExpressionType, bool>(value, false)));
+                Assert.DoesNotContain(new KeyValuePair<ExpressionType, bool>(value, true), enumDictionary);
+                Assert.DoesNotContain(new KeyValuePair<ExpressionType, bool>(value, false), enumDictionary);
             }
 
             Assert.AreEqual(systemDictionary.Count, count);
@@ -510,8 +510,8 @@ public class EnumDictionaryTests
         Assert.IsTrue(EnumByteDictionary.Remove(EnumByte.Z));
         EnumByteDictionary.Add(new KeyValuePair<EnumByte, bool>(EnumByte.A, true));
         EnumByteDictionary.Add(new KeyValuePair<EnumByte, bool>(EnumByte.Z, true));
-        Assert.IsTrue(EnumByteDictionary.Contains(new KeyValuePair<EnumByte, bool>(EnumByte.A, true)));
-        Assert.IsTrue(EnumByteDictionary.Contains(new KeyValuePair<EnumByte, bool>(EnumByte.Z, true)));
+        Assert.Contains(new KeyValuePair<EnumByte, bool>(EnumByte.A, true), EnumByteDictionary);
+        Assert.Contains(new KeyValuePair<EnumByte, bool>(EnumByte.Z, true), EnumByteDictionary);
         Assert.IsTrue(EnumByteDictionary.Remove(new KeyValuePair<EnumByte, bool>(EnumByte.A, true)));
         Assert.IsTrue(EnumByteDictionary.Remove(new KeyValuePair<EnumByte, bool>(EnumByte.Z, true)));
 
@@ -526,8 +526,8 @@ public class EnumDictionaryTests
         Assert.IsTrue(EnumShortDictionary.Remove(EnumShort.Z));
         EnumShortDictionary.Add(new KeyValuePair<EnumShort, bool>(EnumShort.A, true));
         EnumShortDictionary.Add(new KeyValuePair<EnumShort, bool>(EnumShort.Z, true));
-        Assert.IsTrue(EnumShortDictionary.Contains(new KeyValuePair<EnumShort, bool>(EnumShort.A, true)));
-        Assert.IsTrue(EnumShortDictionary.Contains(new KeyValuePair<EnumShort, bool>(EnumShort.Z, true)));
+        Assert.Contains(new KeyValuePair<EnumShort, bool>(EnumShort.A, true), EnumShortDictionary);
+        Assert.Contains(new KeyValuePair<EnumShort, bool>(EnumShort.Z, true), EnumShortDictionary);
         Assert.IsTrue(EnumShortDictionary.Remove(new KeyValuePair<EnumShort, bool>(EnumShort.A, true)));
         Assert.IsTrue(EnumShortDictionary.Remove(new KeyValuePair<EnumShort, bool>(EnumShort.Z, true)));
 
@@ -542,8 +542,8 @@ public class EnumDictionaryTests
         Assert.IsTrue(EnumUShortDictionary.Remove(EnumUShort.Z));
         EnumUShortDictionary.Add(new KeyValuePair<EnumUShort, bool>(EnumUShort.A, true));
         EnumUShortDictionary.Add(new KeyValuePair<EnumUShort, bool>(EnumUShort.Z, true));
-        Assert.IsTrue(EnumUShortDictionary.Contains(new KeyValuePair<EnumUShort, bool>(EnumUShort.A, true)));
-        Assert.IsTrue(EnumUShortDictionary.Contains(new KeyValuePair<EnumUShort, bool>(EnumUShort.Z, true)));
+        Assert.Contains(new KeyValuePair<EnumUShort, bool>(EnumUShort.A, true), EnumUShortDictionary);
+        Assert.Contains(new KeyValuePair<EnumUShort, bool>(EnumUShort.Z, true), EnumUShortDictionary);
         Assert.IsTrue(EnumUShortDictionary.Remove(new KeyValuePair<EnumUShort, bool>(EnumUShort.A, true)));
         Assert.IsTrue(EnumUShortDictionary.Remove(new KeyValuePair<EnumUShort, bool>(EnumUShort.Z, true)));
 
@@ -558,8 +558,8 @@ public class EnumDictionaryTests
         Assert.IsTrue(EnumSByteDictionary.Remove(EnumSByte.Z));
         EnumSByteDictionary.Add(new KeyValuePair<EnumSByte, bool>(EnumSByte.A, true));
         EnumSByteDictionary.Add(new KeyValuePair<EnumSByte, bool>(EnumSByte.Z, true));
-        Assert.IsTrue(EnumSByteDictionary.Contains(new KeyValuePair<EnumSByte, bool>(EnumSByte.A, true)));
-        Assert.IsTrue(EnumSByteDictionary.Contains(new KeyValuePair<EnumSByte, bool>(EnumSByte.Z, true)));
+        Assert.Contains(new KeyValuePair<EnumSByte, bool>(EnumSByte.A, true), EnumSByteDictionary);
+        Assert.Contains(new KeyValuePair<EnumSByte, bool>(EnumSByte.Z, true), EnumSByteDictionary);
         Assert.IsTrue(EnumSByteDictionary.Remove(new KeyValuePair<EnumSByte, bool>(EnumSByte.A, true)));
         Assert.IsTrue(EnumSByteDictionary.Remove(new KeyValuePair<EnumSByte, bool>(EnumSByte.Z, true)));
     }
@@ -677,7 +677,7 @@ public class EnumDictionaryTests
 
     private static void DictionaryAssertAreEqual<TKey, TValue>(IDictionary<TKey, TValue> expected, IDictionary<TKey, TValue> actual)
     {
-        Assert.AreEqual(expected.Count, actual.Count);
+        Assert.HasCount(expected.Count, actual);
 
         var expectedElements = expected.OrderBy(kvp => kvp.Key);
         var actualElements = actual.OrderBy(kvp => kvp.Key);

--- a/Nuqleon/Core/BCL/Tests.Nuqleon.Memory/System/Collections/Generic/PooledDictionaryTests.cs
+++ b/Nuqleon/Core/BCL/Tests.Nuqleon.Memory/System/Collections/Generic/PooledDictionaryTests.cs
@@ -159,7 +159,7 @@ public class PooledDictionaryTests : TestBase
 
             var map = obj.Dictionary;
 
-            Assert.AreEqual(0, map.Count);
+            Assert.IsEmpty(map);
 
             map.Add("qux", 42);
             map.Add("foo", 43);
@@ -177,7 +177,7 @@ public class PooledDictionaryTests : TestBase
 
             var map = obj.Dictionary;
 
-            Assert.AreEqual(0, map.Count);
+            Assert.IsEmpty(map);
 
             map.Add("qux", 42);
             map.Add("foo", 43);
@@ -193,7 +193,7 @@ public class PooledDictionaryTests : TestBase
         {
             var map = PooledDictionary<string, int>.GetInstance();
 
-            Assert.AreEqual(0, map.Count);
+            Assert.IsEmpty(map);
 
             map.Add("qux", 42);
             map.Add("foo", 43);

--- a/Nuqleon/Core/BCL/Tests.Nuqleon.Memory/System/Collections/Generic/PooledHashSetTests.cs
+++ b/Nuqleon/Core/BCL/Tests.Nuqleon.Memory/System/Collections/Generic/PooledHashSetTests.cs
@@ -141,7 +141,7 @@ public class PooledHashSetTests : TestBase
 
             var set = obj.HashSet;
 
-            Assert.AreEqual(0, set.Count);
+            Assert.IsEmpty(set);
 
             set.Add("qux");
             set.Add("foo");
@@ -161,7 +161,7 @@ public class PooledHashSetTests : TestBase
 
             var set = obj.HashSet;
 
-            Assert.AreEqual(0, set.Count);
+            Assert.IsEmpty(set);
 
             set.Add("qux");
             set.Add("foo");
@@ -179,7 +179,7 @@ public class PooledHashSetTests : TestBase
         {
             var set = PooledHashSet<string>.GetInstance();
 
-            Assert.AreEqual(0, set.Count);
+            Assert.IsEmpty(set);
 
             set.Add("qux");
             set.Add("foo");

--- a/Nuqleon/Core/BCL/Tests.Nuqleon.Memory/System/Collections/Generic/PooledListTests.cs
+++ b/Nuqleon/Core/BCL/Tests.Nuqleon.Memory/System/Collections/Generic/PooledListTests.cs
@@ -141,7 +141,7 @@ public class PooledListTests : TestBase
 
             var lst = obj.List;
 
-            Assert.AreEqual(0, lst.Count);
+            Assert.IsEmpty(lst);
 
             lst.Add("qux");
             lst.Add("foo");
@@ -161,7 +161,7 @@ public class PooledListTests : TestBase
 
             var lst = obj.List;
 
-            Assert.AreEqual(0, lst.Count);
+            Assert.IsEmpty(lst);
 
             lst.Add("qux");
             lst.Add("foo");
@@ -179,7 +179,7 @@ public class PooledListTests : TestBase
         {
             var lst = PooledList<string>.GetInstance();
 
-            Assert.AreEqual(0, lst.Count);
+            Assert.IsEmpty(lst);
 
             lst.Add("qux");
             lst.Add("foo");
@@ -199,7 +199,7 @@ public class PooledListTests : TestBase
         {
             var lst = PooledList<string>.GetInstance();
 
-            Assert.AreEqual(0, lst.Count);
+            Assert.IsEmpty(lst);
 
             lst.Add("qux");
             lst.Add("foo");
@@ -222,7 +222,7 @@ public class PooledListTests : TestBase
         {
             var lst = PooledList<string>.GetInstance();
 
-            Assert.AreEqual(0, lst.Count);
+            Assert.IsEmpty(lst);
 
             lst.Add("qux");
             lst.Add("foo");
@@ -243,7 +243,7 @@ public class PooledListTests : TestBase
         {
             var lst = PooledList<string>.GetInstance();
 
-            Assert.AreEqual(0, lst.Count);
+            Assert.IsEmpty(lst);
 
             lst.Add("qux");
             lst.Add("foo");
@@ -254,7 +254,7 @@ public class PooledListTests : TestBase
 
             Assert.IsTrue(exp.SequenceEqual(res));
 
-            Assert.AreEqual(0, lst.Count); // Relies on implementation detail of timing of Free
+            Assert.IsEmpty(lst); // Relies on implementation detail of timing of Free
         }
     }
 

--- a/Nuqleon/Core/BCL/Tests.Nuqleon.Memory/System/Collections/Generic/PooledQueueTests.cs
+++ b/Nuqleon/Core/BCL/Tests.Nuqleon.Memory/System/Collections/Generic/PooledQueueTests.cs
@@ -141,7 +141,7 @@ public class PooledQueueTests : TestBase
 
             var queue = obj.Queue;
 
-            Assert.AreEqual(0, queue.Count);
+            Assert.IsEmpty(queue);
 
             queue.Enqueue("qux");
             queue.Enqueue("foo");
@@ -161,7 +161,7 @@ public class PooledQueueTests : TestBase
 
             var queue = obj.Queue;
 
-            Assert.AreEqual(0, queue.Count);
+            Assert.IsEmpty(queue);
 
             queue.Enqueue("qux");
             queue.Enqueue("foo");
@@ -179,7 +179,7 @@ public class PooledQueueTests : TestBase
         {
             var queue = PooledQueue<string>.GetInstance();
 
-            Assert.AreEqual(0, queue.Count);
+            Assert.IsEmpty(queue);
 
             queue.Enqueue("qux");
             queue.Enqueue("foo");

--- a/Nuqleon/Core/BCL/Tests.Nuqleon.Memory/System/Collections/Generic/PooledStackTests.cs
+++ b/Nuqleon/Core/BCL/Tests.Nuqleon.Memory/System/Collections/Generic/PooledStackTests.cs
@@ -141,7 +141,7 @@ public class PooledStackTests : TestBase
 
             var stack = obj.Stack;
 
-            Assert.AreEqual(0, stack.Count);
+            Assert.IsEmpty(stack);
 
             stack.Push("qux");
             stack.Push("foo");
@@ -161,7 +161,7 @@ public class PooledStackTests : TestBase
 
             var stack = obj.Stack;
 
-            Assert.AreEqual(0, stack.Count);
+            Assert.IsEmpty(stack);
 
             stack.Push("qux");
             stack.Push("foo");
@@ -179,7 +179,7 @@ public class PooledStackTests : TestBase
         {
             var stack = PooledStack<string>.GetInstance();
 
-            Assert.AreEqual(0, stack.Count);
+            Assert.IsEmpty(stack);
 
             stack.Push("qux");
             stack.Push("foo");

--- a/Nuqleon/Core/BCL/Tests.Nuqleon.Memory/System/Memory/CacheDictionaryTests.cs
+++ b/Nuqleon/Core/BCL/Tests.Nuqleon.Memory/System/Memory/CacheDictionaryTests.cs
@@ -26,37 +26,37 @@ public class CacheDictionaryTests
 
         Assert.AreEqual(42, cd.GetOrAdd(21, x => x * 2));
         Assert.AreEqual(1, cd.Count);
-        Assert.AreEqual(1, values.Count());
-        Assert.IsTrue(values.Contains(42));
+        Assert.HasCount(1, values);
+        Assert.Contains(42, values);
 
         Assert.AreEqual(42, cd.GetOrAdd(21, x => x * 2));
         Assert.AreEqual(1, cd.Count);
-        Assert.AreEqual(1, values.Count());
-        Assert.IsTrue(values.Contains(42));
+        Assert.HasCount(1, values);
+        Assert.Contains(42, values);
 
         Assert.AreEqual(44, cd.GetOrAdd(22, x => x * 2));
         Assert.AreEqual(2, cd.Count);
-        Assert.AreEqual(2, values.Count());
+        Assert.HasCount(2, values);
         Assert.IsTrue(values.Contains(42) && values.Contains(44));
 
         Assert.IsTrue(cd.Remove(21));
         Assert.AreEqual(1, cd.Count);
-        Assert.AreEqual(1, values.Count());
-        Assert.IsTrue(values.Contains(44));
+        Assert.HasCount(1, values);
+        Assert.Contains(44, values);
 
         Assert.IsFalse(cd.Remove(21));
         Assert.AreEqual(1, cd.Count);
-        Assert.AreEqual(1, values.Count());
-        Assert.IsTrue(values.Contains(44));
+        Assert.HasCount(1, values);
+        Assert.Contains(44, values);
 
         Assert.IsFalse(cd.Remove(-1));
         Assert.AreEqual(1, cd.Count);
-        Assert.AreEqual(1, values.Count());
-        Assert.IsTrue(values.Contains(44));
+        Assert.HasCount(1, values);
+        Assert.Contains(44, values);
 
         cd.Clear();
         Assert.AreEqual(0, cd.Count);
-        Assert.AreEqual(0, values.Count());
+        Assert.IsEmpty(values);
     }
 
     [TestMethod]
@@ -69,21 +69,21 @@ public class CacheDictionaryTests
 
         Assert.AreEqual(4, cd.GetOrAdd(key: null, x => (x ?? "null").Length));
         Assert.AreEqual(1, cd.Count);
-        Assert.AreEqual(1, values.Count());
-        Assert.IsTrue(values.Contains(4));
+        Assert.HasCount(1, values);
+        Assert.Contains(4, values);
 
         Assert.AreEqual(4, cd.GetOrAdd(key: null, x => (x ?? "null").Length));
         Assert.AreEqual(1, cd.Count);
-        Assert.AreEqual(1, values.Count());
-        Assert.IsTrue(values.Contains(4));
+        Assert.HasCount(1, values);
+        Assert.Contains(4, values);
 
         Assert.IsTrue(cd.Remove(key: null));
         Assert.AreEqual(0, cd.Count);
-        Assert.AreEqual(0, values.Count());
+        Assert.IsEmpty(values);
 
         cd.Clear();
         Assert.AreEqual(0, cd.Count);
-        Assert.AreEqual(0, values.Count());
+        Assert.IsEmpty(values);
     }
 
     [TestMethod]
@@ -96,10 +96,10 @@ public class CacheDictionaryTests
 
         var res = cd.ToArray();
 
-        Assert.AreEqual(2, res.Length);
+        Assert.HasCount(2, res);
 
-        Assert.IsTrue(res.Any(x => x.Key == null && x.Value == 0));
-        Assert.IsTrue(res.Any(x => x.Key == "foo" && x.Value == 3));
+        Assert.Contains(x => x.Key == null && x.Value == 0, res);
+        Assert.Contains(x => x.Key == "foo" && x.Value == 3, res);
 
         Assert.IsNotNull(((IEnumerable)cd).GetEnumerator());
     }

--- a/Nuqleon/Core/BCL/Tests.Nuqleon.Memory/System/Memory/CacheEntryTests.cs
+++ b/Nuqleon/Core/BCL/Tests.Nuqleon.Memory/System/Memory/CacheEntryTests.cs
@@ -114,7 +114,7 @@ public class CacheEntryTests
 
             var sb = new StringBuilder();
             entry.ToDebugView(sb, "");
-            Assert.IsTrue(sb.ToString().Contains("="));
+            Assert.Contains("=", sb.ToString());
         }
     }
 

--- a/Nuqleon/Core/BCL/Tests.Nuqleon.Memory/System/Memory/CacheEntryTests.cs
+++ b/Nuqleon/Core/BCL/Tests.Nuqleon.Memory/System/Memory/CacheEntryTests.cs
@@ -152,7 +152,7 @@ public class CacheEntryTests
 
         var sb = new StringBuilder();
         entry.ToDebugView(sb, "");
-        Assert.IsTrue(sb.ToString().Contains("=") && sb.ToString().Contains("DEGRADATION"));
+        Assert.IsTrue(sb.ToString().Contains('=') && sb.ToString().Contains("DEGRADATION"));
 
         entry.HitCount++;
         Assert.AreEqual(31415926535897931L / 2, entry.AverageAccessTime.Ticks);

--- a/Nuqleon/Core/BCL/Tests.Nuqleon.Memory/System/Memory/CacheEntryTests.cs
+++ b/Nuqleon/Core/BCL/Tests.Nuqleon.Memory/System/Memory/CacheEntryTests.cs
@@ -13,6 +13,11 @@ using System.Text;
 
 namespace Tests;
 
+// MSTEST0058 (no asserts in catch blocks) is a false positive for this file: these tests deliberately
+// throw and catch to obtain a real exception instance (with a stack trace) to use as test data; the
+// assertions run legitimately on the caught exception, not as exception-expectation checks.
+#pragma warning disable MSTEST0058
+
 [TestClass]
 public class CacheEntryTests
 {

--- a/Nuqleon/Core/BCL/Tests.Nuqleon.Memory/System/Memory/ConcurrentCacheDictionaryTests.cs
+++ b/Nuqleon/Core/BCL/Tests.Nuqleon.Memory/System/Memory/ConcurrentCacheDictionaryTests.cs
@@ -26,37 +26,37 @@ public class ConcurrentCacheDictionaryTests
 
         Assert.AreEqual(42, cd.GetOrAdd(21, x => x * 2));
         Assert.AreEqual(1, cd.Count);
-        Assert.AreEqual(1, values.Count());
-        Assert.IsTrue(values.Contains(42));
+        Assert.HasCount(1, values);
+        Assert.Contains(42, values);
 
         Assert.AreEqual(42, cd.GetOrAdd(21, x => x * 2));
         Assert.AreEqual(1, cd.Count);
-        Assert.AreEqual(1, values.Count());
-        Assert.IsTrue(values.Contains(42));
+        Assert.HasCount(1, values);
+        Assert.Contains(42, values);
 
         Assert.AreEqual(44, cd.GetOrAdd(22, x => x * 2));
         Assert.AreEqual(2, cd.Count);
-        Assert.AreEqual(2, values.Count());
+        Assert.HasCount(2, values);
         Assert.IsTrue(values.Contains(42) && values.Contains(44));
 
         Assert.IsTrue(cd.Remove(21));
         Assert.AreEqual(1, cd.Count);
-        Assert.AreEqual(1, values.Count());
-        Assert.IsTrue(values.Contains(44));
+        Assert.HasCount(1, values);
+        Assert.Contains(44, values);
 
         Assert.IsFalse(cd.Remove(21));
         Assert.AreEqual(1, cd.Count);
-        Assert.AreEqual(1, values.Count());
-        Assert.IsTrue(values.Contains(44));
+        Assert.HasCount(1, values);
+        Assert.Contains(44, values);
 
         Assert.IsFalse(cd.Remove(-1));
         Assert.AreEqual(1, cd.Count);
-        Assert.AreEqual(1, values.Count());
-        Assert.IsTrue(values.Contains(44));
+        Assert.HasCount(1, values);
+        Assert.Contains(44, values);
 
         cd.Clear();
         Assert.AreEqual(0, cd.Count);
-        Assert.AreEqual(0, values.Count());
+        Assert.IsEmpty(values);
     }
 
     [TestMethod]
@@ -69,21 +69,21 @@ public class ConcurrentCacheDictionaryTests
 
         Assert.AreEqual(4, cd.GetOrAdd(key: null, x => (x ?? "null").Length));
         Assert.AreEqual(1, cd.Count);
-        Assert.AreEqual(1, values.Count());
-        Assert.IsTrue(values.Contains(4));
+        Assert.HasCount(1, values);
+        Assert.Contains(4, values);
 
         Assert.AreEqual(4, cd.GetOrAdd(key: null, x => (x ?? "null").Length));
         Assert.AreEqual(1, cd.Count);
-        Assert.AreEqual(1, values.Count());
-        Assert.IsTrue(values.Contains(4));
+        Assert.HasCount(1, values);
+        Assert.Contains(4, values);
 
         Assert.IsTrue(cd.Remove(key: null));
         Assert.AreEqual(0, cd.Count);
-        Assert.AreEqual(0, values.Count());
+        Assert.IsEmpty(values);
 
         cd.Clear();
         Assert.AreEqual(0, cd.Count);
-        Assert.AreEqual(0, values.Count());
+        Assert.IsEmpty(values);
     }
 
     [TestMethod]
@@ -96,10 +96,10 @@ public class ConcurrentCacheDictionaryTests
 
         var res = cd.ToArray();
 
-        Assert.AreEqual(2, res.Length);
+        Assert.HasCount(2, res);
 
-        Assert.IsTrue(res.Any(x => x.Key == null && x.Value == 0));
-        Assert.IsTrue(res.Any(x => x.Key == "foo" && x.Value == 3));
+        Assert.Contains(x => x.Key == null && x.Value == 0, res);
+        Assert.Contains(x => x.Key == "foo" && x.Value == 3, res);
 
         Assert.IsNotNull(((IEnumerable)cd).GetEnumerator());
     }

--- a/Nuqleon/Core/BCL/Tests.Nuqleon.Memory/System/Memory/FunctionMemoizationExtensionsTests.cs
+++ b/Nuqleon/Core/BCL/Tests.Nuqleon.Memory/System/Memory/FunctionMemoizationExtensionsTests.cs
@@ -137,7 +137,7 @@ public partial class FunctionMemoizationExtensionsTests
             Assert.AreEqual(2, n);
             Assert.AreEqual(1, res.Cache.Count);
 
-            Assert.IsTrue(!string.IsNullOrEmpty(res.Cache.DebugView));
+            Assert.IsFalse(string.IsNullOrEmpty(res.Cache.DebugView));
         }
     }
 

--- a/Nuqleon/Core/BCL/Tests.Nuqleon.Memory/System/Memory/FunctionMemoizationExtensionsTests.cs
+++ b/Nuqleon/Core/BCL/Tests.Nuqleon.Memory/System/Memory/FunctionMemoizationExtensionsTests.cs
@@ -234,10 +234,10 @@ public partial class FunctionMemoizationExtensionsTests
 
         Assert.AreEqual(0, n);
 
-        Assert.AreEqual(true, res.Delegate());
+        Assert.IsTrue(res.Delegate());
         Assert.AreEqual(1, n);
 
-        Assert.AreEqual(true, res.Delegate());
+        Assert.IsTrue(res.Delegate());
         Assert.AreEqual(1, n);
     }
 
@@ -272,10 +272,10 @@ public partial class FunctionMemoizationExtensionsTests
 
         Assert.AreEqual(0, n);
 
-        Assert.AreEqual(true, res.Delegate(42));
+        Assert.IsTrue(res.Delegate(42));
         Assert.AreEqual(1, n);
 
-        Assert.AreEqual(true, res.Delegate(42));
+        Assert.IsTrue(res.Delegate(42));
         Assert.AreEqual(1, n);
     }
 
@@ -327,10 +327,10 @@ public partial class FunctionMemoizationExtensionsTests
 
         Assert.AreEqual(0, n);
 
-        Assert.AreEqual(true, res.Delegate());
+        Assert.IsTrue(res.Delegate());
         Assert.AreEqual(1, n);
 
-        Assert.AreEqual(true, res.Delegate());
+        Assert.IsTrue(res.Delegate());
         Assert.AreEqual(1, n);
     }
 
@@ -426,10 +426,10 @@ public partial class FunctionMemoizationExtensionsTests
 
         Assert.AreEqual(0, n);
 
-        Assert.AreEqual(true, res.Delegate("foo", 3));
+        Assert.IsTrue(res.Delegate("foo", 3));
         Assert.AreEqual(1, n);
 
-        Assert.AreEqual(true, res.Delegate("foo", 3));
+        Assert.IsTrue(res.Delegate("foo", 3));
         Assert.AreEqual(1, n);
     }
 
@@ -447,10 +447,10 @@ public partial class FunctionMemoizationExtensionsTests
 
         Assert.AreEqual(0, n);
 
-        Assert.AreEqual(true, res.Delegate(3, "foo"));
+        Assert.IsTrue(res.Delegate(3, "foo"));
         Assert.AreEqual(1, n);
 
-        Assert.AreEqual(true, res.Delegate(3, "foo"));
+        Assert.IsTrue(res.Delegate(3, "foo"));
         Assert.AreEqual(1, n);
     }
 
@@ -479,10 +479,10 @@ public partial class FunctionMemoizationExtensionsTests
 
         Assert.AreEqual(0, n);
 
-        Assert.AreEqual(true, res.Delegate(3, "foo", false, 42L, "qux"));
+        Assert.IsTrue(res.Delegate(3, "foo", false, 42L, "qux"));
         Assert.AreEqual(1, n);
 
-        Assert.AreEqual(true, res.Delegate(3, "foo", false, 42L, "qux"));
+        Assert.IsTrue(res.Delegate(3, "foo", false, 42L, "qux"));
         Assert.AreEqual(1, n);
     }
 
@@ -500,10 +500,10 @@ public partial class FunctionMemoizationExtensionsTests
 
         Assert.AreEqual(0, n);
 
-        Assert.AreEqual(true, res.Delegate(3, null, false, 42L, "qux"));
+        Assert.IsTrue(res.Delegate(3, null, false, 42L, "qux"));
         Assert.AreEqual(1, n);
 
-        Assert.AreEqual(true, res.Delegate(3, null, false, 42L, "qux"));
+        Assert.IsTrue(res.Delegate(3, null, false, 42L, "qux"));
         Assert.AreEqual(1, n);
     }
 }

--- a/Nuqleon/Core/BCL/Tests.Nuqleon.Memory/System/Memory/MemoizationCacheFactoryExtensionsTests.cs
+++ b/Nuqleon/Core/BCL/Tests.Nuqleon.Memory/System/Memory/MemoizationCacheFactoryExtensionsTests.cs
@@ -612,7 +612,7 @@ public class MemoizationCacheFactoryExtensionsTests
         Assert.AreEqual(42, c.GetOrAdd(21));
         Assert.AreEqual(1, c.Count);
 
-        Assert.IsTrue(!string.IsNullOrEmpty(c.DebugView));
+        Assert.IsFalse(string.IsNullOrEmpty(c.DebugView));
 
         c.Clear();
         Assert.AreEqual(0, c.Count);

--- a/Nuqleon/Core/BCL/Tests.Nuqleon.Memory/System/Memory/MemoizationCacheFactoryTestsBase.cs
+++ b/Nuqleon/Core/BCL/Tests.Nuqleon.Memory/System/Memory/MemoizationCacheFactoryTestsBase.cs
@@ -107,7 +107,7 @@ public class MemoizationCacheFactoryTestsBase
             Assert.AreEqual(2, cache.Count);
             Assert.AreEqual(4, n);
 
-            Assert.IsTrue(!string.IsNullOrEmpty(cache.DebugView));
+            Assert.IsFalse(string.IsNullOrEmpty(cache.DebugView));
         }
     }
 

--- a/Nuqleon/Core/BCL/Tests.Nuqleon.Memory/System/Memory/MemoizedDelegateCacheTests.cs
+++ b/Nuqleon/Core/BCL/Tests.Nuqleon.Memory/System/Memory/MemoizedDelegateCacheTests.cs
@@ -45,11 +45,13 @@ public class MemoizedDelegateTests
         Assert.IsFalse(m22.Equals(m12));
         Assert.IsFalse(m22.Equals(m21));
 
-        Assert.AreEqual(c11, m11);
-        Assert.AreEqual(c11, m11);
+#pragma warning disable MSTEST0037 // These intentionally test the ==/!= operators (Equals is covered above); the suggested Assert.AreEqual/AreNotEqual call object.Equals instead and would collapse each operator pair into a duplicate assertion.
+        Assert.IsTrue(m11 == c11);
+        Assert.IsFalse(m11 != c11);
 
-        Assert.AreNotEqual(m12, m11);
-        Assert.AreNotEqual(m12, m11);
+        Assert.IsTrue(m11 != m12);
+        Assert.IsFalse(m11 == m12);
+#pragma warning restore MSTEST0037
 
         Assert.AreEqual(m11.GetHashCode(), c11.GetHashCode());
 

--- a/Nuqleon/Core/BCL/Tests.Nuqleon.Memory/System/Memory/MemoizedDelegateCacheTests.cs
+++ b/Nuqleon/Core/BCL/Tests.Nuqleon.Memory/System/Memory/MemoizedDelegateCacheTests.cs
@@ -45,11 +45,11 @@ public class MemoizedDelegateTests
         Assert.IsFalse(m22.Equals(m12));
         Assert.IsFalse(m22.Equals(m21));
 
-        Assert.IsTrue(m11 == c11);
-        Assert.IsFalse(m11 != c11);
+        Assert.AreEqual(c11, m11);
+        Assert.AreEqual(c11, m11);
 
-        Assert.IsTrue(m11 != m12);
-        Assert.IsFalse(m11 == m12);
+        Assert.AreNotEqual(m12, m11);
+        Assert.AreNotEqual(m12, m11);
 
         Assert.AreEqual(m11.GetHashCode(), c11.GetHashCode());
 

--- a/Nuqleon/Core/BCL/Tests.Nuqleon.Memory/System/Memory/ObjectPoolTests.cs
+++ b/Nuqleon/Core/BCL/Tests.Nuqleon.Memory/System/Memory/ObjectPoolTests.cs
@@ -457,15 +457,15 @@ public class ObjectPoolTests
     {
         var pool = new ObjectPool<MyFreeable>(() => new MyFreeable());
 
-        Assert.IsTrue(!string.IsNullOrEmpty(pool.DebugView));
+        Assert.IsFalse(string.IsNullOrEmpty(pool.DebugView));
 
         var obj = pool.Allocate();
 
-        Assert.IsTrue(!string.IsNullOrEmpty(pool.DebugView));
+        Assert.IsFalse(string.IsNullOrEmpty(pool.DebugView));
 
         pool.Free(obj);
 
-        Assert.IsTrue(!string.IsNullOrEmpty(pool.DebugView));
+        Assert.IsFalse(string.IsNullOrEmpty(pool.DebugView));
     }
 #endif
 

--- a/Nuqleon/Core/BCL/Tests.Nuqleon.Memory/System/Memory/TrimmableTests.cs
+++ b/Nuqleon/Core/BCL/Tests.Nuqleon.Memory/System/Memory/TrimmableTests.cs
@@ -38,6 +38,6 @@ public class TrimmableTests
         values.Add(4);
 
         Assert.AreEqual(2, res.Trim(x => x % 2 == 0));
-        Assert.AreEqual(2, values.Count);
+        Assert.HasCount(2, values);
     }
 }

--- a/Nuqleon/Core/BCL/Tests.Nuqleon.Memory/System/Memory/WeakCacheDictionaryTests.cs
+++ b/Nuqleon/Core/BCL/Tests.Nuqleon.Memory/System/Memory/WeakCacheDictionaryTests.cs
@@ -66,7 +66,7 @@ public class WeakCacheDictionaryTests
         Assert.AreEqual(2, n);
 
 #if DEBUG
-        Assert.IsTrue(cd.Keys.Any(x => x == null));
+        Assert.Contains(x => x == null, cd.Keys);
 #endif
     }
 
@@ -79,7 +79,7 @@ public class WeakCacheDictionaryTests
 
         for (var i = 1; i <= 10; i++)
         {
-            Assert.IsTrue(GetOrAdd(cd).Contains("Obj"));
+            Assert.Contains("Obj", GetOrAdd(cd));
 
             GC.Collect();
             GC.WaitForPendingFinalizers();

--- a/Nuqleon/Core/BCL/Tests.Nuqleon.Memory/System/Memory/WeakMemoizationCacheFactoryTests.cs
+++ b/Nuqleon/Core/BCL/Tests.Nuqleon.Memory/System/Memory/WeakMemoizationCacheFactoryTests.cs
@@ -167,7 +167,7 @@ public class WeakMemoizationCacheFactoryTests
 
                 var cache = mcf.Create<Obj, string>(x => x.ToString(), MemoizationOptions.None);
 
-                Assert.IsTrue(GetOrAdd(cache).Contains("Obj"));
+                Assert.Contains("Obj", GetOrAdd(cache));
 
                 GC.Collect();
                 GC.WaitForPendingFinalizers();
@@ -563,9 +563,9 @@ public class WeakMemoizationCacheFactoryTests
 
                 var cache = mcf.Create<Obj, string>(x => x.ToString(), MemoizationOptions.None);
 
-                Assert.IsTrue(GetOrAdd(cache).Contains("Obj"));
-                Assert.IsTrue(GetOrAdd(cache).Contains("Obj"));
-                Assert.IsTrue(GetOrAdd(cache).Contains("Obj"));
+                Assert.Contains("Obj", GetOrAdd(cache));
+                Assert.Contains("Obj", GetOrAdd(cache));
+                Assert.Contains("Obj", GetOrAdd(cache));
                 Assert.AreEqual(3, cache.Count);
 
                 GC.Collect();
@@ -573,12 +573,12 @@ public class WeakMemoizationCacheFactoryTests
 
                 Assert.AreEqual(3, Obj.FinalizeCount);
 
-                Assert.IsTrue(cache.DebugView.Contains("(empty slot)"));
+                Assert.Contains("(empty slot)", cache.DebugView);
                 Assert.AreEqual(3, cache.Count);
 
-                Assert.IsTrue(GetOrAdd(cache).Contains("Obj")); // causes pruning
+                Assert.Contains("Obj", GetOrAdd(cache)); // causes pruning
 
-                Assert.IsFalse(cache.DebugView.Contains("(empty slot)"));
+                Assert.DoesNotContain("(empty slot)", cache.DebugView);
                 Assert.AreEqual(1, cache.Count);
             }
             finally
@@ -603,9 +603,9 @@ public class WeakMemoizationCacheFactoryTests
                 var trim = cache.AsTrimmableByArgumentAndResult();
                 Assert.IsNotNull(trim);
 
-                Assert.IsTrue(GetOrAdd(cache).Contains("Obj"));
-                Assert.IsTrue(GetOrAdd(cache).Contains("Obj"));
-                Assert.IsTrue(GetOrAdd(cache).Contains("Obj"));
+                Assert.Contains("Obj", GetOrAdd(cache));
+                Assert.Contains("Obj", GetOrAdd(cache));
+                Assert.Contains("Obj", GetOrAdd(cache));
                 Assert.AreEqual(3, cache.Count);
 
                 GC.Collect();
@@ -613,12 +613,12 @@ public class WeakMemoizationCacheFactoryTests
 
                 Assert.AreEqual(3, Obj.FinalizeCount);
 
-                Assert.IsTrue(cache.DebugView.Contains("(empty slot)"));
+                Assert.Contains("(empty slot)", cache.DebugView);
                 Assert.AreEqual(3, cache.Count);
 
                 trim.Trim(_ => false); // causes pruning
 
-                Assert.IsFalse(cache.DebugView.Contains("(empty slot)"));
+                Assert.DoesNotContain("(empty slot)", cache.DebugView);
                 Assert.AreEqual(0, cache.Count);
             }
             finally
@@ -1034,9 +1034,9 @@ public class WeakMemoizationCacheFactoryTests
                 var trim = cache.AsTrimmableByArgumentAndResult();
                 Assert.IsNotNull(trim);
 
-                Assert.IsTrue(GetOrAdd(cache).Contains("Obj"));
-                Assert.IsTrue(GetOrAdd(cache).Contains("Obj"));
-                Assert.IsTrue(GetOrAdd(cache).Contains("Obj"));
+                Assert.Contains("Obj", GetOrAdd(cache));
+                Assert.Contains("Obj", GetOrAdd(cache));
+                Assert.Contains("Obj", GetOrAdd(cache));
                 Assert.AreEqual(3, cache.Count);
 
                 GC.Collect();
@@ -1044,12 +1044,12 @@ public class WeakMemoizationCacheFactoryTests
 
                 Assert.AreEqual(3, Obj.FinalizeCount);
 
-                Assert.IsTrue(cache.DebugView.Contains("(empty slot)"));
+                Assert.Contains("(empty slot)", cache.DebugView);
                 Assert.AreEqual(3, cache.Count);
 
                 trim.Trim(_ => false); // causes pruning
 
-                Assert.IsFalse(cache.DebugView.Contains("(empty slot)"));
+                Assert.DoesNotContain("(empty slot)", cache.DebugView);
                 Assert.AreEqual(0, cache.Count);
             }
             finally

--- a/Nuqleon/Core/BCL/Tests.Nuqleon.Memory/System/Memory/WeakMemoizationCacheFactoryTests.cs
+++ b/Nuqleon/Core/BCL/Tests.Nuqleon.Memory/System/Memory/WeakMemoizationCacheFactoryTests.cs
@@ -418,19 +418,19 @@ public class WeakMemoizationCacheFactoryTests
         var trim = res.AsTrimmableByArgumentAndResult();
         Assert.IsNotNull(trim);
 
-        trim.Trim(kv => kv.Key.StartsWith("2"));
+        trim.Trim(kv => kv.Key.StartsWith('2'));
         Assert.AreEqual(1, res.Count);
 
-        trim.Trim(kv => kv.Key.StartsWith("1"));
+        trim.Trim(kv => kv.Key.StartsWith('1'));
         Assert.AreEqual(0, res.Count);
 
         Assert.AreEqual("1!", res.GetOrAdd("1"));
         Assert.AreEqual(1, res.Count);
 
-        trim.Trim(kv => kv.Key.StartsWith("2"));
+        trim.Trim(kv => kv.Key.StartsWith('2'));
         Assert.AreEqual(1, res.Count);
 
-        trim.Trim(kv => kv.Key.StartsWith("1"));
+        trim.Trim(kv => kv.Key.StartsWith('1'));
         Assert.AreEqual(0, res.Count);
     }
 
@@ -944,19 +944,19 @@ public class WeakMemoizationCacheFactoryTests
         var trim = res.AsTrimmableByArgumentAndResult();
         Assert.IsNotNull(trim);
 
-        trim.Trim(kv => kv.Key.StartsWith("2"));
+        trim.Trim(kv => kv.Key.StartsWith('2'));
         Assert.AreEqual(1, res.Count);
 
-        trim.Trim(kv => kv.Key.StartsWith("1"));
+        trim.Trim(kv => kv.Key.StartsWith('1'));
         Assert.AreEqual(0, res.Count);
 
         Assert.AreEqual("1!", res.GetOrAdd("1"));
         Assert.AreEqual(1, res.Count);
 
-        trim.Trim(kv => kv.Key.StartsWith("2"));
+        trim.Trim(kv => kv.Key.StartsWith('2'));
         Assert.AreEqual(1, res.Count);
 
-        trim.Trim(kv => kv.Key.StartsWith("1"));
+        trim.Trim(kv => kv.Key.StartsWith('1'));
         Assert.AreEqual(0, res.Count);
     }
 

--- a/Nuqleon/Core/BCL/Tests.Nuqleon.Memory/System/ServiceProviderExtensionsTests.cs
+++ b/Nuqleon/Core/BCL/Tests.Nuqleon.Memory/System/ServiceProviderExtensionsTests.cs
@@ -10,6 +10,12 @@
 
 namespace Tests;
 
+// CA2263 (prefer the generic overload) is intentional here: this test deliberately exercises BOTH the
+// generic GetService<T>() and the non-generic GetService(Type) extension overloads to verify they behave
+// identically, so the typeof(object) call must stay to cover the Type-based overload (using the generic
+// form would make it a duplicate of the line above and drop that coverage).
+#pragma warning disable CA2263
+
 [TestClass]
 public class ServiceProviderExtensionsTests
 {

--- a/Nuqleon/Core/BCL/Tests.Nuqleon.Reflection.Virtualization/System/Reflection/Tests.cs
+++ b/Nuqleon/Core/BCL/Tests.Nuqleon.Reflection.Virtualization/System/Reflection/Tests.cs
@@ -257,8 +257,8 @@ public class Tests
         Assert.AreEqual(substring, p.GetMethod(typeof(string), nameof(string.Substring), genericParameterCount: 0, BindingFlags.Public | BindingFlags.Instance, binder: null, CallingConventions.Any, [typeof(int), typeof(int)], modifiers: null));
 
         var isNullOrEmpty = p.GetMethod(typeof(string), nameof(string.IsNullOrEmpty));
-        Assert.AreEqual(true, isNullOrEmpty.Invoke(null, [""]));
-        Assert.AreEqual(false, isNullOrEmpty.Invoke(null, ["bar"]));
+        Assert.IsTrue((bool?)isNullOrEmpty.Invoke(null, [""]));
+        Assert.IsFalse((bool?)isNullOrEmpty.Invoke(null, ["bar"]));
 
         Assert.AreEqual(isNullOrEmpty, p.GetMethod(typeof(string), nameof(string.IsNullOrEmpty), BindingFlags.Public | BindingFlags.Static));
 

--- a/Nuqleon/Core/BCL/Tests.Nuqleon.Time/System/Time/StopwatchTests.cs
+++ b/Nuqleon/Core/BCL/Tests.Nuqleon.Time/System/Time/StopwatchTests.cs
@@ -42,7 +42,7 @@ public class StopwatchTests
 
         Assert.IsTrue(SpinWait.SpinUntil(() => sw.ElapsedTicks > 100, 60000));
 
-        Assert.IsTrue(sw.GetTimestamp() > 0L);
+        Assert.IsGreaterThan(0L, sw.GetTimestamp());
     }
 
     [TestMethod]

--- a/Nuqleon/Core/DataModel/Tests.Nuqleon.DataModel.CompilerServices/AnonymizationTests.cs
+++ b/Nuqleon/Core/DataModel/Tests.Nuqleon.DataModel.CompilerServices/AnonymizationTests.cs
@@ -13,6 +13,10 @@ using Nuqleon.DataModel.TypeSystem;
 
 namespace Tests.Nuqleon.DataModel.CompilerServices;
 
+// MSTEST0058 (no asserts in catch blocks) is a false positive here: the catch's Assert.Fail reports an
+// *unexpected* exception with context; the test expects the anonymization checker not to throw.
+#pragma warning disable MSTEST0058
+
 [TestClass]
 public class AnonymizationTests
 {

--- a/Nuqleon/Core/DataModel/Tests.Nuqleon.DataModel.CompilerServices/EntityTypeSubstitutorTests.cs
+++ b/Nuqleon/Core/DataModel/Tests.Nuqleon.DataModel.CompilerServices/EntityTypeSubstitutorTests.cs
@@ -47,7 +47,7 @@ public class EntityTypeSubstitutorTests
             foreach (var e in new Expression[] { e1, e2, e3, e4, e5 })
             {
                 var ex = Assert.ThrowsExactly<InvalidOperationException>(() => s.Apply(e));
-                Assert.IsTrue(ex.Message.Contains("Grmbl"));
+                Assert.Contains("Grmbl", ex.Message);
             }
         }
     }
@@ -70,7 +70,7 @@ public class EntityTypeSubstitutorTests
             foreach (var e in new Expression[] { e1, e2, e3, e4, e5 })
             {
                 var ex = Assert.ThrowsExactly<InvalidOperationException>(() => s.Apply(e));
-                Assert.IsTrue(ex.Message.Contains("Grmbl"));
+                Assert.Contains("Grmbl", ex.Message);
             }
         }
     }
@@ -131,7 +131,7 @@ public class EntityTypeSubstitutorTests
             {
                 // rewrite unsuccessful
                 var ex = Assert.ThrowsExactly<InvalidOperationException>(() => s.Apply(e));
-                Assert.IsTrue(ex.Message.Contains("Grmbl"));
+                Assert.Contains("Grmbl", ex.Message);
             }
         }
     }

--- a/Nuqleon/Core/DataModel/Tests.Nuqleon.DataModel.CompilerServices/Helpers/RecordTreeComparator.cs
+++ b/Nuqleon/Core/DataModel/Tests.Nuqleon.DataModel.CompilerServices/Helpers/RecordTreeComparator.cs
@@ -175,13 +175,12 @@ internal class RecordTreeComparator : ExpressionComparator
 
         foreach (var kvp in xEntities)
         {
-            if (!yEntities.ContainsKey(kvp.Key))
+            if (!yEntities.TryGetValue(kvp.Key, out var yEntity))
             {
                 return false;
             }
 
             var xEntity = kvp.Value;
-            var yEntity = yEntities[kvp.Key];
 
             if (xEntity.HasExpression && yEntity.HasExpression &&
                 (!Equals(xEntity.Expression, yEntity.Expression) || !Equals(xEntity.Type, yEntity.Type)))

--- a/Nuqleon/Core/DataModel/Tests.Nuqleon.DataModel.CompilerServices/TypeSystem/DataTypeCheckerTests.cs
+++ b/Nuqleon/Core/DataModel/Tests.Nuqleon.DataModel.CompilerServices/TypeSystem/DataTypeCheckerTests.cs
@@ -112,17 +112,17 @@ public class DataTypeCheckerTests
         {
             {
                 Assert.IsTrue(DataType.TryCheck(t, out var err), "Type check failed for: " + t.Name);
-                Assert.AreEqual(0, err.Count, "Type check failed for: " + t.Name);
+                Assert.IsEmpty(err, "Type check failed for: " + t.Name);
             }
 
             {
                 Assert.IsTrue(DataType.TryCheck(t, allowCycles: false, out var err), "Type check failed for: " + t.Name);
-                Assert.AreEqual(0, err.Count, "Type check failed for: " + t.Name);
+                Assert.IsEmpty(err, "Type check failed for: " + t.Name);
             }
 
             {
                 Assert.IsTrue(DataType.TryCheck(t, allowCycles: true, out var err), "Type check failed for: " + t.Name);
-                Assert.AreEqual(0, err.Count, "Type check failed for: " + t.Name);
+                Assert.IsEmpty(err, "Type check failed for: " + t.Name);
             }
 
             DataType.Check(t);
@@ -166,17 +166,17 @@ public class DataTypeCheckerTests
         {
             {
                 Assert.IsFalse(DataType.TryCheck(t, out var err), "Type check failed for: " + t.Name);
-                Assert.AreNotEqual(0, err.Count, "Type check failed for: " + t.Name);
+                Assert.IsNotEmpty(err, "Type check failed for: " + t.Name);
             }
 
             {
                 Assert.IsFalse(DataType.TryCheck(t, allowCycles: false, out var err), "Type check failed for: " + t.Name);
-                Assert.AreNotEqual(0, err.Count, "Type check failed for: " + t.Name);
+                Assert.IsNotEmpty(err, "Type check failed for: " + t.Name);
             }
 
             {
                 Assert.IsFalse(DataType.TryCheck(t, allowCycles: true, out var err), "Type check failed for: " + t.Name);
-                Assert.AreNotEqual(0, err.Count, "Type check failed for: " + t.Name);
+                Assert.IsNotEmpty(err, "Type check failed for: " + t.Name);
             }
 
             Assert.ThrowsExactly<AggregateException>(() => DataType.Check(t));
@@ -215,17 +215,17 @@ public class DataTypeCheckerTests
         {
             {
                 Assert.IsFalse(DataType.TryCheck(t, out var err), "Type check failed for: " + t.Name);
-                Assert.AreNotEqual(0, err.Count, "Type check failed for: " + t.Name);
+                Assert.IsNotEmpty(err, "Type check failed for: " + t.Name);
             }
 
             {
                 Assert.IsFalse(DataType.TryCheck(t, allowCycles: false, out var err), "Type check failed for: " + t.Name);
-                Assert.AreNotEqual(0, err.Count, "Type check failed for: " + t.Name);
+                Assert.IsNotEmpty(err, "Type check failed for: " + t.Name);
             }
 
             {
                 Assert.IsFalse(DataType.TryCheck(t, allowCycles: true, out var err), "Type check failed for: " + t.Name);
-                Assert.AreNotEqual(0, err.Count, "Type check failed for: " + t.Name);
+                Assert.IsNotEmpty(err, "Type check failed for: " + t.Name);
             }
 
             Assert.ThrowsExactly<AggregateException>(() => DataType.Check(t));
@@ -247,10 +247,10 @@ public class DataTypeCheckerTests
     {
         Assert.IsFalse(DataType.TryCheck(typeof(Func<int, List<AppDomain[]>>), out var err));
 
-        Assert.AreEqual(1, err.Count);
+        Assert.HasCount(1, err);
         Assert.IsTrue(new[] { typeof(Func<int, List<AppDomain[]>>), typeof(List<AppDomain[]>), typeof(AppDomain[]) }.Reverse().SequenceEqual(err[0].Stack));
 
-        Assert.IsTrue(err[0].ToString().Contains("AppDomain"));
+        Assert.Contains("AppDomain", err[0].ToString());
     }
 
     [TestMethod]
@@ -271,7 +271,7 @@ public class DataTypeCheckerTests
             DataType.Check(t, allowCycles: true);
 
             Assert.IsTrue(DataType.TryCheck(t, allowCycles: true, out var err));
-            Assert.AreEqual(0, err.Count, "Type check failed for: " + t.Name);
+            Assert.IsEmpty(err, "Type check failed for: " + t.Name);
 
             Assert.IsTrue(DataType.TryFromType(t, allowCycles: true, out _));
         }
@@ -298,12 +298,12 @@ public class DataTypeCheckerTests
 
             {
                 Assert.IsFalse(DataType.TryCheck(t, out var err));
-                Assert.AreNotEqual(0, err.Count, "Type check failed for: " + t.Name);
+                Assert.IsNotEmpty(err, "Type check failed for: " + t.Name);
             }
 
             {
                 Assert.IsFalse(DataType.TryCheck(t, allowCycles: false, out var err));
-                Assert.AreNotEqual(0, err.Count, "Type check failed for: " + t.Name);
+                Assert.IsNotEmpty(err, "Type check failed for: " + t.Name);
             }
 
             Assert.IsFalse(DataType.TryFromType(t, out _));
@@ -320,7 +320,7 @@ public class DataTypeCheckerTests
 
         var structural = (StructuralDataType)simple;
 
-        Assert.AreEqual(1, structural.Properties.Count);
+        Assert.HasCount(1, structural.Properties);
 
         Assert.AreSame(structural, structural.Properties[0].Type);
     }

--- a/Nuqleon/Core/DataModel/Tests.Nuqleon.DataModel.CompilerServices/TypeSystem/DataTypeExceptionTests.cs
+++ b/Nuqleon/Core/DataModel/Tests.Nuqleon.DataModel.CompilerServices/TypeSystem/DataTypeExceptionTests.cs
@@ -24,13 +24,13 @@ public class DataTypeExceptionTests
         var ex2 = new DataTypeException("foo");
         Assert.AreEqual("foo", ex2.Message);
         Assert.IsNull(ex2.InnerException);
-        Assert.IsTrue(ex2.ToString().Contains("foo"));
+        Assert.Contains("foo", ex2.ToString());
 
         var iex = new Exception();
         var ex3 = new DataTypeException("foo", iex);
         Assert.AreEqual("foo", ex3.Message);
         Assert.AreSame(iex, ex3.InnerException);
-        Assert.IsTrue(ex3.ToString().Contains("foo"));
+        Assert.Contains("foo", ex3.ToString());
 
         var ex = Assert.ThrowsExactly<ArgumentNullException>(() => new DataTypeException(default(DataTypeError)));
         Assert.AreEqual("error", ex.ParamName);
@@ -38,7 +38,7 @@ public class DataTypeExceptionTests
         var err = new DataTypeError(typeof(int), "bar", [typeof(List<int>)]);
         var ex4 = new DataTypeException(err);
         Assert.AreSame(err, ex4.Error);
-        Assert.IsTrue(ex4.ToString().Contains("bar"));
+        Assert.Contains("bar", ex4.ToString());
     }
 
 }

--- a/Nuqleon/Core/DataModel/Tests.Nuqleon.DataModel.CompilerServices/TypeSystem/DataTypeTests.cs
+++ b/Nuqleon/Core/DataModel/Tests.Nuqleon.DataModel.CompilerServices/TypeSystem/DataTypeTests.cs
@@ -72,7 +72,7 @@ public class DataTypeTests
         Assert.AreEqual(DataTypeKinds.Structural, bar.Kind);
 
         var barStruct = (StructuralDataType)bar;
-        Assert.AreEqual(1, barStruct.Properties.Count);
+        Assert.HasCount(1, barStruct.Properties);
 
         var foosProp = barStruct.Properties[0];
         Assert.AreEqual("foos", foosProp.Name);
@@ -82,7 +82,7 @@ public class DataTypeTests
         Assert.AreEqual(DataTypeKinds.Structural, foosArray.ElementType.Kind);
 
         var fooStruct = (StructuralDataType)foosArray.ElementType;
-        Assert.AreEqual(1, fooStruct.Properties.Count);
+        Assert.HasCount(1, fooStruct.Properties);
 
         var barProp = fooStruct.Properties[0];
         Assert.AreEqual("bar", barProp.Name);
@@ -193,7 +193,7 @@ in  t1
         var s = (StructuralDataType)t;
 
         Assert.AreEqual(StructuralDataTypeKinds.Anonymous, s.StructuralKind);
-        Assert.AreEqual(2, s.Properties.Count);
+        Assert.HasCount(2, s.Properties);
 
         Assert.ThrowsExactly<ArgumentNullException>(() => s.CreateInstance(default));
         Assert.ThrowsExactly<InvalidOperationException>(() => s.CreateInstance());
@@ -220,7 +220,7 @@ in  t1
         var s = (StructuralDataType)t;
 
         Assert.AreEqual(StructuralDataTypeKinds.Record, s.StructuralKind);
-        Assert.AreEqual(2, s.Properties.Count);
+        Assert.HasCount(2, s.Properties);
 
         Assert.ThrowsExactly<ArgumentNullException>(() => s.CreateInstance(default));
         Assert.ThrowsExactly<InvalidOperationException>(() => s.CreateInstance(42));
@@ -246,7 +246,7 @@ in  t1
         var s = (StructuralDataType)t;
 
         Assert.AreEqual(StructuralDataTypeKinds.Tuple, s.StructuralKind);
-        Assert.AreEqual(2, s.Properties.Count);
+        Assert.HasCount(2, s.Properties);
 
         Assert.ThrowsExactly<InvalidOperationException>(() => s.CreateInstance());
         Assert.ThrowsExactly<InvalidOperationException>(() => s.CreateInstance(42));
@@ -278,7 +278,7 @@ in  t1
 
         Assert.AreEqual(3, l[2]);
 
-        Assert.AreEqual(3, l.Count);
+        Assert.HasCount(3, l);
 
         Assert.ThrowsExactly<NotSupportedException>(() => l.Remove(2));
         Assert.ThrowsExactly<NotSupportedException>(() => l.RemoveAt(0));
@@ -287,7 +287,7 @@ in  t1
         var b = t.CreateInstance(4);
         Assert.IsTrue(b is int[]);
         var c = a.GetList(b);
-        Assert.AreEqual(4, c.Count);
+        Assert.HasCount(4, c);
 
         Assert.ThrowsExactly<ArgumentNullException>(() => a.CreateInstance(default));
         Assert.ThrowsExactly<InvalidOperationException>(() => t.CreateInstance());
@@ -310,7 +310,7 @@ in  t1
 
         Assert.AreEqual(3, l[2]);
 
-        Assert.AreEqual(3, l.Count);
+        Assert.HasCount(3, l);
 
         var b = t.CreateInstance(4);
         Assert.IsTrue(b is List<int>);
@@ -321,7 +321,7 @@ in  t1
         c.Add(3);
         c.Add(4);
 
-        Assert.AreEqual(4, c.Count);
+        Assert.HasCount(4, c);
 
         Assert.IsTrue(new[] { 1, 2, 3, 4 }.SequenceEqual(c.Cast<int>()));
 
@@ -378,7 +378,7 @@ in  t1
         Assert.AreEqual(DataTypeKinds.Function, t.Kind);
         var f = (FunctionDataType)t;
 
-        Assert.AreEqual(1, f.ParameterTypes.Count);
+        Assert.HasCount(1, f.ParameterTypes);
         Assert.AreEqual(DataTypeKinds.OpenGenericParameter, f.ReturnType.Kind);
         Assert.AreEqual(DataTypeKinds.OpenGenericParameter, f.ParameterTypes[0].Kind);
 
@@ -454,7 +454,7 @@ in  t1
     {
 
         Assert.IsTrue(DataTypeHelpers.TryCheckCached(typeof(CacheTest), allowCycles: false, out var e1));
-        Assert.AreEqual(0, e1.Count);
+        Assert.IsEmpty(e1);
 
         Assert.IsFalse(DataTypeHelpers.TryCheckCached(typeof(NonDTCacheTest), allowCycles: false, out var e2));
         Assert.IsFalse(DataTypeHelpers.TryCheckCached(typeof(NonDTCacheTest), allowCycles: false, out var e3));

--- a/Nuqleon/Core/DataModel/Tests.Nuqleon.DataModel.Serialization.Binary/DataModelSerializerFactory.TestCases.cs
+++ b/Nuqleon/Core/DataModel/Tests.Nuqleon.DataModel.Serialization.Binary/DataModelSerializerFactory.TestCases.cs
@@ -16,6 +16,12 @@ using IExpressionSerializer = Nuqleon.DataModel.Serialization.Binary.IExpression
 
 namespace Tests.Nuqleon.DataModel.Serialization.Binary;
 
+// CA2263 (prefer the generic overload) is intentional here: this hand-rolled expression-serializer fixture
+// is built on the runtime-Type-based DataSerializer API (it also serializes payloads by runtime Type, e.g.
+// DataSerializer.Deserialize(type, stream) where 'type' comes from Type.GetType), so the statically-known
+// typeof(T) calls stay consistent with that Type-based contract.
+#pragma warning disable CA2263
+
 public class DataModelSerializerFactoryTestCase
 {
 #pragma warning disable CA1822 // Mark static

--- a/Nuqleon/Core/DataModel/Tests.Nuqleon.DataModel.Serialization.Binary/DataModelSerializerFactoryTests.cs
+++ b/Nuqleon/Core/DataModel/Tests.Nuqleon.DataModel.Serialization.Binary/DataModelSerializerFactoryTests.cs
@@ -11,6 +11,12 @@ using Nuqleon.DataModel.TypeSystem;
 
 namespace Tests.Nuqleon.DataModel.Serialization.Binary;
 
+// CA2263 (prefer the generic overload) is intentional here: these tests exercise DataTypeBinarySerializer's
+// runtime-Type-based Serialize(Type, Stream, object) / Deserialize(Type, Stream) public API — including its
+// NotSupported and cyclic-type error paths — which is exactly the contract under test; a generic overload
+// would bypass that code path.
+#pragma warning disable CA2263
+
 [TestClass]
 public partial class DataModelSerializerFactoryTests
 {

--- a/Nuqleon/Core/DataModel/Tests.Nuqleon.DataModel.Serialization.Json/DataSerializerTests.cs
+++ b/Nuqleon/Core/DataModel/Tests.Nuqleon.DataModel.Serialization.Json/DataSerializerTests.cs
@@ -897,7 +897,7 @@ public partial class DataSerializerTests
         var reader = new StreamReader(memoryStream);
         memoryStream.Position = 0;
         var json = reader.ReadToEnd();
-        Assert.AreEqual(2, json.Split(["\"Context\""], 10, StringSplitOptions.None).Length);
+        Assert.HasCount(2, json.Split(["\"Context\""], 10, StringSplitOptions.None));
 
         memoryStream.Position = 0;
 

--- a/Nuqleon/Core/DataModel/Tests.Nuqleon.DataModel.Serialization.Json/DataSerializerTests.cs
+++ b/Nuqleon/Core/DataModel/Tests.Nuqleon.DataModel.Serialization.Json/DataSerializerTests.cs
@@ -246,7 +246,7 @@ public partial class DataSerializerTests
     {
         _jsonSerializer.Serialize((string)null, _stream);
         _stream.Position = 0;
-        Assert.AreEqual(null, _jsonSerializer.Deserialize<string>(_stream));
+        Assert.IsNull(_jsonSerializer.Deserialize<string>(_stream));
     }
 
     /// <summary>
@@ -897,7 +897,7 @@ public partial class DataSerializerTests
         var reader = new StreamReader(memoryStream);
         memoryStream.Position = 0;
         var json = reader.ReadToEnd();
-        Assert.IsTrue(json.Split(["\"Context\""], 10, StringSplitOptions.None).Length == 2);
+        Assert.AreEqual(2, json.Split(["\"Context\""], 10, StringSplitOptions.None).Length);
 
         memoryStream.Position = 0;
 

--- a/Nuqleon/Core/DataModel/Tests.Nuqleon.DataModel/UnitTests.cs
+++ b/Nuqleon/Core/DataModel/Tests.Nuqleon.DataModel/UnitTests.cs
@@ -37,7 +37,7 @@ public class UnitTests
             u2
         };
 
-        Assert.AreEqual(1, d.Count);
+        Assert.HasCount(1, d);
     }
 
     [TestMethod]

--- a/Nuqleon/Core/JSON/Tests.Nuqleon.Json.Interop.Newtonsoft/JsonExpressionWriterTests.cs
+++ b/Nuqleon/Core/JSON/Tests.Nuqleon.Json.Interop.Newtonsoft/JsonExpressionWriterTests.cs
@@ -603,19 +603,22 @@ public class JsonExpressionWriterTests
         AssertNotSupported(w => w.WriteEndConstructor());
         AssertNotSupported(w => w.WriteUndefined());
 
-        Assert.ThrowsExactly<NotSupportedException>(() => new JsonExpressionWriter() { DateFormatHandling = DateFormatHandling.MicrosoftDateFormat }.WriteValue(DateTime.Now));
+        var w1 = new JsonExpressionWriter() { DateFormatHandling = DateFormatHandling.MicrosoftDateFormat };
+        Assert.ThrowsExactly<NotSupportedException>(() => w1.WriteValue(DateTime.Now));
 
-        Assert.ThrowsExactly<NotSupportedException>(() => new JsonExpressionWriter() { DateFormatHandling = DateFormatHandling.MicrosoftDateFormat }.WriteValue(DateTimeOffset.Now));
+        var w2 = new JsonExpressionWriter() { DateFormatHandling = DateFormatHandling.MicrosoftDateFormat };
+        Assert.ThrowsExactly<NotSupportedException>(() => w2.WriteValue(DateTimeOffset.Now));
     }
 
     [TestMethod]
     public void JsonExpressionWriter_InvalidOperation_EndArray()
     {
-        Assert.ThrowsExactly<InvalidOperationException>(() => new JsonExpressionWriter().WriteEndArray());
+        var w1 = new JsonExpressionWriter();
+        Assert.ThrowsExactly<InvalidOperationException>(() => w1.WriteEndArray());
 
-        var w = new JsonExpressionWriter();
-        w.WriteValue(1);
-        Assert.ThrowsExactly<InvalidOperationException>(() => w.WriteEndArray());
+        var w2 = new JsonExpressionWriter();
+        w2.WriteValue(1);
+        Assert.ThrowsExactly<InvalidOperationException>(() => w2.WriteEndArray());
     }
 
     [TestMethod]
@@ -637,11 +640,12 @@ public class JsonExpressionWriterTests
     [TestMethod]
     public void JsonExpressionWriter_InvalidOperation_EndObject()
     {
-        Assert.ThrowsExactly<InvalidOperationException>(() => new JsonExpressionWriter().WriteEndObject());
+        var w1 = new JsonExpressionWriter();
+        Assert.ThrowsExactly<InvalidOperationException>(() => w1.WriteEndObject());
 
-        var w = new JsonExpressionWriter();
-        w.WriteValue(1);
-        Assert.ThrowsExactly<InvalidOperationException>(() => w.WriteEndObject());
+        var w2 = new JsonExpressionWriter();
+        w2.WriteValue(1);
+        Assert.ThrowsExactly<InvalidOperationException>(() => w2.WriteEndObject());
     }
 
     [TestMethod]

--- a/Nuqleon/Core/JSON/Tests.Nuqleon.Json.Interop.Newtonsoft/JsonExpressionWriterTests.cs
+++ b/Nuqleon/Core/JSON/Tests.Nuqleon.Json.Interop.Newtonsoft/JsonExpressionWriterTests.cs
@@ -603,34 +603,19 @@ public class JsonExpressionWriterTests
         AssertNotSupported(w => w.WriteEndConstructor());
         AssertNotSupported(w => w.WriteUndefined());
 
-        Assert.ThrowsExactly<NotSupportedException>(() =>
-        {
-            var w = new JsonExpressionWriter() { DateFormatHandling = DateFormatHandling.MicrosoftDateFormat };
-            w.WriteValue(DateTime.Now);
-        });
+        Assert.ThrowsExactly<NotSupportedException>(() => new JsonExpressionWriter() { DateFormatHandling = DateFormatHandling.MicrosoftDateFormat }.WriteValue(DateTime.Now));
 
-        Assert.ThrowsExactly<NotSupportedException>(() =>
-        {
-            var w = new JsonExpressionWriter() { DateFormatHandling = DateFormatHandling.MicrosoftDateFormat };
-            w.WriteValue(DateTimeOffset.Now);
-        });
+        Assert.ThrowsExactly<NotSupportedException>(() => new JsonExpressionWriter() { DateFormatHandling = DateFormatHandling.MicrosoftDateFormat }.WriteValue(DateTimeOffset.Now));
     }
 
     [TestMethod]
     public void JsonExpressionWriter_InvalidOperation_EndArray()
     {
-        Assert.ThrowsExactly<InvalidOperationException>(() =>
-        {
-            var w = new JsonExpressionWriter();
-            w.WriteEndArray();
-        });
+        Assert.ThrowsExactly<InvalidOperationException>(() => new JsonExpressionWriter().WriteEndArray());
 
-        Assert.ThrowsExactly<InvalidOperationException>(() =>
-        {
-            var w = new JsonExpressionWriter();
-            w.WriteValue(1);
-            w.WriteEndArray();
-        });
+        var w = new JsonExpressionWriter();
+        w.WriteValue(1);
+        Assert.ThrowsExactly<InvalidOperationException>(() => w.WriteEndArray());
     }
 
     [TestMethod]
@@ -642,31 +627,21 @@ public class JsonExpressionWriterTests
             w => w.WriteStartObject(),
         })
         {
-            Assert.ThrowsExactly<InvalidOperationException>(() =>
-            {
-                var w = new JsonExpressionWriter();
-                w.WriteStartArray();
-                write(w);
-                w.WriteEndArray();
-            });
+            var w = new JsonExpressionWriter();
+            w.WriteStartArray();
+            write(w);
+            Assert.ThrowsExactly<InvalidOperationException>(() => w.WriteEndArray());
         }
     }
 
     [TestMethod]
     public void JsonExpressionWriter_InvalidOperation_EndObject()
     {
-        Assert.ThrowsExactly<InvalidOperationException>(() =>
-        {
-            var w = new JsonExpressionWriter();
-            w.WriteEndObject();
-        });
+        Assert.ThrowsExactly<InvalidOperationException>(() => new JsonExpressionWriter().WriteEndObject());
 
-        Assert.ThrowsExactly<InvalidOperationException>(() =>
-        {
-            var w = new JsonExpressionWriter();
-            w.WriteValue(1);
-            w.WriteEndObject();
-        });
+        var w = new JsonExpressionWriter();
+        w.WriteValue(1);
+        Assert.ThrowsExactly<InvalidOperationException>(() => w.WriteEndObject());
     }
 
     [TestMethod]
@@ -678,14 +653,11 @@ public class JsonExpressionWriterTests
             w => w.WriteValue(1),
         })
         {
-            Assert.ThrowsExactly<InvalidOperationException>(() =>
-            {
-                var w = new JsonExpressionWriter();
-                w.WriteStartObject();
-                write(w);
-                w.WriteValue(1);
-                w.WriteEndObject();
-            });
+            var w = new JsonExpressionWriter();
+            w.WriteStartObject();
+            write(w);
+            w.WriteValue(1);
+            Assert.ThrowsExactly<InvalidOperationException>(() => w.WriteEndObject());
         }
     }
 
@@ -698,14 +670,11 @@ public class JsonExpressionWriterTests
             w => w.WriteStartArray(),
         })
         {
-            Assert.ThrowsExactly<InvalidOperationException>(() =>
-            {
-                var w = new JsonExpressionWriter();
-                w.WriteStartObject();
-                w.WritePropertyName("foo");
-                write(w);
-                w.WriteEndObject();
-            });
+            var w = new JsonExpressionWriter();
+            w.WriteStartObject();
+            w.WritePropertyName("foo");
+            write(w);
+            Assert.ThrowsExactly<InvalidOperationException>(() => w.WriteEndObject());
         }
     }
 

--- a/Nuqleon/Core/JSON/Tests.Nuqleon.Json.Serialization/SyntaxTrieTests.cs
+++ b/Nuqleon/Core/JSON/Tests.Nuqleon.Json.Serialization/SyntaxTrieTests.cs
@@ -29,20 +29,20 @@ public class SyntaxTrieTests
 
         Assert.ThrowsExactly<InvalidOperationException>(() => trie.Add("foo", "@XXX"));
 
-        Assert.AreEqual(3, trie.Root.Children.Count);
-        Assert.AreEqual(1, trie.Root.Children['b'].Children.Count);
-        Assert.AreEqual(2, trie.Root.Children['b'].Children['a'].Children.Count);
-        Assert.AreEqual(0, trie.Root.Children['b'].Children['a'].Children['r'].Children.Count);
-        Assert.AreEqual(0, trie.Root.Children['b'].Children['a'].Children['z'].Children.Count);
-        Assert.AreEqual(1, trie.Root.Children['f'].Children.Count);
-        Assert.AreEqual(1, trie.Root.Children['f'].Children['o'].Children.Count);
-        Assert.AreEqual(1, trie.Root.Children['f'].Children['o'].Children['o'].Children.Count);
-        Assert.AreEqual(1, trie.Root.Children['f'].Children['o'].Children['o'].Children['b'].Children.Count);
-        Assert.AreEqual(1, trie.Root.Children['f'].Children['o'].Children['o'].Children['b'].Children['a'].Children.Count);
-        Assert.AreEqual(0, trie.Root.Children['f'].Children['o'].Children['o'].Children['b'].Children['a'].Children['r'].Children.Count);
-        Assert.AreEqual(1, trie.Root.Children['q'].Children.Count);
-        Assert.AreEqual(1, trie.Root.Children['q'].Children['u'].Children.Count);
-        Assert.AreEqual(0, trie.Root.Children['q'].Children['u'].Children['x'].Children.Count);
+        Assert.HasCount(3, trie.Root.Children);
+        Assert.HasCount(1, trie.Root.Children['b'].Children);
+        Assert.HasCount(2, trie.Root.Children['b'].Children['a'].Children);
+        Assert.IsEmpty(trie.Root.Children['b'].Children['a'].Children['r'].Children);
+        Assert.IsEmpty(trie.Root.Children['b'].Children['a'].Children['z'].Children);
+        Assert.HasCount(1, trie.Root.Children['f'].Children);
+        Assert.HasCount(1, trie.Root.Children['f'].Children['o'].Children);
+        Assert.HasCount(1, trie.Root.Children['f'].Children['o'].Children['o'].Children);
+        Assert.HasCount(1, trie.Root.Children['f'].Children['o'].Children['o'].Children['b'].Children);
+        Assert.HasCount(1, trie.Root.Children['f'].Children['o'].Children['o'].Children['b'].Children['a'].Children);
+        Assert.IsEmpty(trie.Root.Children['f'].Children['o'].Children['o'].Children['b'].Children['a'].Children['r'].Children);
+        Assert.HasCount(1, trie.Root.Children['q'].Children);
+        Assert.HasCount(1, trie.Root.Children['q'].Children['u'].Children);
+        Assert.IsEmpty(trie.Root.Children['q'].Children['u'].Children['x'].Children);
 
         Assert.IsNull(trie.Root.Terminal);
         Assert.IsNull(trie.Root.Children['b'].Terminal);

--- a/Nuqleon/Core/JSON/Tests.Nuqleon.Json/ExpressionTests.cs
+++ b/Nuqleon/Core/JSON/Tests.Nuqleon.Json/ExpressionTests.cs
@@ -200,7 +200,7 @@ public class ExpressionTests
                 Assert.IsTrue(elements.SequenceEqual(arr.Elements /* will allocate */));
             }
 
-            Assert.AreEqual(1, arr.Elements.Count);
+            Assert.HasCount(1, arr.Elements);
             Assert.IsTrue(arr.Elements[0].NodeType == Json.ExpressionType.Number && (string)((Json.ConstantExpression)arr.Elements[0]).Value == "1");
 
             var i = arr.ToString();
@@ -228,7 +228,7 @@ public class ExpressionTests
                 Assert.IsTrue(elements.SequenceEqual(arr.Elements /* will allocate */));
             }
 
-            Assert.AreEqual(2, arr.Elements.Count);
+            Assert.HasCount(2, arr.Elements);
             Assert.IsTrue(arr.Elements[0].NodeType == Json.ExpressionType.Number && (string)((Json.ConstantExpression)arr.Elements[0]).Value == "1");
             Assert.IsTrue(arr.Elements[1].NodeType == Json.ExpressionType.Boolean && (bool)((Json.ConstantExpression)arr.Elements[1]).Value == true);
 
@@ -257,7 +257,7 @@ public class ExpressionTests
                 Assert.IsTrue(elements.SequenceEqual(arr.Elements /* will allocate */));
             }
 
-            Assert.AreEqual(3, arr.Elements.Count);
+            Assert.HasCount(3, arr.Elements);
             Assert.IsTrue(arr.Elements[0].NodeType == Json.ExpressionType.Number && (string)((Json.ConstantExpression)arr.Elements[0]).Value == "1");
             Assert.IsTrue(arr.Elements[1].NodeType == Json.ExpressionType.Boolean && (bool)((Json.ConstantExpression)arr.Elements[1]).Value == true);
             Assert.IsTrue(arr.Elements[2].NodeType == Json.ExpressionType.String && (string)((Json.ConstantExpression)arr.Elements[2]).Value == "Hello");
@@ -287,7 +287,7 @@ public class ExpressionTests
                 Assert.IsTrue(elements.SequenceEqual(arr.Elements /* will allocate */));
             }
 
-            Assert.AreEqual(4, arr.Elements.Count);
+            Assert.HasCount(4, arr.Elements);
             Assert.IsTrue(arr.Elements[0].NodeType == Json.ExpressionType.Number && (string)((Json.ConstantExpression)arr.Elements[0]).Value == "1");
             Assert.IsTrue(arr.Elements[1].NodeType == Json.ExpressionType.Boolean && (bool)((Json.ConstantExpression)arr.Elements[1]).Value == true);
             Assert.IsTrue(arr.Elements[2].NodeType == Json.ExpressionType.String && (string)((Json.ConstantExpression)arr.Elements[2]).Value == "Hello");
@@ -318,7 +318,7 @@ public class ExpressionTests
                 Assert.IsTrue(elements.SequenceEqual(arr.Elements /* will allocate */));
             }
 
-            Assert.AreEqual(5, arr.Elements.Count);
+            Assert.HasCount(5, arr.Elements);
             Assert.IsTrue(arr.Elements[0].NodeType == Json.ExpressionType.Number && (string)((Json.ConstantExpression)arr.Elements[0]).Value == "1");
             Assert.IsTrue(arr.Elements[1].NodeType == Json.ExpressionType.Boolean && (bool)((Json.ConstantExpression)arr.Elements[1]).Value == true);
             Assert.IsTrue(arr.Elements[2].NodeType == Json.ExpressionType.String && (string)((Json.ConstantExpression)arr.Elements[2]).Value == "Hello");
@@ -350,7 +350,7 @@ public class ExpressionTests
                 Assert.IsTrue(elements.SequenceEqual(arr.Elements /* will allocate */));
             }
 
-            Assert.AreEqual(6, arr.Elements.Count);
+            Assert.HasCount(6, arr.Elements);
             Assert.IsTrue(arr.Elements[0].NodeType == Json.ExpressionType.Number && (string)((Json.ConstantExpression)arr.Elements[0]).Value == "1");
             Assert.IsTrue(arr.Elements[1].NodeType == Json.ExpressionType.Boolean && (bool)((Json.ConstantExpression)arr.Elements[1]).Value == true);
             Assert.IsTrue(arr.Elements[2].NodeType == Json.ExpressionType.String && (string)((Json.ConstantExpression)arr.Elements[2]).Value == "Hello");
@@ -383,7 +383,7 @@ public class ExpressionTests
                 Assert.IsTrue(elements.SequenceEqual(arr.Elements));
             }
 
-            Assert.AreEqual(7, arr.Elements.Count);
+            Assert.HasCount(7, arr.Elements);
             Assert.IsTrue(arr.Elements[0].NodeType == Json.ExpressionType.Number && (string)((Json.ConstantExpression)arr.Elements[0]).Value == "1");
             Assert.IsTrue(arr.Elements[1].NodeType == Json.ExpressionType.Boolean && (bool)((Json.ConstantExpression)arr.Elements[1]).Value == true);
             Assert.IsTrue(arr.Elements[2].NodeType == Json.ExpressionType.String && (string)((Json.ConstantExpression)arr.Elements[2]).Value == "Hello");
@@ -405,10 +405,10 @@ public class ExpressionTests
         var o = Json.Expression.Parse(j);
         Assert.AreEqual(Json.ExpressionType.Array, o.NodeType);
         var arr = (Json.ArrayExpression)o;
-        Assert.AreEqual(1, arr.Elements.Count);
+        Assert.HasCount(1, arr.Elements);
         Assert.AreEqual(Json.ExpressionType.Array, arr.Elements[0].NodeType);
         var nst = (Json.ArrayExpression)arr.Elements[0];
-        Assert.AreEqual(1, nst.Elements.Count);
+        Assert.HasCount(1, nst.Elements);
         Assert.IsTrue(nst.Elements[0].NodeType == Json.ExpressionType.Boolean && (bool)((Json.ConstantExpression)nst.Elements[0]).Value == true);
     }
 
@@ -459,7 +459,7 @@ public class ExpressionTests
             Assert.AreEqual(n, arr.ElementCount);
             Assert.IsTrue(exprs.SequenceEqual(Enumerable.Range(0, n).Select(i => arr.GetElement(i))));
 
-            Assert.AreEqual(n, arr.Elements.Count);
+            Assert.HasCount(n, arr.Elements);
             Assert.IsTrue(exprs.SequenceEqual(arr.Elements));
 
             Assert.Contains("ArrayExpression" + n, arr.GetType().Name);
@@ -479,10 +479,10 @@ public class ExpressionTests
         var o = Json.Expression.Parse(j);
         Assert.AreEqual(Json.ExpressionType.Object, o.NodeType);
         var obj = (Json.ObjectExpression)o;
-        Assert.AreEqual(3, obj.Members.Keys.Count());
+        Assert.HasCount(3, obj.Members.Keys);
         Assert.AreEqual("Bart", (string)((Json.ConstantExpression)obj.Members["Name"]).Value);
         Assert.AreEqual("21", (string)((Json.ConstantExpression)obj.Members["Age"]).Value);
-        Assert.AreEqual(true, (bool)((Json.ConstantExpression)obj.Members["Weird \"Property\" \t\r\n"]).Value);
+        Assert.IsTrue((bool)((Json.ConstantExpression)obj.Members["Weird \"Property\" \t\r\n"]).Value);
     }
 
     [TestMethod]

--- a/Nuqleon/Core/JSON/Tests.Nuqleon.Json/ExpressionTests.cs
+++ b/Nuqleon/Core/JSON/Tests.Nuqleon.Json/ExpressionTests.cs
@@ -61,7 +61,7 @@ public class ExpressionTests
         var t = Json.Expression.Null();
         var j = t.ToString();
         var o = Json.Expression.Parse(j, ensureTopLevelObjectOrArray: false);
-        Assert.IsTrue(o.NodeType == Json.ExpressionType.Null);
+        Assert.AreEqual(Json.ExpressionType.Null, o.NodeType);
 
         Assert.AreSame(Json.Expression.Null(), Json.Expression.Null());
     }
@@ -94,7 +94,7 @@ public class ExpressionTests
         var t = Json.Expression.Number(value: null);
         var j = t.ToString();
         var o = Json.Expression.Parse(j, ensureTopLevelObjectOrArray: false);
-        Assert.IsTrue(o.NodeType == Json.ExpressionType.Null);
+        Assert.AreEqual(Json.ExpressionType.Null, o.NodeType);
     }
 
     [TestMethod]
@@ -146,7 +146,7 @@ public class ExpressionTests
         var t = Json.Expression.String(s);
         var j = t.ToString();
         var o = Json.Expression.Parse(j, ensureTopLevelObjectOrArray: false);
-        Assert.IsTrue(o.NodeType == Json.ExpressionType.Null);
+        Assert.AreEqual(Json.ExpressionType.Null, o.NodeType);
     }
 
     [TestMethod]
@@ -168,15 +168,15 @@ public class ExpressionTests
         var t = Json.Expression.Array();
         var j = t.ToString();
         var o = Json.Expression.Parse(j);
-        Assert.IsTrue(o.NodeType == Json.ExpressionType.Array);
+        Assert.AreEqual(Json.ExpressionType.Array, o.NodeType);
 
         foreach (var arr in new[] { t, (Json.ArrayExpression)o })
         {
             Assert.ThrowsExactly<ArgumentOutOfRangeException>(() => arr.GetElement(-1));
             Assert.ThrowsExactly<ArgumentOutOfRangeException>(() => arr.GetElement(0));
 
-            Assert.IsTrue(arr.ElementCount == 0);
-            Assert.IsTrue(arr.Elements.Count == 0);
+            Assert.AreEqual(0, arr.ElementCount);
+            Assert.IsEmpty(arr.Elements);
         }
     }
 
@@ -186,7 +186,7 @@ public class ExpressionTests
         var t = Json.Expression.Array(Json.Expression.Number("1"));
         var j = t.ToString();
         var o = Json.Expression.Parse(j);
-        Assert.IsTrue(o.NodeType == Json.ExpressionType.Array);
+        Assert.AreEqual(Json.ExpressionType.Array, o.NodeType);
 
         foreach (var arr in new[] { t, (Json.ArrayExpression)o })
         {
@@ -195,12 +195,12 @@ public class ExpressionTests
 
             for (var k = 0; k < 2; k++) // Twice to check before/after Elements allocation.
             {
-                Assert.IsTrue(arr.ElementCount == 1);
+                Assert.AreEqual(1, arr.ElementCount);
                 var elements = Enumerable.Range(0, 1).Select(arr.GetElement).ToArray();
                 Assert.IsTrue(elements.SequenceEqual(arr.Elements /* will allocate */));
             }
 
-            Assert.IsTrue(arr.Elements.Count == 1);
+            Assert.AreEqual(1, arr.Elements.Count);
             Assert.IsTrue(arr.Elements[0].NodeType == Json.ExpressionType.Number && (string)((Json.ConstantExpression)arr.Elements[0]).Value == "1");
 
             var i = arr.ToString();
@@ -214,7 +214,7 @@ public class ExpressionTests
         var t = Json.Expression.Array(Json.Expression.Number("1"), Json.Expression.Boolean(true));
         var j = t.ToString();
         var o = Json.Expression.Parse(j);
-        Assert.IsTrue(o.NodeType == Json.ExpressionType.Array);
+        Assert.AreEqual(Json.ExpressionType.Array, o.NodeType);
 
         foreach (var arr in new[] { t, (Json.ArrayExpression)o })
         {
@@ -223,12 +223,12 @@ public class ExpressionTests
 
             for (var k = 0; k < 2; k++) // Twice to check before/after Elements allocation.
             {
-                Assert.IsTrue(arr.ElementCount == 2);
+                Assert.AreEqual(2, arr.ElementCount);
                 var elements = Enumerable.Range(0, 2).Select(arr.GetElement).ToArray();
                 Assert.IsTrue(elements.SequenceEqual(arr.Elements /* will allocate */));
             }
 
-            Assert.IsTrue(arr.Elements.Count == 2);
+            Assert.AreEqual(2, arr.Elements.Count);
             Assert.IsTrue(arr.Elements[0].NodeType == Json.ExpressionType.Number && (string)((Json.ConstantExpression)arr.Elements[0]).Value == "1");
             Assert.IsTrue(arr.Elements[1].NodeType == Json.ExpressionType.Boolean && (bool)((Json.ConstantExpression)arr.Elements[1]).Value == true);
 
@@ -243,7 +243,7 @@ public class ExpressionTests
         var t = Json.Expression.Array(Json.Expression.Number("1"), Json.Expression.Boolean(true), Json.Expression.String("Hello"));
         var j = t.ToString();
         var o = Json.Expression.Parse(j);
-        Assert.IsTrue(o.NodeType == Json.ExpressionType.Array);
+        Assert.AreEqual(Json.ExpressionType.Array, o.NodeType);
 
         foreach (var arr in new[] { t, (Json.ArrayExpression)o })
         {
@@ -252,12 +252,12 @@ public class ExpressionTests
 
             for (var k = 0; k < 2; k++) // Twice to check before/after Elements allocation.
             {
-                Assert.IsTrue(arr.ElementCount == 3);
+                Assert.AreEqual(3, arr.ElementCount);
                 var elements = Enumerable.Range(0, 3).Select(arr.GetElement).ToArray();
                 Assert.IsTrue(elements.SequenceEqual(arr.Elements /* will allocate */));
             }
 
-            Assert.IsTrue(arr.Elements.Count == 3);
+            Assert.AreEqual(3, arr.Elements.Count);
             Assert.IsTrue(arr.Elements[0].NodeType == Json.ExpressionType.Number && (string)((Json.ConstantExpression)arr.Elements[0]).Value == "1");
             Assert.IsTrue(arr.Elements[1].NodeType == Json.ExpressionType.Boolean && (bool)((Json.ConstantExpression)arr.Elements[1]).Value == true);
             Assert.IsTrue(arr.Elements[2].NodeType == Json.ExpressionType.String && (string)((Json.ConstantExpression)arr.Elements[2]).Value == "Hello");
@@ -273,7 +273,7 @@ public class ExpressionTests
         var t = Json.Expression.Array(Json.Expression.Number("1"), Json.Expression.Boolean(true), Json.Expression.String("Hello"), Json.Expression.Null());
         var j = t.ToString();
         var o = Json.Expression.Parse(j);
-        Assert.IsTrue(o.NodeType == Json.ExpressionType.Array);
+        Assert.AreEqual(Json.ExpressionType.Array, o.NodeType);
 
         foreach (var arr in new[] { t, (Json.ArrayExpression)o })
         {
@@ -282,16 +282,16 @@ public class ExpressionTests
 
             for (var k = 0; k < 2; k++) // Twice to check before/after Elements allocation.
             {
-                Assert.IsTrue(arr.ElementCount == 4);
+                Assert.AreEqual(4, arr.ElementCount);
                 var elements = Enumerable.Range(0, 4).Select(arr.GetElement).ToArray();
                 Assert.IsTrue(elements.SequenceEqual(arr.Elements /* will allocate */));
             }
 
-            Assert.IsTrue(arr.Elements.Count == 4);
+            Assert.AreEqual(4, arr.Elements.Count);
             Assert.IsTrue(arr.Elements[0].NodeType == Json.ExpressionType.Number && (string)((Json.ConstantExpression)arr.Elements[0]).Value == "1");
             Assert.IsTrue(arr.Elements[1].NodeType == Json.ExpressionType.Boolean && (bool)((Json.ConstantExpression)arr.Elements[1]).Value == true);
             Assert.IsTrue(arr.Elements[2].NodeType == Json.ExpressionType.String && (string)((Json.ConstantExpression)arr.Elements[2]).Value == "Hello");
-            Assert.IsTrue(arr.Elements[3].NodeType == Json.ExpressionType.Null);
+            Assert.AreEqual(Json.ExpressionType.Null, arr.Elements[3].NodeType);
 
             var i = arr.ToString();
             Assert.AreEqual(j, i);
@@ -304,7 +304,7 @@ public class ExpressionTests
         var t = Json.Expression.Array(Json.Expression.Number("1"), Json.Expression.Boolean(true), Json.Expression.String("Hello"), Json.Expression.Null(), Json.Expression.Number("2"));
         var j = t.ToString();
         var o = Json.Expression.Parse(j);
-        Assert.IsTrue(o.NodeType == Json.ExpressionType.Array);
+        Assert.AreEqual(Json.ExpressionType.Array, o.NodeType);
 
         foreach (var arr in new[] { t, (Json.ArrayExpression)o })
         {
@@ -313,16 +313,16 @@ public class ExpressionTests
 
             for (var k = 0; k < 2; k++) // Twice to check before/after Elements allocation.
             {
-                Assert.IsTrue(arr.ElementCount == 5);
+                Assert.AreEqual(5, arr.ElementCount);
                 var elements = Enumerable.Range(0, 5).Select(arr.GetElement).ToArray();
                 Assert.IsTrue(elements.SequenceEqual(arr.Elements /* will allocate */));
             }
 
-            Assert.IsTrue(arr.Elements.Count == 5);
+            Assert.AreEqual(5, arr.Elements.Count);
             Assert.IsTrue(arr.Elements[0].NodeType == Json.ExpressionType.Number && (string)((Json.ConstantExpression)arr.Elements[0]).Value == "1");
             Assert.IsTrue(arr.Elements[1].NodeType == Json.ExpressionType.Boolean && (bool)((Json.ConstantExpression)arr.Elements[1]).Value == true);
             Assert.IsTrue(arr.Elements[2].NodeType == Json.ExpressionType.String && (string)((Json.ConstantExpression)arr.Elements[2]).Value == "Hello");
-            Assert.IsTrue(arr.Elements[3].NodeType == Json.ExpressionType.Null);
+            Assert.AreEqual(Json.ExpressionType.Null, arr.Elements[3].NodeType);
             Assert.IsTrue(arr.Elements[4].NodeType == Json.ExpressionType.Number && (string)((Json.ConstantExpression)arr.Elements[4]).Value == "2");
 
             var i = arr.ToString();
@@ -336,7 +336,7 @@ public class ExpressionTests
         var t = Json.Expression.Array(Json.Expression.Number("1"), Json.Expression.Boolean(true), Json.Expression.String("Hello"), Json.Expression.Null(), Json.Expression.Number("2"), Json.Expression.Boolean(false));
         var j = t.ToString();
         var o = Json.Expression.Parse(j);
-        Assert.IsTrue(o.NodeType == Json.ExpressionType.Array);
+        Assert.AreEqual(Json.ExpressionType.Array, o.NodeType);
 
         foreach (var arr in new[] { t, (Json.ArrayExpression)o })
         {
@@ -345,16 +345,16 @@ public class ExpressionTests
 
             for (var k = 0; k < 2; k++) // Twice to check before/after Elements allocation.
             {
-                Assert.IsTrue(arr.ElementCount == 6);
+                Assert.AreEqual(6, arr.ElementCount);
                 var elements = Enumerable.Range(0, 6).Select(arr.GetElement).ToArray();
                 Assert.IsTrue(elements.SequenceEqual(arr.Elements /* will allocate */));
             }
 
-            Assert.IsTrue(arr.Elements.Count == 6);
+            Assert.AreEqual(6, arr.Elements.Count);
             Assert.IsTrue(arr.Elements[0].NodeType == Json.ExpressionType.Number && (string)((Json.ConstantExpression)arr.Elements[0]).Value == "1");
             Assert.IsTrue(arr.Elements[1].NodeType == Json.ExpressionType.Boolean && (bool)((Json.ConstantExpression)arr.Elements[1]).Value == true);
             Assert.IsTrue(arr.Elements[2].NodeType == Json.ExpressionType.String && (string)((Json.ConstantExpression)arr.Elements[2]).Value == "Hello");
-            Assert.IsTrue(arr.Elements[3].NodeType == Json.ExpressionType.Null);
+            Assert.AreEqual(Json.ExpressionType.Null, arr.Elements[3].NodeType);
             Assert.IsTrue(arr.Elements[4].NodeType == Json.ExpressionType.Number && (string)((Json.ConstantExpression)arr.Elements[4]).Value == "2");
             Assert.IsTrue(arr.Elements[5].NodeType == Json.ExpressionType.Boolean && (bool)((Json.ConstantExpression)arr.Elements[5]).Value == false);
 
@@ -369,7 +369,7 @@ public class ExpressionTests
         var t = Json.Expression.Array(Json.Expression.Number("1"), Json.Expression.Boolean(true), Json.Expression.String("Hello"), Json.Expression.Null(), Json.Expression.Number("2"), Json.Expression.Boolean(false), Json.Expression.Null());
         var j = t.ToString();
         var o = Json.Expression.Parse(j);
-        Assert.IsTrue(o.NodeType == Json.ExpressionType.Array);
+        Assert.AreEqual(Json.ExpressionType.Array, o.NodeType);
 
         foreach (var arr in new[] { t, (Json.ArrayExpression)o })
         {
@@ -378,19 +378,19 @@ public class ExpressionTests
 
             for (var k = 0; k < 2; k++) // Twice for consistency with other tests above.
             {
-                Assert.IsTrue(arr.ElementCount == 7);
+                Assert.AreEqual(7, arr.ElementCount);
                 var elements = Enumerable.Range(0, 7).Select(arr.GetElement).ToArray();
                 Assert.IsTrue(elements.SequenceEqual(arr.Elements));
             }
 
-            Assert.IsTrue(arr.Elements.Count == 7);
+            Assert.AreEqual(7, arr.Elements.Count);
             Assert.IsTrue(arr.Elements[0].NodeType == Json.ExpressionType.Number && (string)((Json.ConstantExpression)arr.Elements[0]).Value == "1");
             Assert.IsTrue(arr.Elements[1].NodeType == Json.ExpressionType.Boolean && (bool)((Json.ConstantExpression)arr.Elements[1]).Value == true);
             Assert.IsTrue(arr.Elements[2].NodeType == Json.ExpressionType.String && (string)((Json.ConstantExpression)arr.Elements[2]).Value == "Hello");
-            Assert.IsTrue(arr.Elements[3].NodeType == Json.ExpressionType.Null);
+            Assert.AreEqual(Json.ExpressionType.Null, arr.Elements[3].NodeType);
             Assert.IsTrue(arr.Elements[4].NodeType == Json.ExpressionType.Number && (string)((Json.ConstantExpression)arr.Elements[4]).Value == "2");
             Assert.IsTrue(arr.Elements[5].NodeType == Json.ExpressionType.Boolean && (bool)((Json.ConstantExpression)arr.Elements[5]).Value == false);
-            Assert.IsTrue(arr.Elements[6].NodeType == Json.ExpressionType.Null);
+            Assert.AreEqual(Json.ExpressionType.Null, arr.Elements[6].NodeType);
 
             var i = arr.ToString();
             Assert.AreEqual(j, i);
@@ -403,12 +403,12 @@ public class ExpressionTests
         var t = Json.Expression.Array(Json.Expression.Array(Json.Expression.Boolean(true)));
         var j = t.ToString();
         var o = Json.Expression.Parse(j);
-        Assert.IsTrue(o.NodeType == Json.ExpressionType.Array);
+        Assert.AreEqual(Json.ExpressionType.Array, o.NodeType);
         var arr = (Json.ArrayExpression)o;
-        Assert.IsTrue(arr.Elements.Count == 1);
-        Assert.IsTrue(arr.Elements[0].NodeType == Json.ExpressionType.Array);
+        Assert.AreEqual(1, arr.Elements.Count);
+        Assert.AreEqual(Json.ExpressionType.Array, arr.Elements[0].NodeType);
         var nst = (Json.ArrayExpression)arr.Elements[0];
-        Assert.IsTrue(nst.Elements.Count == 1);
+        Assert.AreEqual(1, nst.Elements.Count);
         Assert.IsTrue(nst.Elements[0].NodeType == Json.ExpressionType.Boolean && (bool)((Json.ConstantExpression)nst.Elements[0]).Value == true);
     }
 
@@ -420,8 +420,8 @@ public class ExpressionTests
         var arr2 = Json.Expression.Array(new List<Json.Expression>());
         var arr3 = Json.Expression.Array(Enumerable.Empty<Json.Expression>());
 
-        Assert.IsTrue(arr0.ElementCount == 0);
-        Assert.IsTrue(arr0.Elements.Count == 0);
+        Assert.AreEqual(0, arr0.ElementCount);
+        Assert.IsEmpty(arr0.Elements);
 
         Assert.AreSame(arr0, arr1);
         Assert.AreSame(arr0, arr2);
@@ -456,13 +456,13 @@ public class ExpressionTests
 
         foreach (var arr in new[] { arr1, arr2, arr3 })
         {
-            Assert.IsTrue(arr.ElementCount == n);
+            Assert.AreEqual(n, arr.ElementCount);
             Assert.IsTrue(exprs.SequenceEqual(Enumerable.Range(0, n).Select(i => arr.GetElement(i))));
 
-            Assert.IsTrue(arr.Elements.Count == n);
+            Assert.AreEqual(n, arr.Elements.Count);
             Assert.IsTrue(exprs.SequenceEqual(arr.Elements));
 
-            Assert.IsTrue(arr.GetType().Name.Contains("ArrayExpression" + n));
+            Assert.Contains("ArrayExpression" + n, arr.GetType().Name);
         }
     }
 
@@ -477,12 +477,12 @@ public class ExpressionTests
         });
         var j = t.ToString();
         var o = Json.Expression.Parse(j);
-        Assert.IsTrue(o.NodeType == Json.ExpressionType.Object);
+        Assert.AreEqual(Json.ExpressionType.Object, o.NodeType);
         var obj = (Json.ObjectExpression)o;
-        Assert.IsTrue(obj.Members.Keys.Count() == 3);
-        Assert.IsTrue((string)((Json.ConstantExpression)obj.Members["Name"]).Value == "Bart");
-        Assert.IsTrue((string)((Json.ConstantExpression)obj.Members["Age"]).Value == "21");
-        Assert.IsTrue((bool)((Json.ConstantExpression)obj.Members["Weird \"Property\" \t\r\n"]).Value == true);
+        Assert.AreEqual(3, obj.Members.Keys.Count());
+        Assert.AreEqual("Bart", (string)((Json.ConstantExpression)obj.Members["Name"]).Value);
+        Assert.AreEqual("21", (string)((Json.ConstantExpression)obj.Members["Age"]).Value);
+        Assert.AreEqual(true, (bool)((Json.ConstantExpression)obj.Members["Weird \"Property\" \t\r\n"]).Value);
     }
 
     [TestMethod]

--- a/Nuqleon/Core/JSON/Tests.Nuqleon.Json/Json.cs
+++ b/Nuqleon/Core/JSON/Tests.Nuqleon.Json/Json.cs
@@ -23,7 +23,7 @@ public class JsonTests
         var t = Json.Expression.Null();
         var j = t.ToString();
         var o = Json.Expression.Parse(j, ensureTopLevelObjectOrArray: false);
-        Assert.IsTrue(o.NodeType == Json.ExpressionType.Null);
+        Assert.AreEqual(Json.ExpressionType.Null, o.NodeType);
     }
 
     [TestMethod]
@@ -72,7 +72,7 @@ public class JsonTests
         var t = Json.Expression.String(s);
         var j = t.ToString();
         var o = Json.Expression.Parse(j, ensureTopLevelObjectOrArray: false);
-        Assert.IsTrue(o.NodeType == Json.ExpressionType.Null);
+        Assert.AreEqual(Json.ExpressionType.Null, o.NodeType);
     }
 
     [TestMethod]
@@ -90,9 +90,9 @@ public class JsonTests
         var t = Json.Expression.Array(Json.Expression.Number("1"));
         var j = t.ToString();
         var o = Json.Expression.Parse(j);
-        Assert.IsTrue(o.NodeType == Json.ExpressionType.Array);
+        Assert.AreEqual(Json.ExpressionType.Array, o.NodeType);
         var arr = (Json.ArrayExpression)o;
-        Assert.IsTrue(arr.Elements.Count == 1);
+        Assert.AreEqual(1, arr.Elements.Count);
         Assert.IsTrue(arr.Elements[0].NodeType == Json.ExpressionType.Number && (string)((Json.ConstantExpression)arr.Elements[0]).Value == "1");
     }
 
@@ -102,9 +102,9 @@ public class JsonTests
         var t = Json.Expression.Array(Json.Expression.Number("1"), Json.Expression.Boolean(true), Json.Expression.String("Hello"));
         var j = t.ToString();
         var o = Json.Expression.Parse(j);
-        Assert.IsTrue(o.NodeType == Json.ExpressionType.Array);
+        Assert.AreEqual(Json.ExpressionType.Array, o.NodeType);
         var arr = (Json.ArrayExpression)o;
-        Assert.IsTrue(arr.Elements.Count == 3);
+        Assert.AreEqual(3, arr.Elements.Count);
         Assert.IsTrue(arr.Elements[0].NodeType == Json.ExpressionType.Number && (string)((Json.ConstantExpression)arr.Elements[0]).Value == "1");
         Assert.IsTrue(arr.Elements[1].NodeType == Json.ExpressionType.Boolean && (bool)((Json.ConstantExpression)arr.Elements[1]).Value == true);
         Assert.IsTrue(arr.Elements[2].NodeType == Json.ExpressionType.String && (string)((Json.ConstantExpression)arr.Elements[2]).Value == "Hello");
@@ -116,12 +116,12 @@ public class JsonTests
         var t = Json.Expression.Array(Json.Expression.Array(Json.Expression.Boolean(true)));
         var j = t.ToString();
         var o = Json.Expression.Parse(j);
-        Assert.IsTrue(o.NodeType == Json.ExpressionType.Array);
+        Assert.AreEqual(Json.ExpressionType.Array, o.NodeType);
         var arr = (Json.ArrayExpression)o;
-        Assert.IsTrue(arr.Elements.Count == 1);
-        Assert.IsTrue(arr.Elements[0].NodeType == Json.ExpressionType.Array);
+        Assert.AreEqual(1, arr.Elements.Count);
+        Assert.AreEqual(Json.ExpressionType.Array, arr.Elements[0].NodeType);
         var nst = (Json.ArrayExpression)arr.Elements[0];
-        Assert.IsTrue(nst.Elements.Count == 1);
+        Assert.AreEqual(1, nst.Elements.Count);
         Assert.IsTrue(nst.Elements[0].NodeType == Json.ExpressionType.Boolean && (bool)((Json.ConstantExpression)nst.Elements[0]).Value == true);
     }
 
@@ -136,13 +136,13 @@ public class JsonTests
         });
         var j = t.ToString();
         var o = Json.Expression.Parse(j);
-        Assert.IsTrue(o.NodeType == Json.ExpressionType.Object);
+        Assert.AreEqual(Json.ExpressionType.Object, o.NodeType);
         var obj = (Json.ObjectExpression)o;
 
-        Assert.IsTrue(obj.Members.Keys.Count() == 3);
-        Assert.IsTrue((string)((Json.ConstantExpression)obj.Members["Name"]).Value == "Bart");
-        Assert.IsTrue((string)((Json.ConstantExpression)obj.Members["Age"]).Value == "21");
-        Assert.IsTrue((bool)((Json.ConstantExpression)obj.Members["Weird \"Property\" \t\r\n"]).Value == true);
+        Assert.AreEqual(3, obj.Members.Keys.Count());
+        Assert.AreEqual("Bart", (string)((Json.ConstantExpression)obj.Members["Name"]).Value);
+        Assert.AreEqual("21", (string)((Json.ConstantExpression)obj.Members["Age"]).Value);
+        Assert.AreEqual(true, (bool)((Json.ConstantExpression)obj.Members["Weird \"Property\" \t\r\n"]).Value);
     }
 
 #pragma warning restore IDE0100 // Remove redundant equality

--- a/Nuqleon/Core/JSON/Tests.Nuqleon.Json/Json.cs
+++ b/Nuqleon/Core/JSON/Tests.Nuqleon.Json/Json.cs
@@ -92,7 +92,7 @@ public class JsonTests
         var o = Json.Expression.Parse(j);
         Assert.AreEqual(Json.ExpressionType.Array, o.NodeType);
         var arr = (Json.ArrayExpression)o;
-        Assert.AreEqual(1, arr.Elements.Count);
+        Assert.HasCount(1, arr.Elements);
         Assert.IsTrue(arr.Elements[0].NodeType == Json.ExpressionType.Number && (string)((Json.ConstantExpression)arr.Elements[0]).Value == "1");
     }
 
@@ -104,7 +104,7 @@ public class JsonTests
         var o = Json.Expression.Parse(j);
         Assert.AreEqual(Json.ExpressionType.Array, o.NodeType);
         var arr = (Json.ArrayExpression)o;
-        Assert.AreEqual(3, arr.Elements.Count);
+        Assert.HasCount(3, arr.Elements);
         Assert.IsTrue(arr.Elements[0].NodeType == Json.ExpressionType.Number && (string)((Json.ConstantExpression)arr.Elements[0]).Value == "1");
         Assert.IsTrue(arr.Elements[1].NodeType == Json.ExpressionType.Boolean && (bool)((Json.ConstantExpression)arr.Elements[1]).Value == true);
         Assert.IsTrue(arr.Elements[2].NodeType == Json.ExpressionType.String && (string)((Json.ConstantExpression)arr.Elements[2]).Value == "Hello");
@@ -118,10 +118,10 @@ public class JsonTests
         var o = Json.Expression.Parse(j);
         Assert.AreEqual(Json.ExpressionType.Array, o.NodeType);
         var arr = (Json.ArrayExpression)o;
-        Assert.AreEqual(1, arr.Elements.Count);
+        Assert.HasCount(1, arr.Elements);
         Assert.AreEqual(Json.ExpressionType.Array, arr.Elements[0].NodeType);
         var nst = (Json.ArrayExpression)arr.Elements[0];
-        Assert.AreEqual(1, nst.Elements.Count);
+        Assert.HasCount(1, nst.Elements);
         Assert.IsTrue(nst.Elements[0].NodeType == Json.ExpressionType.Boolean && (bool)((Json.ConstantExpression)nst.Elements[0]).Value == true);
     }
 
@@ -139,10 +139,10 @@ public class JsonTests
         Assert.AreEqual(Json.ExpressionType.Object, o.NodeType);
         var obj = (Json.ObjectExpression)o;
 
-        Assert.AreEqual(3, obj.Members.Keys.Count());
+        Assert.HasCount(3, obj.Members.Keys);
         Assert.AreEqual("Bart", (string)((Json.ConstantExpression)obj.Members["Name"]).Value);
         Assert.AreEqual("21", (string)((Json.ConstantExpression)obj.Members["Age"]).Value);
-        Assert.AreEqual(true, (bool)((Json.ConstantExpression)obj.Members["Weird \"Property\" \t\r\n"]).Value);
+        Assert.IsTrue((bool)((Json.ConstantExpression)obj.Members["Weird \"Property\" \t\r\n"]).Value);
     }
 
 #pragma warning restore IDE0100 // Remove redundant equality

--- a/Nuqleon/Core/JSON/Tests.Nuqleon.Json/SerializerTests.cs
+++ b/Nuqleon/Core/JSON/Tests.Nuqleon.Json/SerializerTests.cs
@@ -175,9 +175,9 @@ public class SerializerTests
         var d = ys as IList;
         Assert.IsNotNull(d);
 
-        Assert.IsTrue(int.Parse((string)d[0]) == 1); // TODO: by design?
-        Assert.IsTrue(int.Parse((string)d[1]) == 2);
-        Assert.IsTrue(int.Parse((string)d[2]) == 3);
+        Assert.AreEqual(1, int.Parse((string)d[0])); // TODO: by design?
+        Assert.AreEqual(2, int.Parse((string)d[1]));
+        Assert.AreEqual(3, int.Parse((string)d[2]));
     }
 
     [TestMethod]
@@ -283,8 +283,8 @@ public class SerializerTests
         var d = q as Dictionary<string, object>;
         Assert.IsNotNull(d);
 
-        Assert.IsTrue(int.Parse((string)d["Age"]) == 21); // TODO: by design?
-        Assert.IsTrue((string)d["Name"] == "Bart");
+        Assert.AreEqual(21, int.Parse((string)d["Age"])); // TODO: by design?
+        Assert.AreEqual("Bart", (string)d["Name"]);
     }
 
     [TestMethod]

--- a/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.CompilerServices/CollectionExtensionsTests.cs
+++ b/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.CompilerServices/CollectionExtensionsTests.cs
@@ -53,15 +53,15 @@ public class CollectionExtensionsTests
         var xs = new List<int> { 2, 3, 5 };
 
         var ro = xs.ToReadOnly();
-        Assert.AreEqual(3, ro.Count);
+        Assert.HasCount(3, ro);
         Assert.IsTrue(new[] { 2, 3, 5 }.SequenceEqual(ro));
 
         xs.Add(7);
-        Assert.AreEqual(3, ro.Count);
+        Assert.HasCount(3, ro);
         Assert.IsTrue(new[] { 2, 3, 5 }.SequenceEqual(ro));
 
         xs.Clear();
-        Assert.AreEqual(3, ro.Count);
+        Assert.HasCount(3, ro);
         Assert.IsTrue(new[] { 2, 3, 5 }.SequenceEqual(ro));
     }
 
@@ -72,15 +72,15 @@ public class CollectionExtensionsTests
         var ys = xs.Select(x => x);
 
         var ro = ys.ToReadOnly();
-        Assert.AreEqual(3, ro.Count);
+        Assert.HasCount(3, ro);
         Assert.IsTrue(new[] { 2, 3, 5 }.SequenceEqual(ro));
 
         xs.Add(7);
-        Assert.AreEqual(3, ro.Count);
+        Assert.HasCount(3, ro);
         Assert.IsTrue(new[] { 2, 3, 5 }.SequenceEqual(ro));
 
         xs.Clear();
-        Assert.AreEqual(3, ro.Count);
+        Assert.HasCount(3, ro);
         Assert.IsTrue(new[] { 2, 3, 5 }.SequenceEqual(ro));
     }
 
@@ -126,7 +126,7 @@ public class CollectionExtensionsTests
 
         var ys = CollectionExtensions.AsArray(xs);
 
-        Assert.AreEqual(0, ys.Length);
+        Assert.IsEmpty(ys);
     }
 
     [TestMethod]
@@ -156,7 +156,7 @@ public class CollectionExtensionsTests
 
         var ys = CollectionExtensions.AsCollection(xs);
 
-        Assert.AreEqual(0, ys.Count);
+        Assert.IsEmpty(ys);
     }
 
     [TestMethod]
@@ -206,6 +206,6 @@ public class CollectionExtensionsTests
 
     private static void AssertEmpty<T>(ReadOnlyCollection<T> c)
     {
-        Assert.AreEqual(0, c.Count);
+        Assert.IsEmpty(c);
     }
 }

--- a/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.CompilerServices/Collections/IndexedTests.cs
+++ b/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.CompilerServices/Collections/IndexedTests.cs
@@ -29,7 +29,9 @@ public class IndexedTests
         AssertNotEqual(i1, i4);
         AssertNotEqual(i2, i4);
 
+#pragma warning disable MSTEST0037 // The suggested 'Assert.IsNotNull' is always-true here (MSTEST0032): Indexed<T> is a value type. Keep AreNotEqual to exercise boxed inequality against null.
         Assert.AreNotEqual<object>(null, i1);
+#pragma warning restore MSTEST0037
         Assert.AreNotEqual<object>("foo", i1);
     }
 

--- a/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.CompilerServices/Collections/TreeTests.cs
+++ b/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.CompilerServices/Collections/TreeTests.cs
@@ -37,8 +37,8 @@ public class TreeTests
 
         Assert.AreEqual(42, tree.Value);
         Assert.AreEqual(42, ((ITree)tree).Value);
-        Assert.AreEqual(0, tree.Children.Count);
-        Assert.AreEqual(0, ((ITree)tree).Children.Count);
+        Assert.IsEmpty(tree.Children);
+        Assert.IsEmpty(((ITree)tree).Children);
 
         Assert.AreEqual("42()", tree.ToString());
         Assert.AreEqual("42()", tree.ToString(indent: 0));
@@ -50,7 +50,7 @@ public class TreeTests
         var tree = new Tree<string>(value: null);
 
         Assert.IsNull(tree.Value);
-        Assert.AreEqual(0, tree.Children.Count);
+        Assert.IsEmpty(tree.Children);
 
         Assert.AreEqual("<null>()", tree.ToString());
         Assert.AreEqual("<null>()", tree.ToString(indent: 0));
@@ -73,12 +73,12 @@ public class TreeTests
         Assert.AreEqual(43, leaf2.Value);
         Assert.AreEqual(42, leaf1.Value);
 
-        Assert.AreEqual(1, node3.Children.Count);
-        Assert.AreEqual(2, node2.Children.Count);
-        Assert.AreEqual(2, node1.Children.Count);
-        Assert.AreEqual(0, leaf3.Children.Count);
-        Assert.AreEqual(0, leaf2.Children.Count);
-        Assert.AreEqual(0, leaf1.Children.Count);
+        Assert.HasCount(1, node3.Children);
+        Assert.HasCount(2, node2.Children);
+        Assert.HasCount(2, node1.Children);
+        Assert.IsEmpty(leaf3.Children);
+        Assert.IsEmpty(leaf2.Children);
+        Assert.IsEmpty(leaf1.Children);
 
         Assert.IsTrue(new[] { node2 }.SequenceEqual(node3.Children));
         Assert.IsTrue(new[] { node1, leaf3 }.SequenceEqual(node2.Children));

--- a/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.CompilerServices/Evaluation/EvaluationTests.cs
+++ b/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.CompilerServices/Evaluation/EvaluationTests.cs
@@ -327,7 +327,7 @@ public class EvaluationTests
 
         var del = Expression.Lambda(exp).Compile(new SimpleCompiledDelegateCache());
 
-        Assert.AreEqual(17, ((Array)del.DynamicInvoke()).Length);
+        Assert.HasCount(17, (Array)del.DynamicInvoke());
     }
 
     [TestMethod]

--- a/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.CompilerServices/Expressions/Analysis/FreeVariableScannerTests.cs
+++ b/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.CompilerServices/Expressions/Analysis/FreeVariableScannerTests.cs
@@ -32,7 +32,7 @@ public class FreeVariableScannerTests
         var e = Expression.Constant(42);
 
         var res = FreeVariableScanner.Scan(e);
-        Assert.AreEqual(0, res.Count());
+        Assert.IsEmpty(res);
 
         Assert.IsFalse(FreeVariableScanner.HasFreeVariables(e));
     }
@@ -54,7 +54,7 @@ public class FreeVariableScannerTests
         var e = (Expression<Func<int, int>>)(x => x);
 
         var res = FreeVariableScanner.Scan(e);
-        Assert.AreEqual(0, res.Count());
+        Assert.IsEmpty(res);
 
         Assert.IsFalse(FreeVariableScanner.HasFreeVariables(e));
     }
@@ -65,7 +65,7 @@ public class FreeVariableScannerTests
         var e = (Expression<Func<int, Func<int, int>>>)(x => y => x + y);
 
         var res = FreeVariableScanner.Scan(e);
-        Assert.AreEqual(0, res.Count());
+        Assert.IsEmpty(res);
 
         Assert.IsFalse(FreeVariableScanner.HasFreeVariables(e));
     }
@@ -89,7 +89,7 @@ public class FreeVariableScannerTests
         var e = Expression.Block([p], p);
 
         var res = FreeVariableScanner.Scan(e);
-        Assert.AreEqual(0, res.Count());
+        Assert.IsEmpty(res);
 
         Assert.IsFalse(FreeVariableScanner.HasFreeVariables(e));
     }
@@ -115,7 +115,7 @@ public class FreeVariableScannerTests
         var e = Expression.Lambda(Expression.Lambda(p, p), p);
 
         var res = FreeVariableScanner.Scan(e);
-        Assert.AreEqual(0, res.Count());
+        Assert.IsEmpty(res);
 
         Assert.IsFalse(FreeVariableScanner.HasFreeVariables(e));
     }
@@ -130,7 +130,7 @@ public class FreeVariableScannerTests
         var e = Expression.TryCatch(Expression.Call(writeLine, Expression.Constant("Hello")), Expression.Catch(p, Expression.Call(writeLine, Expression.MakeMemberAccess(p, exMessage))));
 
         var res = FreeVariableScanner.Scan(e);
-        Assert.AreEqual(0, res.Count());
+        Assert.IsEmpty(res);
 
         Assert.IsFalse(FreeVariableScanner.HasFreeVariables(e));
     }

--- a/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.CompilerServices/Expressions/ExpressionExtensionsTests.cs
+++ b/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.CompilerServices/Expressions/ExpressionExtensionsTests.cs
@@ -601,7 +601,7 @@ public class ExpressionExtensionsTests
 
         var res = e.ToCSharp();
 
-        Assert.AreEqual(3, res.Constants.Count);
+        Assert.HasCount(3, res.Constants);
         Assert.AreSame(d, res.Constants["__c0"].Value);
         Assert.AreEqual(n, res.Constants["__c1"].Value);
         Assert.AreEqual(n, res.Constants["__c2"].Value);
@@ -818,7 +818,7 @@ public class ExpressionExtensionsTests
 
         var res = e.ToCSharp();
 
-        Assert.AreEqual(1, res.GlobalVariables.Count);
+        Assert.HasCount(1, res.GlobalVariables);
         Assert.AreSame(e, res.GlobalVariables[0]);
     }
 

--- a/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.CompilerServices/Expressions/ExpressionTreeTests.cs
+++ b/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.CompilerServices/Expressions/ExpressionTreeTests.cs
@@ -1105,7 +1105,7 @@ public class ExpressionTreeTests
         var tr = ei.ToExpressionTree();
 
         Assert.AreSame(ei, tr.ElementInit);
-        Assert.AreEqual(1, tr.Children.Count);
+        Assert.HasCount(1, tr.Children);
 
         var ce = tr.Children[0] as ExpressionTree<ConstantExpression>;
         Assert.IsNotNull(ce);
@@ -1172,7 +1172,7 @@ public class ExpressionTreeTests
         Assert.IsNotNull(tr);
 
         Assert.AreSame(ma, tr.MemberAssignment);
-        Assert.AreEqual(1, tr.Children.Count);
+        Assert.HasCount(1, tr.Children);
 
         var ce = tr.Children[0] as ExpressionTree<ConstantExpression>;
         Assert.IsNotNull(ce);
@@ -1265,7 +1265,7 @@ public class ExpressionTreeTests
         Assert.IsNotNull(tr);
 
         Assert.AreSame(mb, tr.MemberMemberBinding);
-        Assert.AreEqual(1, tr.Children.Count);
+        Assert.HasCount(1, tr.Children);
 
         var ma = tr.Children[0] as MemberAssignmentExpressionTree;
         Assert.IsNotNull(ma);
@@ -1362,7 +1362,7 @@ public class ExpressionTreeTests
         Assert.IsNotNull(tr);
 
         Assert.AreSame(lb, tr.MemberListBinding);
-        Assert.AreEqual(1, tr.Children.Count);
+        Assert.HasCount(1, tr.Children);
 
         var ei = tr.Children[0] as ElementInitExpressionTree;
         Assert.IsNotNull(ei);

--- a/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.CompilerServices/Expressions/Rewriters/BURS/BottomUpExpressionRewriterTests.cs
+++ b/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.CompilerServices/Expressions/Rewriters/BURS/BottomUpExpressionRewriterTests.cs
@@ -97,7 +97,7 @@ public class BottomUpExpressionRewriterTests
         var f = new ExpressionTreeWildcardFactory();
         var w = f.CreateWildcard(p);
 
-        Assert.AreEqual(0, w.Children.Count);
+        Assert.IsEmpty(w.Children);
 
         Assert.AreEqual(ExpressionTreeNodeType.Expression, w.Value.NodeType);
         var n = (ExpressionExpressionTreeNode)w.Value;

--- a/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.CompilerServices/Expressions/Rewriters/Misc/ConstantHoisterTests.cs
+++ b/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.CompilerServices/Expressions/Rewriters/Misc/ConstantHoisterTests.cs
@@ -16,8 +16,14 @@ using System.Text.RegularExpressions;
 namespace Tests.System.Linq.CompilerServices;
 
 [TestClass]
-public class ConstantHoisterTests
+public partial class ConstantHoisterTests
 {
+    [GeneratedRegex(@"\<\>f__AnonymousType[\da-fA-F]*")]
+    private static partial Regex AnonymousTypeRegex();
+
+    [GeneratedRegex(@"\<\>h__TransparentIdentifier[\da-fA-F]*")]
+    private static partial Regex TransparentIdentifierRegex();
+
     [TestMethod]
     public void ConstantHoister_ArgumentChecking()
     {
@@ -132,8 +138,8 @@ public class ConstantHoisterTests
         Assert.AreEqual("int @p0 = 1;\r\nint @p1 = 0;\r\nstring @p2 = \"Foo\";\r\nreturn (IEnumerable<int> xs) => xs.Select((int x) => new { x, y = x + @p0 }).Where(t => t.y > @p1).Select(t => new { t, s = t.x.ToString() }).Where(t => !t.s.EndsWith(@p2)).Select(t => t.s.Substring(@p1, @p0) + @p2);\r\n", c.ToCSharpString());
 
         var t = c.ToString();
-        var u = Regex.Replace(t, @"\<\>f__AnonymousType[\da-fA-F]*", "anon");
-        var v = Regex.Replace(u, @"\<\>h__TransparentIdentifier[\da-fA-F]*", "tran");
+        var u = AnonymousTypeRegex().Replace(t, "anon");
+        var v = TransparentIdentifierRegex().Replace(u, "tran");
 
         Assert.AreEqual("(xs => xs.Select(x => new anon`2(x = x, y = (x + @p0))).Where(tran => (tran.y > @p1)).Select(tran => new anon`2(tran = tran, s = tran.x.ToString())).Where(tran => Not(tran.s.EndsWith(@p2))).Select(tran => (tran.s.Substring(@p1, @p0) + @p2)))[|@p0 : System.Int32 = 1, @p1 : System.Int32 = 0, @p2 : System.String = \"Foo\"|]", v);
 
@@ -223,7 +229,11 @@ public class ConstantHoisterTests
 #pragma warning restore IDE0034
 
         var e1 = (Expression<Func<string>>)(() => string.Format("{0}:{1}", new object[] { 123, "foo" }));
+        // SYSLIB1045: 'new Regex("abc")' is intentional expression-tree test data (the constant-hoisting
+        // subject); converting it to a [GeneratedRegex] method call would change the tree under test.
+#pragma warning disable SYSLIB1045
         var e2 = (Expression<Func<bool>>)(() => new Regex("abc").IsMatch("bar"));
+#pragma warning restore SYSLIB1045
         var e3 = (Expression<Func<int>>)(() => "qux".Length);
         var e4 = (Expression<Func<string>>)(() => "baz".ToUpper());
         var e5 = (Expression<Func<string>>)(() => string.Concat("bar", "foo"));

--- a/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.CompilerServices/Expressions/Rewriters/Misc/ConstantHoisterTests.cs
+++ b/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.CompilerServices/Expressions/Rewriters/Misc/ConstantHoisterTests.cs
@@ -49,7 +49,7 @@ public class ConstantHoisterTests
         var b = Expression.Constant(new Bar());
         var c = Expression.Equal(b, b);
         var res = HoistAndEval(c);
-        Assert.AreEqual(1, res.Environment.Count);
+        Assert.HasCount(1, res.Environment);
     }
 
     [TestMethod]
@@ -58,7 +58,7 @@ public class ConstantHoisterTests
         var b = Expression.Constant(new Bar());
         var c = Expression.NotEqual(b, b);
         var res = HoistAndEval(c);
-        Assert.AreEqual(1, res.Environment.Count);
+        Assert.HasCount(1, res.Environment);
     }
 
     [TestMethod]
@@ -67,7 +67,7 @@ public class ConstantHoisterTests
         var b = Expression.Constant(new Bar());
         var c = Expression.Call(b, (MethodInfo)ReflectionHelpers.InfoOf((Bar _) => _.Equals(_)), b);
         var res = HoistAndEval(c);
-        Assert.AreEqual(1, res.Environment.Count);
+        Assert.HasCount(1, res.Environment);
     }
 
     [TestMethod]
@@ -75,7 +75,7 @@ public class ConstantHoisterTests
     {
         var e = Expression.Add(Expression.Constant(new Bar()), Expression.Constant(new Foo()));
         var res = ConstantHoister.Hoist(e, useDefaultForNull: false);
-        Assert.AreEqual(2, res.Environment.Count);
+        Assert.HasCount(2, res.Environment);
     }
 
     [TestMethod]
@@ -83,7 +83,7 @@ public class ConstantHoisterTests
     {
         var c = Expression.Constant(value: null, typeof(string));
         var res = ConstantHoister.Hoist(c, useDefaultForNull: false);
-        Assert.AreEqual(1, res.Environment.Count);
+        Assert.HasCount(1, res.Environment);
         var e = res.Environment.Single();
         Assert.AreEqual(c.Type, e.Key.Type);
         Assert.AreEqual(default(string), e.Value);
@@ -94,7 +94,7 @@ public class ConstantHoisterTests
     {
         var c = Expression.Constant(value: null, typeof(int?));
         var res = ConstantHoister.Hoist(c, useDefaultForNull: false);
-        Assert.AreEqual(1, res.Environment.Count);
+        Assert.HasCount(1, res.Environment);
         var e = res.Environment.Single();
         Assert.AreEqual(c.Type, e.Key.Type);
         Assert.AreEqual(default(int?), e.Value);
@@ -105,7 +105,7 @@ public class ConstantHoisterTests
     {
         var c = Expression.Constant(value: null, typeof(string));
         var res = ConstantHoister.Hoist(c, useDefaultForNull: true);
-        Assert.AreEqual(0, res.Environment.Count);
+        Assert.IsEmpty(res.Environment);
         var e = res.Expression as DefaultExpression;
         Assert.IsNotNull(e);
         Assert.AreEqual(c.Type, e.Type);
@@ -121,10 +121,10 @@ public class ConstantHoisterTests
 #pragma warning restore IDE0079
         var c = ConstantHoister.Hoist(e, useDefaultForNull: false);
 
-        Assert.AreEqual(3, c.Environment.Count);
-        Assert.IsTrue(c.Environment.Values.Contains(0));
-        Assert.IsTrue(c.Environment.Values.Contains(1));
-        Assert.IsTrue(c.Environment.Values.Contains("Foo"));
+        Assert.HasCount(3, c.Environment);
+        Assert.Contains(0, c.Environment.Values);
+        Assert.Contains(1, c.Environment.Values);
+        Assert.Contains("Foo", c.Environment.Values);
 
         var i = (Expression)c.ToInvocation();
 
@@ -160,7 +160,7 @@ public class ConstantHoisterTests
         });
         Assert.AreEqual(typeof(ArgumentException), ex.GetType());
 
-        Assert.IsTrue(ex.Message.Contains("not a method call, new, or member access"));
+        Assert.Contains("not a method call, new, or member access", ex.Message);
 
         var ex2 = Assert.ThrowsExactly<ArgumentException>(() =>
         {
@@ -170,7 +170,7 @@ public class ConstantHoisterTests
         });
         Assert.AreEqual(typeof(ArgumentException), ex2.GetType());
 
-        Assert.IsTrue(ex2.Message.Contains("not a constant or a default expression"));
+        Assert.Contains("not a constant or a default expression", ex2.Message);
 
         var ex3 = Assert.ThrowsExactly<ArgumentException>(() =>
         {
@@ -180,7 +180,7 @@ public class ConstantHoisterTests
         });
         Assert.AreEqual(typeof(ArgumentException), ex3.GetType());
 
-        Assert.IsTrue(ex3.Message.Contains("no holes for constants"));
+        Assert.Contains("no holes for constants", ex3.Message);
 
         var ex4 = Assert.ThrowsExactly<ArgumentException>(() =>
         {
@@ -190,7 +190,7 @@ public class ConstantHoisterTests
         });
         Assert.AreEqual(typeof(ArgumentException), ex4.GetType());
 
-        Assert.IsTrue(ex4.Message.Contains("not used"));
+        Assert.Contains("not used", ex4.Message);
 
         var ex5 = Assert.ThrowsExactly<ArgumentException>(() =>
         {
@@ -200,7 +200,7 @@ public class ConstantHoisterTests
         });
         Assert.AreEqual(typeof(ArgumentException), ex5.GetType());
 
-        Assert.IsTrue(ex5.Message.Contains("used multiple times"));
+        Assert.Contains("used multiple times", ex5.Message);
 #pragma warning restore IDE0034 // Simplify 'default' expression
 #pragma warning restore IDE0004 // Cast is redundant.
     }
@@ -234,18 +234,18 @@ public class ConstantHoisterTests
         var r4 = HoistAndEval(hoister, e4.Body);
         var r5 = HoistAndEval(hoister, e5.Body);
 
-        Assert.AreEqual(2, r1.Environment.Count);
-        Assert.IsTrue(r1.Environment.Values.OfType<int>().Any(v => v == 123));
-        Assert.IsTrue(r1.Environment.Values.OfType<string>().Any(v => v == "foo"));
+        Assert.HasCount(2, r1.Environment);
+        Assert.Contains(v => v == 123, r1.Environment.Values.OfType<int>());
+        Assert.Contains(v => v == "foo", r1.Environment.Values.OfType<string>());
 
-        Assert.AreEqual(1, r2.Environment.Count);
-        Assert.IsTrue(r2.Environment.Values.OfType<string>().Any(v => v == "bar"));
+        Assert.HasCount(1, r2.Environment);
+        Assert.Contains(v => v == "bar", r2.Environment.Values.OfType<string>());
 
-        Assert.AreEqual(0, r3.Environment.Count);
+        Assert.IsEmpty(r3.Environment);
 
-        Assert.AreEqual(0, r4.Environment.Count);
+        Assert.IsEmpty(r4.Environment);
 
-        Assert.AreEqual(0, r5.Environment.Count);
+        Assert.IsEmpty(r5.Environment);
     }
 
     [TestMethod]

--- a/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.CompilerServices/Expressions/Rewriters/Misc/ExpressionTupletizerTests.cs
+++ b/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.CompilerServices/Expressions/Rewriters/Misc/ExpressionTupletizerTests.cs
@@ -78,10 +78,10 @@ public class ExpressionTupletizerTests
                 if (u.Type.GetGenericTypeDefinition() == typeof(Tuple<,,,,,,,>))
                 {
                     u = f.Arguments.Last();
-                    Assert.IsTrue(u.Type.Name.StartsWith("Tuple"));
+                    Assert.StartsWith("Tuple", u.Type.Name);
 
                     Assert.IsTrue(f.Members.Take(7).Select(m => m.Name).SequenceEqual(Enumerable.Range(1, 7).Select(j => "Item" + j)));
-                    Assert.IsTrue(f.Members.Last().Name == "Rest");
+                    Assert.AreEqual("Rest", f.Members.Last().Name);
                     n--;
                 }
                 else
@@ -148,7 +148,7 @@ public class ExpressionTupletizerTests
 
                 if (n == 1)
                 {
-                    Assert.IsTrue(g.Parameters[0].Type.FullName.StartsWith("System.Tuple`"), "Parameter type: " + f.ToString());
+                    Assert.StartsWith("System.Tuple`", g.Parameters[0].Type.FullName, "Parameter type: " + f.ToString());
                 }
 
                 var h = ExpressionTupletizer.Unpack(g);
@@ -203,7 +203,7 @@ public class ExpressionTupletizerTests
                 var g = pack(f);
 
                 var n = g.Parameters.Count;
-                Assert.IsTrue(n == 1, "Parameter count: " + f.ToString());
+                Assert.AreEqual(1, n, "Parameter count: " + f.ToString());
 
                 if (n == 1)
                 {
@@ -215,7 +215,7 @@ public class ExpressionTupletizerTests
                     }
                     else
                     {
-                        Assert.IsTrue(p.Type.FullName.StartsWith("System.Tuple`"), "Parameter type: " + f.ToString());
+                        Assert.StartsWith("System.Tuple`", p.Type.FullName, "Parameter type: " + f.ToString());
                     }
                 }
 
@@ -332,7 +332,7 @@ public class ExpressionTupletizerTests
         Assert.AreSame(expression.Parameters, parameters);
 #else
         Assert.IsTrue(new ExpressionEqualityComparer(() => new GlobalParameterSafeComparator()).Equals(expression.Body, body));
-        Assert.AreEqual(0, parameters.Count());
+        Assert.IsEmpty(parameters);
 #endif
 
         Unpack(expression, typeof(void), out body, out parameters);
@@ -341,7 +341,7 @@ public class ExpressionTupletizerTests
         Assert.AreSame(expression.Parameters, parameters);
 #else
         Assert.IsTrue(new ExpressionEqualityComparer(() => new GlobalParameterSafeComparator()).Equals(expression.Body, body));
-        Assert.AreEqual(0, parameters.Count());
+        Assert.IsEmpty(parameters);
 #endif
     }
 
@@ -374,7 +374,7 @@ public class ExpressionTupletizerTests
         var ex = Assert.ThrowsExactly<ArgumentException>(() => Pack([((Expression<Action<string>>)(s => Console.WriteLine(s))).Body]));
         Assert.AreEqual("expressions", ex.ParamName);
 
-        Assert.IsTrue(ex.Message.Contains("WriteLine"));
+        Assert.Contains("WriteLine", ex.Message);
     }
 
     [TestMethod]

--- a/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.CompilerServices/Expressions/Rewriters/Optimization/Interning/ExpressionInterningTests.cs
+++ b/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.CompilerServices/Expressions/Rewriters/Optimization/Interning/ExpressionInterningTests.cs
@@ -1811,7 +1811,7 @@ public class ExpressionInterningTests
 #pragma warning disable MSTEST0055 // Return value should not be ignored. (These are where-clause predicates in expression-tree test data; nothing is discarded.)
         var ys = from x in xs
                  where x > 42 && !(-x < 17)
-                 where x.ToString().StartsWith("a")
+                 where x.ToString().StartsWith('a')
                  where Console.ReadLine().StartsWith("foo")
                  where Environment.MachineName.Length > 1
                  where new int[2].Length <= 3
@@ -1824,7 +1824,7 @@ public class ExpressionInterningTests
 
         var zs = from y in xs
                  where y > 42 && !(-y < 17)
-                 where y.ToString().StartsWith("a")
+                 where y.ToString().StartsWith('a')
                  where Console.ReadLine().StartsWith("foo")
                  where Environment.MachineName.Length > 1
                  where new int[2].Length <= 3

--- a/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.CompilerServices/Expressions/Rewriters/TypeSystem/TypeSubstitutionExpressionVisitorTests.cs
+++ b/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.CompilerServices/Expressions/Rewriters/TypeSystem/TypeSubstitutionExpressionVisitorTests.cs
@@ -952,7 +952,7 @@ public class TypeSubstitutionExpressionVisitorTests
     public void TypeSubstitutionExpressionVisitor_Anonymize()
     {
         var pers = typeof(Person);
-        var query = (Expression<Func<IEnumerable<Person>, IEnumerable<string>>>)(xs => from x in xs where x.Age > 10 let name = x.Name where name.StartsWith("B") select name.ToUpper() + " is " + x.Age);
+        var query = (Expression<Func<IEnumerable<Person>, IEnumerable<string>>>)(xs => from x in xs where x.Age > 10 let name = x.Name where name.StartsWith('B') select name.ToUpper() + " is " + x.Age);
 
         var check1 = new TypeErasureChecker([typeof(Person)]);
         Assert.ThrowsExactly<InvalidOperationException>(() => check1.Visit(query));

--- a/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.CompilerServices/Expressions/UnboundParameterExceptionTests.cs
+++ b/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.CompilerServices/Expressions/UnboundParameterExceptionTests.cs
@@ -33,7 +33,7 @@ public class UnboundParameterExceptionTests
         var e = Expression.Constant(42);
         var p = new[] { Expression.Parameter(typeof(int)) };
         var ex = new UnboundParameterException("Oops", e, p);
-        Assert.IsTrue(ex.Message.StartsWith("Oops"));
+        Assert.StartsWith("Oops", ex.Message);
         Assert.AreSame(e, ex.Expression);
         Assert.IsTrue(p.SequenceEqual(ex.Parameters));
     }

--- a/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.CompilerServices/Reflection/Emit/RuntimeCompilerTests.cs
+++ b/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.CompilerServices/Reflection/Emit/RuntimeCompilerTests.cs
@@ -415,13 +415,19 @@ public class RuntimeCompilerTests
         var props3 = new[] { new StructuralFieldDeclaration("bar", typeof(Bar)) };
 
         Assert.ThrowsExactly<InvalidOperationException>(() => RuntimeCompiler.CreateAnonymousType(props));
-        Assert.ThrowsExactly<InvalidOperationException>(() => { var rtc = new RuntimeCompiler(); var atb = rtc.GetNewAnonymousTypeBuilder(); rtc.DefineAnonymousType(atb, props); });
+        var rtc = new RuntimeCompiler();
+        var atb = rtc.GetNewAnonymousTypeBuilder();
+        Assert.ThrowsExactly<InvalidOperationException>(() => rtc.DefineAnonymousType(atb, props));
 
         Assert.ThrowsExactly<InvalidOperationException>(() => RuntimeCompiler.CreateAnonymousType(props2));
-        Assert.ThrowsExactly<InvalidOperationException>(() => { var rtc = new RuntimeCompiler(); var atb = rtc.GetNewAnonymousTypeBuilder(); rtc.DefineAnonymousType(atb, props2); });
+        rtc = new RuntimeCompiler();
+        atb = rtc.GetNewAnonymousTypeBuilder();
+        Assert.ThrowsExactly<InvalidOperationException>(() => rtc.DefineAnonymousType(atb, props2));
 
         Assert.ThrowsExactly<InvalidOperationException>(() => RuntimeCompiler.CreateAnonymousType(props3));
-        Assert.ThrowsExactly<InvalidOperationException>(() => { var rtc = new RuntimeCompiler(); var atb = rtc.GetNewAnonymousTypeBuilder(); rtc.DefineAnonymousType(atb, props3); });
+        rtc = new RuntimeCompiler();
+        atb = rtc.GetNewAnonymousTypeBuilder();
+        Assert.ThrowsExactly<InvalidOperationException>(() => rtc.DefineAnonymousType(atb, props3));
 
     }
 
@@ -552,7 +558,9 @@ public class RuntimeCompilerTests
         var props = new[] { new KeyValuePair<string, Type>("bar", typeof(Bar)) };
 
         Assert.ThrowsExactly<InvalidOperationException>(() => RuntimeCompiler.CreateClosureType(props));
-        Assert.ThrowsExactly<InvalidOperationException>(() => { var rtc = new RuntimeCompiler(); var atb = rtc.GetNewClosureTypeBuilder(); rtc.DefineClosureType(atb, props); });
+        var rtc = new RuntimeCompiler();
+        var atb = rtc.GetNewClosureTypeBuilder();
+        Assert.ThrowsExactly<InvalidOperationException>(() => rtc.DefineClosureType(atb, props));
     }
 
     #endregion
@@ -737,13 +745,19 @@ public class RuntimeCompilerTests
         var props3 = new[] { new StructuralFieldDeclaration("bar", typeof(Bar)) };
 
         Assert.ThrowsExactly<InvalidOperationException>(() => RuntimeCompiler.CreateRecordType(props, valueEquality: true));
-        Assert.ThrowsExactly<InvalidOperationException>(() => { var rtc = new RuntimeCompiler(); var atb = rtc.GetNewRecordTypeBuilder(); rtc.DefineRecordType(atb, props, valueEquality: true); });
+        var rtc = new RuntimeCompiler();
+        var atb = rtc.GetNewRecordTypeBuilder();
+        Assert.ThrowsExactly<InvalidOperationException>(() => rtc.DefineRecordType(atb, props, valueEquality: true));
 
         Assert.ThrowsExactly<InvalidOperationException>(() => RuntimeCompiler.CreateRecordType(props2, valueEquality: true));
-        Assert.ThrowsExactly<InvalidOperationException>(() => { var rtc = new RuntimeCompiler(); var atb = rtc.GetNewRecordTypeBuilder(); rtc.DefineRecordType(atb, props2, valueEquality: true); });
+        rtc = new RuntimeCompiler();
+        atb = rtc.GetNewRecordTypeBuilder();
+        Assert.ThrowsExactly<InvalidOperationException>(() => rtc.DefineRecordType(atb, props2, valueEquality: true));
 
         Assert.ThrowsExactly<InvalidOperationException>(() => RuntimeCompiler.CreateRecordType(props3, valueEquality: true));
-        Assert.ThrowsExactly<InvalidOperationException>(() => { var rtc = new RuntimeCompiler(); var atb = rtc.GetNewRecordTypeBuilder(); rtc.DefineRecordType(atb, props3, valueEquality: true); });
+        rtc = new RuntimeCompiler();
+        atb = rtc.GetNewRecordTypeBuilder();
+        Assert.ThrowsExactly<InvalidOperationException>(() => rtc.DefineRecordType(atb, props3, valueEquality: true));
     }
 
     [TestMethod]

--- a/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.CompilerServices/Reflection/Emit/RuntimeCompilerTests.cs
+++ b/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.CompilerServices/Reflection/Emit/RuntimeCompilerTests.cs
@@ -160,10 +160,10 @@ public class RuntimeCompilerTests
         Assert.IsTrue(ant.IsDefined(typeof(CompilerGeneratedAttribute), inherit: false));
 
         var ctors = ant.GetConstructors();
-        Assert.AreEqual(1, ctors.Length);
+        Assert.HasCount(1, ctors);
 
         var ctorParams = ctors[0].GetParameters();
-        Assert.AreEqual(2, ctorParams.Length);
+        Assert.HasCount(2, ctorParams);
 
         var ctorParam0 = ctorParams[0];
         Assert.AreEqual("Name", ctorParam0.Name);
@@ -174,7 +174,7 @@ public class RuntimeCompilerTests
         Assert.AreEqual(typeof(int), ctorParam1.ParameterType);
 
         var props = ant.GetProperties().OrderByDescending(p => p.Name).ToArray();
-        Assert.AreEqual(2, props.Length);
+        Assert.HasCount(2, props);
 
         var prop0 = props[0];
         Assert.AreEqual("Name", prop0.Name);
@@ -248,10 +248,10 @@ public class RuntimeCompilerTests
         Assert.IsTrue(ant.IsDefined(typeof(CompilerGeneratedAttribute), inherit: false));
 
         var ctors = ant.GetConstructors();
-        Assert.AreEqual(1, ctors.Length);
+        Assert.HasCount(1, ctors);
 
         var ctorParams = ctors[0].GetParameters();
-        Assert.AreEqual(2, ctorParams.Length);
+        Assert.HasCount(2, ctorParams);
 
         var ctorParam0 = ctorParams[0];
         Assert.AreEqual("Name", ctorParam0.Name);
@@ -262,7 +262,7 @@ public class RuntimeCompilerTests
         Assert.AreEqual(typeof(int), ctorParam1.ParameterType);
 
         var props = ant.GetProperties().OrderByDescending(p => p.Name).ToArray();
-        Assert.AreEqual(2, props.Length);
+        Assert.HasCount(2, props);
 
         var prop0 = props[0];
         Assert.AreEqual("Name", prop0.Name);
@@ -319,13 +319,13 @@ public class RuntimeCompilerTests
         Assert.IsTrue(ant.IsDefined(typeof(CompilerGeneratedAttribute), inherit: false));
 
         var ctors = ant.GetConstructors();
-        Assert.AreEqual(1, ctors.Length);
+        Assert.HasCount(1, ctors);
 
         var ctorParams = ctors[0].GetParameters();
-        Assert.AreEqual(0, ctorParams.Length);
+        Assert.IsEmpty(ctorParams);
 
         var props = ant.GetProperties();
-        Assert.AreEqual(0, props.Length);
+        Assert.IsEmpty(props);
 
         var foo = Activator.CreateInstance(ant);
 
@@ -528,7 +528,7 @@ public class RuntimeCompilerTests
         Assert.IsTrue(clt.IsDefined(typeof(CompilerGeneratedAttribute), inherit: false));
 
         var flds = clt.GetFields();
-        Assert.AreEqual(2, flds.Length);
+        Assert.HasCount(2, flds);
 
         var fld0 = flds[0];
         Assert.AreEqual("bar", fld0.Name);
@@ -670,13 +670,13 @@ public class RuntimeCompilerTests
         Assert.IsTrue(rdt.IsDefined(typeof(CompilerGeneratedAttribute), inherit: false));
 
         var ctors = rdt.GetConstructors();
-        Assert.AreEqual(1, ctors.Length);
+        Assert.HasCount(1, ctors);
 
         var ctorParams = ctors[0].GetParameters();
-        Assert.AreEqual(0, ctorParams.Length);
+        Assert.IsEmpty(ctorParams);
 
         var props = rdt.GetProperties().OrderByDescending(p => p.Name).ToArray();
-        Assert.AreEqual(2, props.Length);
+        Assert.HasCount(2, props);
 
         var prop0 = props[0];
         Assert.AreEqual("Name", prop0.Name);

--- a/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.CompilerServices/Tools/BURS/BottomUpOptimizerTests.Academic.cs
+++ b/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.CompilerServices/Tools/BURS/BottomUpOptimizerTests.Academic.cs
@@ -61,7 +61,7 @@ public partial class BottomUpOptimizerTests
 
         // Internal tables
         var debugView = burw.DebugView;
-        Assert.IsTrue(!string.IsNullOrEmpty(debugView));
+        Assert.IsFalse(string.IsNullOrEmpty(debugView));
 
         var e = !(!BoolConst.True & !BoolConst.False);
 
@@ -110,7 +110,7 @@ public partial class BottomUpOptimizerTests
 
         // Internal tables
         var debugView = burw.DebugView;
-        Assert.IsTrue(!string.IsNullOrEmpty(debugView));
+        Assert.IsFalse(string.IsNullOrEmpty(debugView));
 
         var e = !(!BoolConst.True & !BoolConst.False);
 

--- a/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.CompilerServices/Tools/BURS/BottomUpRewriterTests.Academic.cs
+++ b/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.CompilerServices/Tools/BURS/BottomUpRewriterTests.Academic.cs
@@ -213,7 +213,7 @@ public partial class BottomUpRewriterTests
 
         var res = burw.Rewrite(e);
 
-        Assert.IsTrue(res.ToString().Contains("Lazy"));
+        Assert.Contains("Lazy", res.ToString());
         Assert.AreEqual(e.Eval(), res.Eval());
     }
 

--- a/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.CompilerServices/Tools/BURS/BottomUpRewriterTests.Academic.cs
+++ b/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.CompilerServices/Tools/BURS/BottomUpRewriterTests.Academic.cs
@@ -44,7 +44,7 @@ public partial class BottomUpRewriterTests
 
         // Internal tables
         var debugView = burw.DebugView;
-        Assert.IsTrue(!string.IsNullOrEmpty(debugView));
+        Assert.IsFalse(string.IsNullOrEmpty(debugView));
 
         var e = new Add(
             new Mul(
@@ -96,7 +96,7 @@ public partial class BottomUpRewriterTests
 
         // Internal tables
         var debugView = burw.DebugView;
-        Assert.IsTrue(!string.IsNullOrEmpty(debugView));
+        Assert.IsFalse(string.IsNullOrEmpty(debugView));
 
         var e = new TimesPlus(
             new Inc(
@@ -144,7 +144,7 @@ public partial class BottomUpRewriterTests
 
         // Internal tables
         var debugView = burw.DebugView;
-        Assert.IsTrue(!string.IsNullOrEmpty(debugView));
+        Assert.IsFalse(string.IsNullOrEmpty(debugView));
 
         var e = new TimesPlus(
             new Inc(
@@ -195,7 +195,7 @@ public partial class BottomUpRewriterTests
 
         // Internal tables
         var debugView = burw.DebugView;
-        Assert.IsTrue(!string.IsNullOrEmpty(debugView));
+        Assert.IsFalse(string.IsNullOrEmpty(debugView));
 
         var e = new TimesPlus(
             new Inc(
@@ -249,7 +249,7 @@ public partial class BottomUpRewriterTests
 
         // Internal tables
         var debugView = burw.DebugView;
-        Assert.IsTrue(!string.IsNullOrEmpty(debugView));
+        Assert.IsFalse(string.IsNullOrEmpty(debugView));
 
         var e = new TimesPlus(
             new Inc(

--- a/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.CompilerServices/Tools/BURS/_NAryMapTests.cs
+++ b/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.CompilerServices/Tools/BURS/_NAryMapTests.cs
@@ -83,8 +83,8 @@ public class _NAryMapTests
             entries.Add(kv);
         }
 
-        Assert.AreEqual(2, entries.Count);
-        Assert.IsTrue(entries.Single(kv => kv.Key.SequenceEqual([19, 23])).Value == "Answer 1");
-        Assert.IsTrue(entries.Single(kv => kv.Key.SequenceEqual([19, 24])).Value == "Answer 2");
+        Assert.HasCount(2, entries);
+        Assert.AreEqual("Answer 1", entries.Single(kv => kv.Key.SequenceEqual([19, 23])).Value);
+        Assert.AreEqual("Answer 2", entries.Single(kv => kv.Key.SequenceEqual([19, 24])).Value);
     }
 }

--- a/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.CompilerServices/TypeSystem/TypeExtensionsTests.cs
+++ b/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.CompilerServices/TypeSystem/TypeExtensionsTests.cs
@@ -389,8 +389,8 @@ public class TypeExtensionsTests
         Assert.ThrowsExactly<InvalidOperationException>(() => t.ToCSharpString());
 
         var n = t.ToCSharpString(useNamespaceQualifiedNames: true, useCSharpTypeAliases: false, disallowCompilerGeneratedTypes: false);
-        Assert.IsTrue(n.StartsWith("<>f__AnonymousType"));
-        Assert.IsTrue(n.EndsWith("<System.Int32>"));
+        Assert.StartsWith("<>f__AnonymousType", n);
+        Assert.EndsWith("<System.Int32>", n);
     }
 
     [TestMethod]
@@ -426,13 +426,13 @@ public class TypeExtensionsTests
 
         Assert.IsTrue(TypeExtensions.TryUnifyExact(t1, t2, out IDictionary<Type, Type> r1));
 
-        Assert.AreEqual(2, r1.Count);
+        Assert.HasCount(2, r1);
         Assert.AreSame(typeof(string), r1[typeof(T)]);
         Assert.AreSame(typeof(bool), r1[typeof(R)]);
 
         Assert.IsTrue(TypeExtensions.TryUnifyExact(t1, t2, EqualityComparer<Type>.Default, out IDictionary<Type, Type> r2));
 
-        Assert.AreEqual(2, r2.Count);
+        Assert.HasCount(2, r2);
         Assert.AreSame(typeof(string), r2[typeof(T)]);
         Assert.AreSame(typeof(bool), r2[typeof(R)]);
     }
@@ -473,7 +473,7 @@ public class TypeExtensionsTests
 
         var res = t1.UnifyExact(t2);
 
-        Assert.AreEqual(0, res.Count);
+        Assert.IsEmpty(res);
     }
 
     [TestMethod]
@@ -484,7 +484,7 @@ public class TypeExtensionsTests
 
         var res = t1.UnifyExact(t2);
 
-        Assert.AreEqual(0, res.Count);
+        Assert.IsEmpty(res);
     }
 
     [TestMethod]
@@ -494,11 +494,11 @@ public class TypeExtensionsTests
         var t2 = typeof(T);
 
         var res1 = t1.UnifyExact(t2);
-        Assert.AreEqual(1, res1.Count);
+        Assert.HasCount(1, res1);
         Assert.AreSame(t1, res1[typeof(T)]);
 
         var res2 = t2.UnifyExact(t1);
-        Assert.AreEqual(1, res2.Count);
+        Assert.HasCount(1, res2);
         Assert.AreSame(t1, res2[typeof(T)]);
     }
 
@@ -509,11 +509,11 @@ public class TypeExtensionsTests
         var t2 = typeof(T);
 
         var res1 = t1.UnifyExact(t2);
-        Assert.AreEqual(1, res1.Count);
+        Assert.HasCount(1, res1);
         Assert.AreSame(t1, res1[typeof(T)]);
 
         var res2 = t2.UnifyExact(t1);
-        Assert.AreEqual(1, res2.Count);
+        Assert.HasCount(1, res2);
         Assert.AreSame(t1, res2[typeof(T)]);
     }
 
@@ -524,11 +524,11 @@ public class TypeExtensionsTests
         var t2 = typeof(T[]);
 
         var res1 = t1.UnifyExact(t2);
-        Assert.AreEqual(1, res1.Count);
+        Assert.HasCount(1, res1);
         Assert.AreSame(typeof(int), res1[typeof(T)]);
 
         var res2 = t2.UnifyExact(t1);
-        Assert.AreEqual(1, res2.Count);
+        Assert.HasCount(1, res2);
         Assert.AreSame(typeof(int), res2[typeof(T)]);
     }
 
@@ -539,11 +539,11 @@ public class TypeExtensionsTests
         var t2 = typeof(Func<T, T>);
 
         var res1 = t1.UnifyExact(t2);
-        Assert.AreEqual(1, res1.Count);
+        Assert.HasCount(1, res1);
         Assert.AreSame(typeof(int), res1[typeof(T)]);
 
         var res2 = t2.UnifyExact(t1);
-        Assert.AreEqual(1, res2.Count);
+        Assert.HasCount(1, res2);
         Assert.AreSame(typeof(int), res2[typeof(T)]);
     }
 
@@ -564,12 +564,12 @@ public class TypeExtensionsTests
         var t2 = typeof(Func<T, T, R>);
 
         var res1 = t1.UnifyExact(t2);
-        Assert.AreEqual(2, res1.Count);
+        Assert.HasCount(2, res1);
         Assert.AreSame(typeof(int), res1[typeof(T)]);
         Assert.AreSame(typeof(int), res1[typeof(R)]);
 
         var res2 = t2.UnifyExact(t1);
-        Assert.AreEqual(2, res2.Count);
+        Assert.HasCount(2, res2);
         Assert.AreSame(typeof(int), res2[typeof(T)]);
         Assert.AreSame(typeof(int), res2[typeof(R)]);
     }
@@ -581,12 +581,12 @@ public class TypeExtensionsTests
         var t2 = typeof(Func<T, T, R>);
 
         var res1 = t1.UnifyExact(t2);
-        Assert.AreEqual(2, res1.Count);
+        Assert.HasCount(2, res1);
         Assert.AreSame(typeof(int), res1[typeof(T)]);
         Assert.AreSame(typeof(int), res1[typeof(R)]);
 
         var res2 = t2.UnifyExact(t1);
-        Assert.AreEqual(2, res2.Count);
+        Assert.HasCount(2, res2);
         Assert.AreSame(typeof(int), res2[typeof(T)]);
         Assert.AreSame(typeof(int), res2[typeof(R)]);
     }
@@ -598,12 +598,12 @@ public class TypeExtensionsTests
         var t2 = typeof(Func<T, R, T>);
 
         var res1 = t1.UnifyExact(t2);
-        Assert.AreEqual(2, res1.Count);
+        Assert.HasCount(2, res1);
         Assert.AreSame(typeof(int), res1[typeof(T)]);
         Assert.AreSame(typeof(int), res1[typeof(R)]);
 
         var res2 = t2.UnifyExact(t1);
-        Assert.AreEqual(2, res2.Count);
+        Assert.HasCount(2, res2);
         Assert.AreSame(typeof(int), res2[typeof(T)]);
         Assert.AreSame(typeof(int), res2[typeof(R)]);
     }
@@ -620,13 +620,13 @@ public class TypeExtensionsTests
         var t2 = typeof(Func<T, T, R>);
 
         var res1 = t1.UnifyExact(t2);
-        Assert.AreEqual(3, res1.Count);
+        Assert.HasCount(3, res1);
         Assert.AreSame(typeof(int), res1[typeof(T)]);
         Assert.AreSame(typeof(int), res1[typeof(R)]);
         Assert.AreSame(typeof(int), res1[typeof(U)]);
 
         var res2 = t2.UnifyExact(t1);
-        Assert.AreEqual(3, res2.Count);
+        Assert.HasCount(3, res2);
         Assert.AreSame(typeof(int), res2[typeof(T)]);
         Assert.AreSame(typeof(int), res2[typeof(R)]);
         Assert.AreSame(typeof(int), res2[typeof(U)]);
@@ -639,13 +639,13 @@ public class TypeExtensionsTests
         var t2 = typeof(Func<T, T, R, T>);
 
         var res1 = t1.UnifyExact(t2);
-        Assert.AreEqual(3, res1.Count);
+        Assert.HasCount(3, res1);
         Assert.AreSame(typeof(int), res1[typeof(T)]);
         Assert.AreSame(typeof(int), res1[typeof(R)]);
         Assert.AreSame(typeof(int), res1[typeof(U)]);
 
         var res2 = t2.UnifyExact(t1);
-        Assert.AreEqual(3, res2.Count);
+        Assert.HasCount(3, res2);
         Assert.AreSame(typeof(int), res2[typeof(T)]);
         Assert.AreSame(typeof(int), res2[typeof(R)]);
         Assert.AreSame(typeof(int), res2[typeof(U)]);
@@ -678,13 +678,13 @@ public class TypeExtensionsTests
         var t2 = typeof(Func<T3, T1, T2, int>);
 
         var res1 = t1.UnifyExact(t2);
-        Assert.AreEqual(3, res1.Count);
+        Assert.HasCount(3, res1);
         Assert.AreSame(typeof(int), res1[typeof(T1)]);
         Assert.AreSame(typeof(int), res1[typeof(T2)]);
         Assert.AreSame(typeof(int), res1[typeof(T3)]);
 
         var res2 = t2.UnifyExact(t1);
-        Assert.AreEqual(3, res2.Count);
+        Assert.HasCount(3, res2);
         Assert.AreSame(typeof(int), res2[typeof(T1)]);
         Assert.AreSame(typeof(int), res2[typeof(T2)]);
         Assert.AreSame(typeof(int), res2[typeof(T3)]);
@@ -697,13 +697,13 @@ public class TypeExtensionsTests
         var t2 = typeof(Func<T3, T1, T3, int>);
 
         var res1 = t1.UnifyExact(t2);
-        Assert.AreEqual(3, res1.Count);
+        Assert.HasCount(3, res1);
         Assert.AreSame(typeof(int), res1[typeof(T1)]);
         Assert.AreSame(typeof(int), res1[typeof(T2)]);
         Assert.AreSame(typeof(int), res1[typeof(T3)]);
 
         var res2 = t2.UnifyExact(t1);
-        Assert.AreEqual(3, res2.Count);
+        Assert.HasCount(3, res2);
         Assert.AreSame(typeof(int), res2[typeof(T1)]);
         Assert.AreSame(typeof(int), res2[typeof(T2)]);
         Assert.AreSame(typeof(int), res2[typeof(T3)]);
@@ -766,14 +766,14 @@ public class TypeExtensionsTests
         var t2 = typeof(Func<T2, T4, T3, int, T3>);
 
         var res1 = t1.UnifyExact(t2);
-        Assert.AreEqual(4, res1.Count);
+        Assert.HasCount(4, res1);
         Assert.AreSame(typeof(int), res1[typeof(T1)]);
         Assert.AreSame(typeof(int), res1[typeof(T2)]);
         Assert.AreSame(typeof(int), res1[typeof(T3)]);
         Assert.AreSame(typeof(int), res1[typeof(T4)]);
 
         var res2 = t2.UnifyExact(t1);
-        Assert.AreEqual(4, res2.Count);
+        Assert.HasCount(4, res2);
         Assert.AreSame(typeof(int), res2[typeof(T1)]);
         Assert.AreSame(typeof(int), res2[typeof(T2)]);
         Assert.AreSame(typeof(int), res2[typeof(T3)]);
@@ -787,14 +787,14 @@ public class TypeExtensionsTests
         var t2 = typeof(Func<T2, int, T4, T3>);
 
         var res1 = t1.UnifyExact(t2);
-        Assert.AreEqual(4, res1.Count);
+        Assert.HasCount(4, res1);
         Assert.AreSame(typeof(int), res1[typeof(T1)]);
         Assert.AreSame(typeof(int), res1[typeof(T2)]);
         Assert.AreSame(typeof(int), res1[typeof(T3)]);
         Assert.AreSame(typeof(int), res1[typeof(T4)]);
 
         var res2 = t2.UnifyExact(t1);
-        Assert.AreEqual(4, res2.Count);
+        Assert.HasCount(4, res2);
         Assert.AreSame(typeof(int), res2[typeof(T1)]);
         Assert.AreSame(typeof(int), res2[typeof(T2)]);
         Assert.AreSame(typeof(int), res2[typeof(T3)]);
@@ -808,14 +808,14 @@ public class TypeExtensionsTests
         var t2 = typeof(Func<T2, T4, int, T3>);
 
         var res1 = t1.UnifyExact(t2);
-        Assert.AreEqual(4, res1.Count);
+        Assert.HasCount(4, res1);
         Assert.AreSame(typeof(int), res1[typeof(T1)]);
         Assert.AreSame(typeof(int), res1[typeof(T2)]);
         Assert.AreSame(typeof(int), res1[typeof(T3)]);
         Assert.AreSame(typeof(int), res1[typeof(T4)]);
 
         var res2 = t2.UnifyExact(t1);
-        Assert.AreEqual(4, res2.Count);
+        Assert.HasCount(4, res2);
         Assert.AreSame(typeof(int), res2[typeof(T1)]);
         Assert.AreSame(typeof(int), res2[typeof(T2)]);
         Assert.AreSame(typeof(int), res2[typeof(T3)]);
@@ -847,9 +847,9 @@ public class TypeExtensionsTests
 
         var r1 = t1.UnifyExact(t2, new TestTypeComparer());
         var r2 = t3.UnifyExact(t4, new TestTypeComparer());
-        Assert.AreEqual(1, r1.Count);
+        Assert.HasCount(1, r1);
         Assert.AreEqual(t1.GenericTypeArguments[0], r1[typeof(T)]);
-        Assert.AreEqual(1, r2.Count);
+        Assert.HasCount(1, r2);
         Assert.AreEqual(t3.GenericTypeArguments[1], r2[typeof(T)]);
     }
 
@@ -910,13 +910,13 @@ public class TypeExtensionsTests
 
         Assert.IsTrue(TypeExtensions.TryUnifyWith(t1, t2, out IDictionary<Type, Type> res));
 
-        Assert.AreEqual(2, res.Count);
+        Assert.HasCount(2, res);
         Assert.AreSame(typeof(string), res[typeof(T)]);
         Assert.AreSame(typeof(bool), res[typeof(R)]);
 
         Assert.IsTrue(TypeExtensions.TryUnifyWith(t1, t2, EqualityComparer<Type>.Default, out IDictionary<Type, Type> r2));
 
-        Assert.AreEqual(2, r2.Count);
+        Assert.HasCount(2, r2);
         Assert.AreSame(typeof(string), r2[typeof(T)]);
         Assert.AreSame(typeof(bool), r2[typeof(R)]);
     }
@@ -957,7 +957,7 @@ public class TypeExtensionsTests
 
         var res = t1.UnifyWith(t2);
 
-        Assert.AreEqual(0, res.Count);
+        Assert.IsEmpty(res);
     }
 
     [TestMethod]
@@ -968,7 +968,7 @@ public class TypeExtensionsTests
 
         var res = t1.UnifyWith(t2);
 
-        Assert.AreEqual(0, res.Count);
+        Assert.IsEmpty(res);
     }
 
     [TestMethod]
@@ -978,7 +978,7 @@ public class TypeExtensionsTests
         var t2 = typeof(T);
 
         var res2 = t2.UnifyWith(t1);
-        Assert.AreEqual(1, res2.Count);
+        Assert.HasCount(1, res2);
         Assert.AreSame(t1, res2[typeof(T)]);
     }
 
@@ -989,7 +989,7 @@ public class TypeExtensionsTests
         var t2 = typeof(T);
 
         var res2 = t2.UnifyWith(t1);
-        Assert.AreEqual(1, res2.Count);
+        Assert.HasCount(1, res2);
         Assert.AreSame(t1, res2[typeof(T)]);
     }
 
@@ -1000,7 +1000,7 @@ public class TypeExtensionsTests
         var t2 = typeof(T[]);
 
         var res2 = t2.UnifyWith(t1);
-        Assert.AreEqual(1, res2.Count);
+        Assert.HasCount(1, res2);
         Assert.AreSame(typeof(int), res2[typeof(T)]);
     }
 
@@ -1011,7 +1011,7 @@ public class TypeExtensionsTests
         var t2 = typeof(Func<T, T>);
 
         var res2 = t2.UnifyWith(t1);
-        Assert.AreEqual(1, res2.Count);
+        Assert.HasCount(1, res2);
         Assert.AreSame(typeof(int), res2[typeof(T)]);
     }
 
@@ -1058,9 +1058,9 @@ public class TypeExtensionsTests
 
         var r1 = t2.UnifyWith(t1, new TestTypeComparer());
         var r2 = t4.UnifyWith(t3, new TestTypeComparer());
-        Assert.AreEqual(1, r1.Count);
+        Assert.HasCount(1, r1);
         Assert.AreEqual(t1.GenericTypeArguments[0], r1[typeof(T)]);
-        Assert.AreEqual(1, r2.Count);
+        Assert.HasCount(1, r2);
         Assert.AreEqual(t3.GenericTypeArguments[1], r2[typeof(T)]);
     }
 
@@ -1404,7 +1404,7 @@ public class TypeExtensionsTests
         var res = target.IsReferenceAssignableFrom(value, out IDictionary<Type, Type> subst);
         Assert.IsTrue(res, $"{target} <: {value}");
 
-        Assert.AreEqual(unifications.Count, subst.Count);
+        Assert.HasCount(unifications.Count, subst);
         Assert.IsTrue(new HashSet<Type>(unifications.Keys).SetEquals(new HashSet<Type>(subst.Keys)));
 
         foreach (var kv in unifications)
@@ -1421,7 +1421,7 @@ public class TypeExtensionsTests
         if (errorSubstring != null)
         {
             var ex = Assert.ThrowsExactly<InvalidOperationException>(() => target.IsReferenceAssignableFrom(value, out ignored, throwException: true));
-            Assert.IsTrue(ex.Message.Contains(errorSubstring));
+            Assert.Contains(errorSubstring, ex.Message);
         }
     }
 }

--- a/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.Expressions.Bonsai.Serialization/Tests.cs
+++ b/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.Expressions.Bonsai.Serialization/Tests.cs
@@ -23,6 +23,10 @@ using Json = Nuqleon.Json.Expressions;
 
 namespace Tests;
 
+// MSTEST0058 (no asserts in catch blocks) is a false positive here: the catch's Assert.Fail reports a
+// regression if the roundtrip unexpectedly throws; the test expects it not to throw.
+#pragma warning disable MSTEST0058
+
 [TestClass]
 public partial class Tests
 {

--- a/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.Expressions.Bonsai.Serialization/Tests.cs
+++ b/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.Expressions.Bonsai.Serialization/Tests.cs
@@ -30,6 +30,9 @@ namespace Tests;
 [TestClass]
 public partial class Tests
 {
+    [GeneratedRegex("Constant\\((.*?),(.*?)\\)")]
+    private static partial Regex ConstantValueRegex();
+
     #region Constant
 
     [TestMethod]
@@ -3627,8 +3630,8 @@ public partial class Tests
         var sbc = backCompatSerializer.Serialize(d);
         var sbd = backCompatSerializer.Deserialize(sbc);
 
-        var expectedString = Regex.Replace(slim.ToString(), "Constant\\((.*?),(.*?)\\)", "Constant(value,$2)");
-        var actualString = Regex.Replace(sbd.ToString(), "Constant\\((.*?),(.*?)\\)", "Constant(value,$2)");
+        var expectedString = ConstantValueRegex().Replace(slim.ToString(), "Constant(value,$2)");
+        var actualString = ConstantValueRegex().Replace(sbd.ToString(), "Constant(value,$2)");
 
         Assert.AreEqual(expectedString, actualString);
 

--- a/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.Expressions.Bonsai.Serialization/Tests.cs
+++ b/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.Expressions.Bonsai.Serialization/Tests.cs
@@ -1585,7 +1585,7 @@ public partial class Tests
         Assert.AreEqual(a.Type, r.Type);
         Assert.AreEqual(a.NodeType, r.NodeType);
         Assert.AreEqual(a.Comparison, r.Comparison);
-        Assert.AreEqual(a.Cases.Count, r.Cases.Count);
+        Assert.HasCount(a.Cases.Count, r.Cases);
 
         for (int i = 0; i < a.Cases.Count; ++i)
         {
@@ -2043,7 +2043,7 @@ public partial class Tests
 
         Assert.IsTrue(new ExpressionEqualityComparer(() => new GlobalParameterSafeComparator()).Equals(a.Body, r.Body));
 
-        Assert.AreEqual(a.Handlers.Count, r.Handlers.Count);
+        Assert.HasCount(a.Handlers.Count, r.Handlers);
         for (int i = 0; i < a.Handlers.Count; ++i)
         {
             var handlerA = a.Handlers[i];

--- a/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.Expressions.Bonsai/CompilerServices/Expressions/Rewriters/TypeSystem/TypeSubstitutionExpressionSlimVisitor.cs
+++ b/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.Expressions.Bonsai/CompilerServices/Expressions/Rewriters/TypeSystem/TypeSubstitutionExpressionSlimVisitor.cs
@@ -966,7 +966,7 @@ public class TypeSubstitutionExpressionSlimVisitorTests : TestBase
     public void TypeSubstitutionExpressionSlimVisitor_Anonymize()
     {
         var pers = typeof(Person);
-        var query = (Expression<Func<IEnumerable<Person>, IEnumerable<string>>>)(xs => from x in xs where x.Age > 10 let name = x.Name where name.StartsWith("B") select name.ToUpper() + " is " + x.Age);
+        var query = (Expression<Func<IEnumerable<Person>, IEnumerable<string>>>)(xs => from x in xs where x.Age > 10 let name = x.Name where name.StartsWith('B') select name.ToUpper() + " is " + x.Age);
 
         var check1 = new TypeErasureChecker([typeof(Person)]);
         Assert.ThrowsExactly<InvalidOperationException>(() => check1.Visit(query));

--- a/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.Expressions.Bonsai/CompilerServices/Reflection/SlimReflectionHelpersTests.cs
+++ b/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.Expressions.Bonsai/CompilerServices/Reflection/SlimReflectionHelpersTests.cs
@@ -152,7 +152,7 @@ public class SlimReflectionHelpersTests : TestBase
     private static void AssertAreSameGenericDefinitionMethod(MethodInfo methodInfo, GenericDefinitionMethodInfoSlim genericDefinitionMethodInfoSlim)
     {
         Assert.AreEqual(methodInfo.Name, genericDefinitionMethodInfoSlim.Name);
-        Assert.AreEqual(methodInfo.GetGenericArguments().Length, genericDefinitionMethodInfoSlim.GenericParameterTypes.Count);
+        Assert.HasCount(methodInfo.GetGenericArguments().Length, genericDefinitionMethodInfoSlim.GenericParameterTypes);
     }
 
     private static void AssertAreSameGenericMethod(MethodInfo methodInfo, GenericMethodInfoSlim genericMethodInfoSlim)

--- a/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.Expressions.Bonsai/System/Linq/Expressions/ExpressionSlim.cs
+++ b/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.Expressions.Bonsai/System/Linq/Expressions/ExpressionSlim.cs
@@ -328,11 +328,11 @@ public class ExpressionSlimTests : TestBase
         var conv = ExpressionSlim.Lambda(ExpressionSlim.Empty());
 
         var ex = Assert.ThrowsExactly<ArgumentException>(() => ExpressionSlim.MakeBinary(nt, left, right));
-        Assert.IsTrue(ex.Message.Contains("not a valid binary expression type"));
+        Assert.Contains("not a valid binary expression type", ex.Message);
         var ex2 = Assert.ThrowsExactly<ArgumentException>(() => ExpressionSlim.MakeBinary(nt, left, right, liftToNull: false, method));
-        Assert.IsTrue(ex2.Message.Contains("not a valid binary expression type"));
+        Assert.Contains("not a valid binary expression type", ex2.Message);
         var ex3 = Assert.ThrowsExactly<ArgumentException>(() => ExpressionSlim.MakeBinary(nt, left, right, liftToNull: false, method, conv));
-        Assert.IsTrue(ex3.Message.Contains("not a valid binary expression type"));
+        Assert.Contains("not a valid binary expression type", ex3.Message);
     }
 
     [TestMethod]
@@ -571,7 +571,7 @@ public class ExpressionSlimTests : TestBase
         Assert.AreSame(methodSlim, call.Method);
         Assert.AreEqual(ExpressionType.Call, call.NodeType);
         Assert.IsNull(call.Object);
-        Assert.IsTrue(call.Arguments.Count == 0);
+        Assert.IsEmpty(call.Arguments);
 
         call = ExpressionSlim.Call(methodSlim, new[] { arg0, arg1 }.ToList());
         Assert.AreSame(methodSlim, call.Method);
@@ -622,7 +622,7 @@ public class ExpressionSlimTests : TestBase
         var ifThen = ExpressionSlim.IfThen(test, ifTrue);
         Assert.AreSame(test, ifThen.Test);
         Assert.AreSame(ifTrue, ifThen.IfTrue);
-        Assert.IsTrue(ifThen.IfFalse.NodeType == ExpressionType.Default);
+        Assert.AreEqual(ExpressionType.Default, ifThen.IfFalse.NodeType);
         Assert.AreEqual(typeof(void).ToTypeSlim(), ifThen.Type);
         Assert.AreEqual(ExpressionType.Conditional, ifThen.NodeType);
 
@@ -696,7 +696,7 @@ public class ExpressionSlimTests : TestBase
         var body = ExpressionSlim.Parameter(SlimType);
         var lambda = ExpressionSlim.Lambda(delegateType: null, body, [body]);
         Assert.AreSame(body, lambda.Body);
-        Assert.AreEqual(1, lambda.Parameters.Count);
+        Assert.HasCount(1, lambda.Parameters);
         Assert.AreSame(body, lambda.Parameters[0]);
         Assert.AreEqual(ExpressionType.Lambda, lambda.NodeType);
     }
@@ -746,12 +746,12 @@ public class ExpressionSlimTests : TestBase
         var v5 = e5.Evaluate<List<int>>();
         var v6 = e6.Evaluate<List<int>>();
 
-        Assert.AreEqual(1, v1.Count);
-        Assert.AreEqual(1, v2.Count);
-        Assert.AreEqual(1, v3.Count);
-        Assert.AreEqual(1, v4.Count);
-        Assert.AreEqual(1, v5.Count);
-        Assert.AreEqual(1, v6.Count);
+        Assert.HasCount(1, v1);
+        Assert.HasCount(1, v2);
+        Assert.HasCount(1, v3);
+        Assert.HasCount(1, v4);
+        Assert.HasCount(1, v5);
+        Assert.HasCount(1, v6);
 
         Assert.AreEqual(42, v1[0]);
         Assert.AreEqual(42, v2[0]);
@@ -784,10 +784,10 @@ public class ExpressionSlimTests : TestBase
         var v3 = e3.Evaluate<List<int>>();
         var v4 = e4.Evaluate<List<int>>();
 
-        Assert.AreEqual(0, v1.Count);
-        Assert.AreEqual(0, v2.Count);
-        Assert.AreEqual(0, v3.Count);
-        Assert.AreEqual(0, v4.Count);
+        Assert.IsEmpty(v1);
+        Assert.IsEmpty(v2);
+        Assert.IsEmpty(v3);
+        Assert.IsEmpty(v4);
 
         Expression<Func<int>> a = () => new { X = 43, Y = "foo" }.X;
         var na = (NewExpressionSlim)((MemberExpression)a.Body).Expression.ToExpressionSlim();
@@ -970,9 +970,9 @@ public class ExpressionSlimTests : TestBase
         var typ = TypeSlimExtensions.IntegerType;
 
         var ex = Assert.ThrowsExactly<ArgumentException>(() => ExpressionSlim.MakeUnary(nt, operand, typ));
-        Assert.IsTrue(ex.Message.Contains("not a valid unary expression type"));
+        Assert.Contains("not a valid unary expression type", ex.Message);
         var ex2 = Assert.ThrowsExactly<ArgumentException>(() => ExpressionSlim.MakeUnary(nt, operand, typ, method));
-        Assert.IsTrue(ex2.Message.Contains("not a valid unary expression type"));
+        Assert.Contains("not a valid unary expression type", ex2.Message);
     }
 
     [TestMethod]
@@ -1256,7 +1256,7 @@ public class ExpressionSlimTests : TestBase
         {
             var blk = ExpressionSlim.Block(cs);
             AssertElementsAreSame(cs, blk.Expressions);
-            Assert.AreEqual(0, blk.Variables.Count);
+            Assert.IsEmpty(blk.Variables);
             Assert.IsNull(blk.Type);
             Assert.AreEqual(c, blk.Result);
         }
@@ -1264,7 +1264,7 @@ public class ExpressionSlimTests : TestBase
         {
             var blk = ExpressionSlim.Block(a, b, c);
             AssertElementsAreSame([a, b, c], blk.Expressions);
-            Assert.AreEqual(0, blk.Variables.Count);
+            Assert.IsEmpty(blk.Variables);
             Assert.IsNull(blk.Type);
             Assert.AreEqual(c, blk.Result);
         }
@@ -1300,7 +1300,7 @@ public class ExpressionSlimTests : TestBase
         {
             var blk = ExpressionSlim.Block(SlimType, cs);
             AssertElementsAreSame(cs, blk.Expressions);
-            Assert.AreEqual(0, blk.Variables.Count);
+            Assert.IsEmpty(blk.Variables);
             Assert.AreSame(SlimType, blk.Type);
             Assert.AreEqual(c, blk.Result);
         }
@@ -1308,7 +1308,7 @@ public class ExpressionSlimTests : TestBase
         {
             var blk = ExpressionSlim.Block(SlimType, a, b, c);
             AssertElementsAreSame([a, b, c], blk.Expressions);
-            Assert.AreEqual(0, blk.Variables.Count);
+            Assert.IsEmpty(blk.Variables);
             Assert.AreSame(SlimType, blk.Type);
             Assert.AreEqual(c, blk.Result);
         }
@@ -1373,7 +1373,7 @@ public class ExpressionSlimTests : TestBase
 
     private static void AssertElementsAreSame<T>(ICollection<T> expected, ICollection<T> actual)
     {
-        Assert.AreEqual(expected.Count, actual.Count);
+        Assert.HasCount(expected.Count, actual);
 
         foreach (var pair in expected.Zip(actual, (Expected, Actual) => (Expected, Actual)))
             Assert.AreSame(pair.Expected, pair.Actual);
@@ -1534,14 +1534,14 @@ public class ExpressionSlimTests : TestBase
 
             var tryfinally = ExpressionSlim.TryFinally(b, @finally);
             Assert.AreSame(b, tryfinally.Body);
-            Assert.AreEqual(0, tryfinally.Handlers.Count);
+            Assert.IsEmpty(tryfinally.Handlers);
             Assert.IsNull(tryfinally.Fault);
             Assert.AreSame(@finally, tryfinally.Finally);
             Assert.IsNull(tryfinally.Type);
 
             var tryfault = ExpressionSlim.TryFault(b, @fault);
             Assert.AreSame(b, tryfault.Body);
-            Assert.AreEqual(0, tryfault.Handlers.Count);
+            Assert.IsEmpty(tryfault.Handlers);
             Assert.AreSame(@fault, tryfault.Fault);
             Assert.IsNull(tryfault.Finally);
             Assert.IsNull(tryfault.Type);
@@ -1630,7 +1630,7 @@ public class ExpressionSlimTests : TestBase
         Assert.ThrowsExactly<ArgumentOutOfRangeException>(() => i.GetArgument(-1));
         Assert.ThrowsExactly<ArgumentOutOfRangeException>(() => i.GetArgument(0));
 
-        Assert.AreEqual(0, i.Arguments.Count);
+        Assert.IsEmpty(i.Arguments);
 
         var n2 = (MethodCallExpressionSlim)new ArgVisitor(0).Visit(i);
 
@@ -1661,7 +1661,7 @@ public class ExpressionSlimTests : TestBase
         Assert.AreSame(a0, i.GetArgument(0));
         Assert.ThrowsExactly<ArgumentOutOfRangeException>(() => i.GetArgument(1));
 
-        Assert.AreEqual(1, i.Arguments.Count);
+        Assert.HasCount(1, i.Arguments);
 
         Assert.AreSame(a0, i.Arguments[0]);
 
@@ -1710,7 +1710,7 @@ public class ExpressionSlimTests : TestBase
         Assert.AreSame(a1, i.GetArgument(1));
         Assert.ThrowsExactly<ArgumentOutOfRangeException>(() => i.GetArgument(2));
 
-        Assert.AreEqual(2, i.Arguments.Count);
+        Assert.HasCount(2, i.Arguments);
 
         Assert.AreSame(a0, i.Arguments[0]);
         Assert.AreSame(a1, i.Arguments[1]);
@@ -1763,7 +1763,7 @@ public class ExpressionSlimTests : TestBase
         Assert.AreSame(a2, i.GetArgument(2));
         Assert.ThrowsExactly<ArgumentOutOfRangeException>(() => i.GetArgument(3));
 
-        Assert.AreEqual(3, i.Arguments.Count);
+        Assert.HasCount(3, i.Arguments);
 
         Assert.AreSame(a0, i.Arguments[0]);
         Assert.AreSame(a1, i.Arguments[1]);
@@ -1820,7 +1820,7 @@ public class ExpressionSlimTests : TestBase
         Assert.AreSame(a3, i.GetArgument(3));
         Assert.ThrowsExactly<ArgumentOutOfRangeException>(() => i.GetArgument(4));
 
-        Assert.AreEqual(4, i.Arguments.Count);
+        Assert.HasCount(4, i.Arguments);
 
         Assert.AreSame(a0, i.Arguments[0]);
         Assert.AreSame(a1, i.Arguments[1]);
@@ -1881,7 +1881,7 @@ public class ExpressionSlimTests : TestBase
         Assert.AreSame(a4, i.GetArgument(4));
         Assert.ThrowsExactly<ArgumentOutOfRangeException>(() => i.GetArgument(5));
 
-        Assert.AreEqual(5, i.Arguments.Count);
+        Assert.HasCount(5, i.Arguments);
 
         Assert.AreSame(a0, i.Arguments[0]);
         Assert.AreSame(a1, i.Arguments[1]);
@@ -1936,7 +1936,7 @@ public class ExpressionSlimTests : TestBase
         Assert.AreSame(a5, i.GetArgument(5));
         Assert.ThrowsExactly<ArgumentOutOfRangeException>(() => i.GetArgument(6));
 
-        Assert.AreEqual(6, i.Arguments.Count);
+        Assert.HasCount(6, i.Arguments);
 
         Assert.AreSame(a0, i.Arguments[0]);
         Assert.AreSame(a1, i.Arguments[1]);
@@ -1983,7 +1983,7 @@ public class ExpressionSlimTests : TestBase
         Assert.ThrowsExactly<ArgumentOutOfRangeException>(() => i.GetArgument(-1));
         Assert.ThrowsExactly<ArgumentOutOfRangeException>(() => i.GetArgument(0));
 
-        Assert.AreEqual(0, i.Arguments.Count);
+        Assert.IsEmpty(i.Arguments);
 
         var n1 = (MethodCallExpressionSlim)new ObjectVisitor().Visit(i);
 
@@ -2020,7 +2020,7 @@ public class ExpressionSlimTests : TestBase
         Assert.AreSame(a0, i.GetArgument(0));
         Assert.ThrowsExactly<ArgumentOutOfRangeException>(() => i.GetArgument(1));
 
-        Assert.AreEqual(1, i.Arguments.Count);
+        Assert.HasCount(1, i.Arguments);
 
         Assert.AreSame(a0, i.Arguments[0]);
 
@@ -2075,7 +2075,7 @@ public class ExpressionSlimTests : TestBase
         Assert.AreSame(a1, i.GetArgument(1));
         Assert.ThrowsExactly<ArgumentOutOfRangeException>(() => i.GetArgument(2));
 
-        Assert.AreEqual(2, i.Arguments.Count);
+        Assert.HasCount(2, i.Arguments);
 
         Assert.AreSame(a0, i.Arguments[0]);
         Assert.AreSame(a1, i.Arguments[1]);
@@ -2134,7 +2134,7 @@ public class ExpressionSlimTests : TestBase
         Assert.AreSame(a2, i.GetArgument(2));
         Assert.ThrowsExactly<ArgumentOutOfRangeException>(() => i.GetArgument(3));
 
-        Assert.AreEqual(3, i.Arguments.Count);
+        Assert.HasCount(3, i.Arguments);
 
         Assert.AreSame(a0, i.Arguments[0]);
         Assert.AreSame(a1, i.Arguments[1]);
@@ -2197,7 +2197,7 @@ public class ExpressionSlimTests : TestBase
         Assert.AreSame(a3, i.GetArgument(3));
         Assert.ThrowsExactly<ArgumentOutOfRangeException>(() => i.GetArgument(4));
 
-        Assert.AreEqual(4, i.Arguments.Count);
+        Assert.HasCount(4, i.Arguments);
 
         Assert.AreSame(a0, i.Arguments[0]);
         Assert.AreSame(a1, i.Arguments[1]);
@@ -2264,7 +2264,7 @@ public class ExpressionSlimTests : TestBase
         Assert.AreSame(a4, i.GetArgument(4));
         Assert.ThrowsExactly<ArgumentOutOfRangeException>(() => i.GetArgument(5));
 
-        Assert.AreEqual(5, i.Arguments.Count);
+        Assert.HasCount(5, i.Arguments);
 
         Assert.AreSame(a0, i.Arguments[0]);
         Assert.AreSame(a1, i.Arguments[1]);
@@ -2325,7 +2325,7 @@ public class ExpressionSlimTests : TestBase
         Assert.AreSame(a5, i.GetArgument(5));
         Assert.ThrowsExactly<ArgumentOutOfRangeException>(() => i.GetArgument(6));
 
-        Assert.AreEqual(6, i.Arguments.Count);
+        Assert.HasCount(6, i.Arguments);
 
         Assert.AreSame(a0, i.Arguments[0]);
         Assert.AreSame(a1, i.Arguments[1]);
@@ -2381,7 +2381,7 @@ public class ExpressionSlimTests : TestBase
         Assert.ThrowsExactly<ArgumentOutOfRangeException>(() => i.GetArgument(-1));
         Assert.ThrowsExactly<ArgumentOutOfRangeException>(() => i.GetArgument(0));
 
-        Assert.AreEqual(0, i.Arguments.Count);
+        Assert.IsEmpty(i.Arguments);
 
         var n1 = (InvocationExpressionSlim)new FuncVisitor().Visit(i);
 
@@ -2415,7 +2415,7 @@ public class ExpressionSlimTests : TestBase
         Assert.AreSame(a0, i.GetArgument(0));
         Assert.ThrowsExactly<ArgumentOutOfRangeException>(() => i.GetArgument(1));
 
-        Assert.AreEqual(1, i.Arguments.Count);
+        Assert.HasCount(1, i.Arguments);
 
         Assert.AreSame(a0, i.Arguments[0]);
 
@@ -2470,7 +2470,7 @@ public class ExpressionSlimTests : TestBase
         Assert.AreSame(a1, i.GetArgument(1));
         Assert.ThrowsExactly<ArgumentOutOfRangeException>(() => i.GetArgument(2));
 
-        Assert.AreEqual(2, i.Arguments.Count);
+        Assert.HasCount(2, i.Arguments);
 
         Assert.AreSame(a0, i.Arguments[0]);
         Assert.AreSame(a1, i.Arguments[1]);
@@ -2529,7 +2529,7 @@ public class ExpressionSlimTests : TestBase
         Assert.AreSame(a2, i.GetArgument(2));
         Assert.ThrowsExactly<ArgumentOutOfRangeException>(() => i.GetArgument(3));
 
-        Assert.AreEqual(3, i.Arguments.Count);
+        Assert.HasCount(3, i.Arguments);
 
         Assert.AreSame(a0, i.Arguments[0]);
         Assert.AreSame(a1, i.Arguments[1]);
@@ -2592,7 +2592,7 @@ public class ExpressionSlimTests : TestBase
         Assert.AreSame(a3, i.GetArgument(3));
         Assert.ThrowsExactly<ArgumentOutOfRangeException>(() => i.GetArgument(4));
 
-        Assert.AreEqual(4, i.Arguments.Count);
+        Assert.HasCount(4, i.Arguments);
 
         Assert.AreSame(a0, i.Arguments[0]);
         Assert.AreSame(a1, i.Arguments[1]);
@@ -2659,7 +2659,7 @@ public class ExpressionSlimTests : TestBase
         Assert.AreSame(a4, i.GetArgument(4));
         Assert.ThrowsExactly<ArgumentOutOfRangeException>(() => i.GetArgument(5));
 
-        Assert.AreEqual(5, i.Arguments.Count);
+        Assert.HasCount(5, i.Arguments);
 
         Assert.AreSame(a0, i.Arguments[0]);
         Assert.AreSame(a1, i.Arguments[1]);
@@ -2709,7 +2709,7 @@ public class ExpressionSlimTests : TestBase
         Assert.ThrowsExactly<ArgumentOutOfRangeException>(() => i.GetArgument(-1));
         Assert.ThrowsExactly<ArgumentOutOfRangeException>(() => i.GetArgument(0));
 
-        Assert.AreEqual(0, i.Arguments.Count);
+        Assert.IsEmpty(i.Arguments);
 
         var n2 = (NewExpressionSlim)new ArgVisitor(0).Visit(i);
 
@@ -2739,7 +2739,7 @@ public class ExpressionSlimTests : TestBase
         Assert.ThrowsExactly<ArgumentOutOfRangeException>(() => i.GetArgument(-1));
         Assert.ThrowsExactly<ArgumentOutOfRangeException>(() => i.GetArgument(0));
 
-        Assert.AreEqual(0, i.Arguments.Count);
+        Assert.IsEmpty(i.Arguments);
 
         var n2 = (NewExpressionSlim)new ArgVisitor(0).Visit(i);
 
@@ -2774,7 +2774,7 @@ public class ExpressionSlimTests : TestBase
         Assert.AreSame(a0, i.GetArgument(0));
         Assert.ThrowsExactly<ArgumentOutOfRangeException>(() => i.GetArgument(1));
 
-        Assert.AreEqual(1, i.Arguments.Count);
+        Assert.HasCount(1, i.Arguments);
 
         Assert.AreSame(a0, i.Arguments[0]);
 
@@ -2827,7 +2827,7 @@ public class ExpressionSlimTests : TestBase
         Assert.AreSame(a1, i.GetArgument(1));
         Assert.ThrowsExactly<ArgumentOutOfRangeException>(() => i.GetArgument(2));
 
-        Assert.AreEqual(2, i.Arguments.Count);
+        Assert.HasCount(2, i.Arguments);
 
         Assert.AreSame(a0, i.Arguments[0]);
         Assert.AreSame(a1, i.Arguments[1]);
@@ -2884,7 +2884,7 @@ public class ExpressionSlimTests : TestBase
         Assert.AreSame(a2, i.GetArgument(2));
         Assert.ThrowsExactly<ArgumentOutOfRangeException>(() => i.GetArgument(3));
 
-        Assert.AreEqual(3, i.Arguments.Count);
+        Assert.HasCount(3, i.Arguments);
 
         Assert.AreSame(a0, i.Arguments[0]);
         Assert.AreSame(a1, i.Arguments[1]);
@@ -2945,7 +2945,7 @@ public class ExpressionSlimTests : TestBase
         Assert.AreSame(a3, i.GetArgument(3));
         Assert.ThrowsExactly<ArgumentOutOfRangeException>(() => i.GetArgument(4));
 
-        Assert.AreEqual(4, i.Arguments.Count);
+        Assert.HasCount(4, i.Arguments);
 
         Assert.AreSame(a0, i.Arguments[0]);
         Assert.AreSame(a1, i.Arguments[1]);
@@ -3010,7 +3010,7 @@ public class ExpressionSlimTests : TestBase
         Assert.AreSame(a4, i.GetArgument(4));
         Assert.ThrowsExactly<ArgumentOutOfRangeException>(() => i.GetArgument(5));
 
-        Assert.AreEqual(5, i.Arguments.Count);
+        Assert.HasCount(5, i.Arguments);
 
         Assert.AreSame(a0, i.Arguments[0]);
         Assert.AreSame(a1, i.Arguments[1]);

--- a/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.Expressions.Bonsai/System/Linq/Expressions/ListArgumentProviderSlimTests.cs
+++ b/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.Expressions.Bonsai/System/Linq/Expressions/ListArgumentProviderSlimTests.cs
@@ -55,7 +55,7 @@ public class ListArgumentProviderSlimTests
 
         Assert.AreEqual(0, argProvider.IndexOf(a0));
         Assert.AreEqual(1, argProvider.IndexOf(a1));
-        Assert.IsTrue(argProvider.IndexOf(d) < 0);
+        Assert.IsLessThan(0, argProvider.IndexOf(d));
 
         var arr = new ExpressionSlim[5];
         argProvider.CopyTo(arr, 2);

--- a/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.Expressions.Bonsai/System/Reflection/FreeVariableScannerSlim.cs
+++ b/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.Expressions.Bonsai/System/Reflection/FreeVariableScannerSlim.cs
@@ -26,8 +26,8 @@ public class FreeVariableScannerSlimTests : TestBase
         var slimExpr = ExpressionSlim.Lambda(p1);
 
         var free = FreeVariableScannerSlim.Find(slimExpr);
-        Assert.AreEqual(1, free.Count);
-        Assert.IsTrue(free.Contains(p1));
+        Assert.HasCount(1, free);
+        Assert.Contains(p1, free);
     }
 
     [TestMethod]
@@ -39,8 +39,8 @@ public class FreeVariableScannerSlimTests : TestBase
         var slimExpr = ExpressionSlim.Lambda(ExpressionSlim.Add(p1, p2), p1);
 
         var free = FreeVariableScannerSlim.Find(slimExpr);
-        Assert.AreEqual(1, free.Count);
-        Assert.IsTrue(free.Contains(p2));
+        Assert.HasCount(1, free);
+        Assert.Contains(p2, free);
     }
 
     [TestMethod]
@@ -51,8 +51,8 @@ public class FreeVariableScannerSlimTests : TestBase
         var slimExpr = ExpressionSlim.Block(p1);
 
         var free = FreeVariableScannerSlim.Find(slimExpr);
-        Assert.AreEqual(1, free.Count);
-        Assert.IsTrue(free.Contains(p1));
+        Assert.HasCount(1, free);
+        Assert.Contains(p1, free);
     }
 
     [TestMethod]
@@ -64,8 +64,8 @@ public class FreeVariableScannerSlimTests : TestBase
         var slimExpr = ExpressionSlim.Block([p1], ExpressionSlim.Add(p1, p2));
 
         var free = FreeVariableScannerSlim.Find(slimExpr);
-        Assert.AreEqual(1, free.Count);
-        Assert.IsTrue(free.Contains(p2));
+        Assert.HasCount(1, free);
+        Assert.Contains(p2, free);
     }
 
     [TestMethod]
@@ -76,8 +76,8 @@ public class FreeVariableScannerSlimTests : TestBase
         var slimExpr = ExpressionSlim.TryCatch(ExpressionSlim.Empty(), ExpressionSlim.Catch(SlimType, p1));
 
         var free = FreeVariableScannerSlim.Find(slimExpr);
-        Assert.AreEqual(1, free.Count);
-        Assert.IsTrue(free.Contains(p1));
+        Assert.HasCount(1, free);
+        Assert.Contains(p1, free);
     }
 
     [TestMethod]
@@ -89,7 +89,7 @@ public class FreeVariableScannerSlimTests : TestBase
         var slimExpr = ExpressionSlim.TryCatch(ExpressionSlim.Empty(), ExpressionSlim.Catch(p1, ExpressionSlim.Add(p1, p2)));
 
         var free = FreeVariableScannerSlim.Find(slimExpr);
-        Assert.AreEqual(1, free.Count);
-        Assert.IsTrue(free.Contains(p2));
+        Assert.HasCount(1, free);
+        Assert.Contains(p2, free);
     }
 }

--- a/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.Expressions.Bonsai/System/Reflection/GenericTypeSlim.cs
+++ b/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.Expressions.Bonsai/System/Reflection/GenericTypeSlim.cs
@@ -116,7 +116,7 @@ public class GenericTypeSlimTests : TestBase
 
     private static void AssertOptimized(GenericTypeSlim type, int arity, params TypeSlim[] args)
     {
-        Assert.IsTrue(type.GetType().Name.EndsWith(arity.ToString()));
+        Assert.EndsWith(arity.ToString(), type.GetType().Name);
 
         Assert.AreEqual(arity, type.GenericArgumentCount);
 
@@ -129,7 +129,7 @@ public class GenericTypeSlimTests : TestBase
 
         Assert.AreSame(genArgs, type.GenericArguments);
 
-        Assert.AreEqual(arity, genArgs.Count);
+        Assert.HasCount(arity, genArgs);
 
         for (var i = 0; i < args.Length; i++)
         {

--- a/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.Expressions.Bonsai/System/Reflection/TypeSlimEqualityComparer.cs
+++ b/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.Expressions.Bonsai/System/Reflection/TypeSlimEqualityComparer.cs
@@ -240,7 +240,7 @@ public class TypeSlimEqualityComparerTests : TestBase
                       select (Collection: f, Version: v))
                      .ToArray();
 
-        Assert.IsTrue(fields.Length > 0);
+        Assert.IsNotEmpty(fields);
 
         var p1 = SlimType.GetProperty("Foo", SlimType, EmptyReadOnlyCollection<TypeSlim>.Instance, canWrite: true);
         var s1 = TypeSlim.Structural(new List<PropertyInfoSlim> { p1 }.AsReadOnly(), hasValueEqualitySemantics: true, StructuralTypeSlimKind.Record);

--- a/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.Expressions.Bonsai/System/Reflection/TypeSlimExtensions.cs
+++ b/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.Expressions.Bonsai/System/Reflection/TypeSlimExtensions.cs
@@ -353,7 +353,7 @@ public class TypeSlimExtensionsTest : TestBase
 
         var genType = (GenericTypeSlim)typeof(List<int>).ToTypeSlim();
         var res2 = genType.GetGenericArguments();
-        Assert.AreEqual(1, res2.Length);
+        Assert.HasCount(1, res2);
         Assert.AreSame(res2[0], genType.GenericArguments[0]);
 
         var res3 = typeof(int).ToTypeSlim().GetGenericArguments();
@@ -370,7 +370,7 @@ public class TypeSlimExtensionsTest : TestBase
         var res = (GenericTypeSlim)genDef.MakeGenericType(genArgs);
 
         Assert.AreSame(genDef, res.GenericTypeDefinition);
-        Assert.AreEqual(1, res.GenericArguments.Count);
+        Assert.HasCount(1, res.GenericArguments);
         Assert.AreSame(genArg, res.GenericArguments[0]);
 
         Assert.ThrowsExactly<InvalidOperationException>(() => typeof(int).ToTypeSlim().MakeGenericType(genArgs));

--- a/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.Expressions.Bonsai/System/Reflection/TypeSlimExtensions.cs
+++ b/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.Expressions.Bonsai/System/Reflection/TypeSlimExtensions.cs
@@ -353,11 +353,11 @@ public class TypeSlimExtensionsTest : TestBase
 
         var genType = (GenericTypeSlim)typeof(List<int>).ToTypeSlim();
         var res2 = genType.GetGenericArguments();
-        Assert.IsTrue(res2.Length == 1);
+        Assert.AreEqual(1, res2.Length);
         Assert.AreSame(res2[0], genType.GenericArguments[0]);
 
         var res3 = typeof(int).ToTypeSlim().GetGenericArguments();
-        Assert.IsTrue(res3.Length == 0);
+        Assert.IsEmpty(res3);
     }
 
     [TestMethod]
@@ -370,7 +370,7 @@ public class TypeSlimExtensionsTest : TestBase
         var res = (GenericTypeSlim)genDef.MakeGenericType(genArgs);
 
         Assert.AreSame(genDef, res.GenericTypeDefinition);
-        Assert.IsTrue(res.GenericArguments.Count == 1);
+        Assert.AreEqual(1, res.GenericArguments.Count);
         Assert.AreSame(genArg, res.GenericArguments[0]);
 
         Assert.ThrowsExactly<InvalidOperationException>(() => typeof(int).ToTypeSlim().MakeGenericType(genArgs));

--- a/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.Expressions.Bonsai/System/Reflection/TypeUnifier.cs
+++ b/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.Expressions.Bonsai/System/Reflection/TypeUnifier.cs
@@ -73,7 +73,7 @@ public class TypeUnifierTests : TestBase
         var typeToSlim = new TypeToTypeSlimConverter();
         var slim = typeToSlim.Visit(typeof(Func<int, int>));
         Assert.IsTrue(unifier.Unify(typeof(Func<T, T>), slim));
-        Assert.AreEqual(0, unifier.Entries.Count);
+        Assert.IsEmpty(unifier.Entries);
     }
 
     [TestMethod]
@@ -83,7 +83,7 @@ public class TypeUnifierTests : TestBase
         var typeToSlim = new TypeToTypeSlimConverter();
         var slim = typeToSlim.Visit(typeof(Func<int, bool>));
         Assert.IsFalse(unifier.Unify(typeof(Func<T, T>), slim));
-        Assert.AreEqual(0, unifier.Entries.Count);
+        Assert.IsEmpty(unifier.Entries);
     }
 
     [TestMethod]
@@ -115,7 +115,7 @@ public class TypeUnifierTests : TestBase
         var intSlim = typeToSlim.Visit(typeof(int));
 
         Assert.IsTrue(unifier.Unify(typeof(int), intSlim));
-        Assert.AreEqual(0, unifier.Entries.Count);
+        Assert.IsEmpty(unifier.Entries);
     }
 
     #endregion
@@ -154,7 +154,7 @@ public class TypeUnifierTests : TestBase
         var intArraySlim = typeToSlim.Visit(typeof(int[]));
 
         Assert.IsTrue(unifier.Unify(typeof(int[]), intArraySlim));
-        Assert.AreEqual(0, unifier.Entries.Count);
+        Assert.IsEmpty(unifier.Entries);
     }
 
     #endregion
@@ -234,7 +234,7 @@ public class TypeUnifierTests : TestBase
 
         Assert.IsTrue(unifier.Unify(structuralType, slimStructuralType));
 
-        Assert.AreEqual(1, unifier.Entries.Count);
+        Assert.HasCount(1, unifier.Entries);
 
         Assert.IsTrue(unifier.Entries.ContainsKey(slimStructuralType));
         Assert.AreEqual(unifier.Entries[slimStructuralType], structuralType);
@@ -321,7 +321,7 @@ public class TypeUnifierTests : TestBase
         var slimDefinition = typeToSlim.Visit(definition);
 
         Assert.IsTrue(unifier.Unify(definition, slimDefinition));
-        Assert.AreEqual(0, unifier.Entries.Count);
+        Assert.IsEmpty(unifier.Entries);
     }
 
     #endregion
@@ -355,7 +355,7 @@ public class TypeUnifierTests : TestBase
         var slimGeneric = typeToSlim.Visit(generic);
 
         Assert.IsTrue(unifier.Unify(generic, slimGeneric));
-        Assert.AreEqual(0, unifier.Entries.Count);
+        Assert.IsEmpty(unifier.Entries);
     }
 
     #endregion
@@ -448,7 +448,7 @@ public class TypeUnifierTests : TestBase
         var slimList = typeToSlim.Visit(list);
 
         Assert.IsTrue(unifier.Unify(list, slimList));
-        Assert.AreEqual(2, unifier.Entries.Count);
+        Assert.HasCount(2, unifier.Entries);
     }
 
     [TestMethod]
@@ -476,7 +476,7 @@ public class TypeUnifierTests : TestBase
 
         Assert.IsTrue(unifier.Unify(rt1, slim));
         Assert.IsTrue(unifier.Unify(rt2, slim));
-        Assert.AreEqual(1, unifier.Entries.Count);
+        Assert.HasCount(1, unifier.Entries);
         Assert.AreSame(rt1, unifier.Entries[slim]);
     }
 

--- a/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.Expressions.Optimizers/AssignmentAnalyzerTests.cs
+++ b/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.Expressions.Optimizers/AssignmentAnalyzerTests.cs
@@ -34,7 +34,7 @@ public class AssignmentAnalyzerTests
 
         Assert.AreSame(b.Expressions, res);
 
-        Assert.AreEqual(0, analyze.Unassigned.Count);
+        Assert.IsEmpty(analyze.Unassigned);
     }
 
     [TestMethod]
@@ -58,7 +58,7 @@ public class AssignmentAnalyzerTests
 
         Assert.AreSame(b.Expressions, res);
 
-        Assert.AreEqual(0, analyze.Unassigned.Count);
+        Assert.IsEmpty(analyze.Unassigned);
     }
 
     [TestMethod]
@@ -78,7 +78,7 @@ public class AssignmentAnalyzerTests
 
         Assert.AreSame(b.Expressions, res);
 
-        Assert.AreEqual(0, analyze.Unassigned.Count);
+        Assert.IsEmpty(analyze.Unassigned);
     }
 
     [TestMethod]
@@ -98,7 +98,7 @@ public class AssignmentAnalyzerTests
 
         Assert.AreSame(b.Expressions, res);
 
-        Assert.AreEqual(0, analyze.Unassigned.Count);
+        Assert.IsEmpty(analyze.Unassigned);
     }
 
     [TestMethod]

--- a/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.Expressions.Optimizers/ExpressionOptimizerTests.cs
+++ b/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.Expressions.Optimizers/ExpressionOptimizerTests.cs
@@ -14,6 +14,11 @@ using System.Reflection;
 
 namespace Tests.System.Linq.Expressions.Optimizers;
 
+// MSTEST0058 (no asserts in catch blocks) is a false positive for this file: AssertEval is a dual-path
+// helper — the catch verifies the optimizer's result for a throwing expression (NodeType == Throw),
+// while the code after the try verifies the value for a non-throwing one.
+#pragma warning disable MSTEST0058
+
 [TestClass]
 public partial class ExpressionOptimizerTests
 {

--- a/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.Expressions.Optimizers/PureMemberCatalogTests.cs
+++ b/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.Expressions.Optimizers/PureMemberCatalogTests.cs
@@ -16,6 +16,10 @@ using System.Text.RegularExpressions;
 
 namespace Tests.System.Linq.Expressions.Optimizers;
 
+// MSTEST0058 (no asserts in catch blocks) is a false positive here: the catch's Assert.Fail reports an
+// *unexpected* exception with context; the test expects the member access not to throw.
+#pragma warning disable MSTEST0058
+
 [TestClass]
 public class PureMemberCatalogTests
 {

--- a/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.Expressions.Optimizers/PureMemberCatalogTests.cs
+++ b/Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.Expressions.Optimizers/PureMemberCatalogTests.cs
@@ -118,7 +118,11 @@ public class PureMemberCatalogTests
     [TestMethod]
     public void PureMemberCatalog_Regex()
     {
+        // SYSLIB1045: 'new Regex(...)' is intentional expression-tree test data — the optimizer must see the
+        // Regex constructor/Match as a pure member to fold this to "bar"; a [GeneratedRegex] call would not be.
+#pragma warning disable SYSLIB1045
         Expression<Func<string>> f = () => new Regex("[0-9]([a-z]*)[0-9]").Match("1bar2").Groups[1].Value;
+#pragma warning restore SYSLIB1045
         AssertOptimize(f.Body, Expression.Constant("bar"));
     }
 

--- a/Nuqleon/Pearls/BCL/ProjectJohnnie/Tests.Nuqleon.Memory.Diagnostics/AccessTests.cs
+++ b/Nuqleon/Pearls/BCL/ProjectJohnnie/Tests.Nuqleon.Memory.Diagnostics/AccessTests.cs
@@ -130,7 +130,7 @@ public class AccessTests
 
         Assert.AreEqual(AccessType.Composite, a.AccessType);
 
-        Assert.AreEqual(3, a.Accesses.Count);
+        Assert.HasCount(3, a.Accesses);
         Assert.AreSame(a0, a.Accesses[0]);
         Assert.AreSame(a1, a.Accesses[1]);
         Assert.AreSame(a2, a.Accesses[2]);

--- a/Nuqleon/Pearls/BCL/ProjectJohnnie/Tests.Nuqleon.Memory.Diagnostics/HeapUsageAnalyzerTests.cs
+++ b/Nuqleon/Pearls/BCL/ProjectJohnnie/Tests.Nuqleon.Memory.Diagnostics/HeapUsageAnalyzerTests.cs
@@ -51,16 +51,16 @@ public class HeapUsageAnalyzerTests
         Assert.IsTrue(sh.SetEquals([name]));
 
         var byGen1 = res.Reports[p1].SplitByGeneration();
-        Assert.AreEqual(GC.MaxGeneration + 1, byGen1.Length);
+        Assert.HasCount(GC.MaxGeneration + 1, byGen1);
         Assert.IsTrue(r1.SetEquals(byGen1.SelectMany(g => g.Objects)));
 
         var byGen2 = res.Reports[p2].SplitByGeneration();
-        Assert.AreEqual(GC.MaxGeneration + 1, byGen2.Length);
+        Assert.HasCount(GC.MaxGeneration + 1, byGen2);
         Assert.IsTrue(r2.SetEquals(byGen2.SelectMany(g => g.Objects)));
 
         var stats1 = res.Reports[p1].GetStats();
 
-        Assert.AreEqual(4, stats1.InstanceCountPerType.Count); // anon, string, KeyValuePair<string, int>, string[]
+        Assert.HasCount(4, stats1.InstanceCountPerType); // anon, string, KeyValuePair<string, int>, string[]
         Assert.AreEqual(1, stats1.InstanceCountPerType[anon1.GetType()]);
         Assert.AreEqual(3, stats1.InstanceCountPerType[typeof(string)]);
         Assert.AreEqual(1, stats1.InstanceCountPerType[typeof(KeyValuePair<string, int>)]);
@@ -74,7 +74,7 @@ public class HeapUsageAnalyzerTests
 
         var stats2 = res.Reports[p2].GetStats();
 
-        Assert.AreEqual(4, stats2.InstanceCountPerType.Count); // anon, string, KeyValuePair<string, int>, string[]
+        Assert.HasCount(4, stats2.InstanceCountPerType); // anon, string, KeyValuePair<string, int>, string[]
         Assert.AreEqual(1, stats2.InstanceCountPerType[anon2.GetType()]);
         Assert.AreEqual(2, stats2.InstanceCountPerType[typeof(string)]);
         Assert.AreEqual(1, stats2.InstanceCountPerType[typeof(Tuple<string, int>)]);
@@ -88,7 +88,7 @@ public class HeapUsageAnalyzerTests
 
         var statsS = res.Shared.GetStats();
 
-        Assert.AreEqual(1, statsS.InstanceCountPerType.Count); // string
+        Assert.HasCount(1, statsS.InstanceCountPerType); // string
         Assert.AreEqual(1, statsS.InstanceCountPerType[typeof(string)]);
 
         Assert.AreEqual(0, statsS.BoxedValueCount);

--- a/Nuqleon/Pearls/BCL/ProjectJohnnie/Tests.Nuqleon.Memory.Diagnostics/ObjectSetTests.cs
+++ b/Nuqleon/Pearls/BCL/ProjectJohnnie/Tests.Nuqleon.Memory.Diagnostics/ObjectSetTests.cs
@@ -45,7 +45,7 @@ public class ObjectSetTests
 
         var arr = set.ToArray();
 
-        Assert.AreEqual(0, arr.Length);
+        Assert.IsEmpty(arr);
 
         //
         // Remove

--- a/Nuqleon/Pearls/LINQ/ExpressionJit/Tests.Nuqleon.Linq.Expressions.Jit/System/ArrayExtensionsTests.cs
+++ b/Nuqleon/Pearls/LINQ/ExpressionJit/Tests.Nuqleon.Linq.Expressions.Jit/System/ArrayExtensionsTests.cs
@@ -12,7 +12,7 @@ public class ArrayExtensionsTests
     {
         var xs = new[] { 42 };
         var res = xs.RemoveFirst();
-        Assert.AreEqual(0, res.Length);
+        Assert.IsEmpty(res);
         Assert.AreSame([], res);
     }
 
@@ -21,7 +21,7 @@ public class ArrayExtensionsTests
     {
         var xs = new[] { 42, 43 };
         var res = xs.RemoveFirst();
-        Assert.AreEqual(1, res.Length);
+        Assert.HasCount(1, res);
         Assert.AreEqual(43, res[0]);
     }
 
@@ -30,7 +30,7 @@ public class ArrayExtensionsTests
     {
         var xs = new[] { 2, 3, 5, 7 };
         var res = xs.RemoveFirst();
-        Assert.AreEqual(3, res.Length);
+        Assert.HasCount(3, res);
         Assert.IsTrue(new[] { 3, 5, 7 }.SequenceEqual(res));
     }
 
@@ -39,7 +39,7 @@ public class ArrayExtensionsTests
     {
         var xs = Array.Empty<int>();
         var res = xs.Map(x => x * 2);
-        Assert.AreEqual(0, xs.Length);
+        Assert.IsEmpty(xs);
         Assert.AreSame([], res);
     }
 
@@ -48,7 +48,7 @@ public class ArrayExtensionsTests
     {
         var xs = new[] { 1, 2, 3, 4 };
         var res = xs.Map(x => x * 2);
-        Assert.AreEqual(4, xs.Length);
+        Assert.HasCount(4, xs);
         Assert.IsTrue(new[] { 2, 4, 6, 8 }.SequenceEqual(res));
     }
 }

--- a/Nuqleon/Pearls/LINQ/ExpressionJit/Tests.Nuqleon.Linq.Expressions.Jit/System/Collections/ObjectModel/ReadOnlyCollectionExtensionsTests.cs
+++ b/Nuqleon/Pearls/LINQ/ExpressionJit/Tests.Nuqleon.Linq.Expressions.Jit/System/Collections/ObjectModel/ReadOnlyCollectionExtensionsTests.cs
@@ -12,7 +12,7 @@ public class ReadOnlyCollectionExtensionsTests
     {
         var xs = new ReadOnlyCollection<int>([3, 5, 7]);
         var res = xs.AddFirst(2);
-        Assert.AreEqual(4, res.Count);
+        Assert.HasCount(4, res);
         Assert.IsTrue(new[] { 2, 3, 5, 7 }.SequenceEqual(res));
     }
 }

--- a/Nuqleon/Pearls/LINQ/ExpressionJit/Tests.Nuqleon.Linq.Expressions.Jit/System/Linq/Expressions/Jit/AnalyzerTests.cs
+++ b/Nuqleon/Pearls/LINQ/ExpressionJit/Tests.Nuqleon.Linq.Expressions.Jit/System/Linq/Expressions/Jit/AnalyzerTests.cs
@@ -32,7 +32,7 @@ public class AnalyzerTests
 
         var a = Analyzer.Analyze(e, methodTable: null);
 
-        Assert.AreEqual(1, a.Count);
+        Assert.HasCount(1, a);
 
         var l = a[e];
 
@@ -40,7 +40,7 @@ public class AnalyzerTests
         Assert.IsNull(l.Parent);
         Assert.IsFalse(l.NeedsClosure);
         Assert.IsFalse(l.HasHoistedLocals);
-        Assert.AreEqual(0, l.Locals.Count);
+        Assert.IsEmpty(l.Locals);
     }
 
     [TestMethod]
@@ -51,7 +51,7 @@ public class AnalyzerTests
 
         var a = Analyzer.Analyze(e, methodTable: null);
 
-        Assert.AreEqual(1, a.Count);
+        Assert.HasCount(1, a);
 
         var l = a[e];
 
@@ -59,7 +59,7 @@ public class AnalyzerTests
         Assert.IsNull(l.Parent);
         Assert.IsFalse(l.NeedsClosure);
         Assert.IsFalse(l.HasHoistedLocals);
-        Assert.AreEqual(1, l.Locals.Count);
+        Assert.HasCount(1, l.Locals);
 
         Assert.AreEqual(StorageKind.Local, l.Locals[x]);
     }
@@ -72,7 +72,7 @@ public class AnalyzerTests
 
         var a = Analyzer.Analyze(e, methodTable: null);
 
-        Assert.AreEqual(1, a.Count);
+        Assert.HasCount(1, a);
 
         var l = a[e];
 
@@ -80,7 +80,7 @@ public class AnalyzerTests
         Assert.IsNull(l.Parent);
         Assert.IsFalse(l.NeedsClosure);
         Assert.IsFalse(l.HasHoistedLocals);
-        Assert.AreEqual(1, l.Locals.Count);
+        Assert.HasCount(1, l.Locals);
 
         Assert.AreEqual(StorageKind.Local, l.Locals[x]);
     }
@@ -95,7 +95,7 @@ public class AnalyzerTests
 
         var a = Analyzer.Analyze(e, methodTable: null);
 
-        Assert.AreEqual(2, a.Count);
+        Assert.HasCount(2, a);
 
         var l1 = a[e];
 
@@ -103,7 +103,7 @@ public class AnalyzerTests
         Assert.IsNull(l1.Parent);
         Assert.IsFalse(l1.NeedsClosure);
         Assert.IsFalse(l1.HasHoistedLocals);
-        Assert.AreEqual(1, l1.Locals.Count);
+        Assert.HasCount(1, l1.Locals);
 
         Assert.AreEqual(StorageKind.Local, l1.Locals[x]);
 
@@ -113,7 +113,7 @@ public class AnalyzerTests
         Assert.AreSame(l1, l2.Parent);
         Assert.IsFalse(l2.NeedsClosure);
         Assert.IsFalse(l2.HasHoistedLocals);
-        Assert.AreEqual(1, l2.Locals.Count);
+        Assert.HasCount(1, l2.Locals);
 
         Assert.AreEqual(StorageKind.Local, l2.Locals[y]);
     }
@@ -128,7 +128,7 @@ public class AnalyzerTests
 
         var a = Analyzer.Analyze(e, methodTable: null);
 
-        Assert.AreEqual(2, a.Count);
+        Assert.HasCount(2, a);
 
         var l1 = a[e];
 
@@ -136,7 +136,7 @@ public class AnalyzerTests
         Assert.IsNull(l1.Parent);
         Assert.IsFalse(l1.NeedsClosure);
         Assert.IsTrue(l1.HasHoistedLocals);
-        Assert.AreEqual(1, l1.Locals.Count);
+        Assert.HasCount(1, l1.Locals);
 
         Assert.AreEqual(StorageKind.Hoisted, l1.Locals[x]);
 
@@ -146,7 +146,7 @@ public class AnalyzerTests
         Assert.AreSame(l1, l2.Parent);
         Assert.IsTrue(l2.NeedsClosure);
         Assert.IsFalse(l2.HasHoistedLocals);
-        Assert.AreEqual(1, l2.Locals.Count);
+        Assert.HasCount(1, l2.Locals);
 
         Assert.AreEqual(StorageKind.Local, l2.Locals[y]);
     }
@@ -161,7 +161,7 @@ public class AnalyzerTests
 
         var a = Analyzer.Analyze(e, methodTable: null);
 
-        Assert.AreEqual(2, a.Count);
+        Assert.HasCount(2, a);
 
         var l1 = a[e];
 
@@ -169,7 +169,7 @@ public class AnalyzerTests
         Assert.IsNull(l1.Parent);
         Assert.IsFalse(l1.NeedsClosure);
         Assert.IsTrue(l1.HasHoistedLocals);
-        Assert.AreEqual(1, l1.Locals.Count);
+        Assert.HasCount(1, l1.Locals);
 
         Assert.AreEqual(StorageKind.Hoisted | StorageKind.Boxed, l1.Locals[x]);
 
@@ -179,7 +179,7 @@ public class AnalyzerTests
         Assert.AreSame(l1, l2.Parent);
         Assert.IsTrue(l2.NeedsClosure);
         Assert.IsFalse(l2.HasHoistedLocals);
-        Assert.AreEqual(1, l2.Locals.Count);
+        Assert.HasCount(1, l2.Locals);
 
         Assert.AreEqual(StorageKind.Local, l2.Locals[y]);
     }
@@ -194,7 +194,7 @@ public class AnalyzerTests
 
         var a = Analyzer.Analyze(e, methodTable: null);
 
-        Assert.AreEqual(2, a.Count);
+        Assert.HasCount(2, a);
 
         var l1 = a[e];
 
@@ -202,7 +202,7 @@ public class AnalyzerTests
         Assert.IsNull(l1.Parent);
         Assert.IsFalse(l1.NeedsClosure);
         Assert.IsFalse(l1.HasHoistedLocals);
-        Assert.AreEqual(1, l1.Locals.Count);
+        Assert.HasCount(1, l1.Locals);
 
         Assert.AreEqual(StorageKind.Local, l1.Locals[x]);
 
@@ -212,7 +212,7 @@ public class AnalyzerTests
         Assert.AreSame(l1, b1.Parent);
         Assert.IsTrue(b1.NeedsClosure); // REVIEW
         Assert.IsFalse(b1.HasHoistedLocals);
-        Assert.AreEqual(1, b1.Locals.Count);
+        Assert.HasCount(1, b1.Locals);
 
         Assert.AreEqual(StorageKind.Local, b1.Locals[y]);
     }
@@ -225,7 +225,7 @@ public class AnalyzerTests
 
         var a = Analyzer.Analyze(e, methodTable: null);
 
-        Assert.AreEqual(1, a.Count);
+        Assert.HasCount(1, a);
 
         var l = a[e];
 
@@ -233,7 +233,7 @@ public class AnalyzerTests
         Assert.IsNull(l.Parent);
         Assert.IsFalse(l.NeedsClosure);
         Assert.IsTrue(l.HasHoistedLocals);
-        Assert.AreEqual(1, l.Locals.Count);
+        Assert.HasCount(1, l.Locals);
 
         Assert.AreEqual(StorageKind.Boxed | StorageKind.Hoisted, l.Locals[x]);
     }
@@ -249,7 +249,7 @@ public class AnalyzerTests
 
         var a = Analyzer.Analyze(e, methodTable: null);
 
-        Assert.AreEqual(2, a.Count);
+        Assert.HasCount(2, a);
 
         var l1 = a[e];
 
@@ -257,7 +257,7 @@ public class AnalyzerTests
         Assert.IsNull(l1.Parent);
         Assert.IsFalse(l1.NeedsClosure);
         Assert.IsFalse(l1.HasHoistedLocals);
-        Assert.AreEqual(1, l1.Locals.Count);
+        Assert.HasCount(1, l1.Locals);
 
         Assert.AreEqual(StorageKind.Local, l1.Locals[x]);
 
@@ -267,7 +267,7 @@ public class AnalyzerTests
         Assert.AreSame(l1, c1.Parent);
         Assert.IsFalse(c1.NeedsClosure);
         Assert.IsFalse(c1.HasHoistedLocals);
-        Assert.AreEqual(1, c1.Locals.Count);
+        Assert.HasCount(1, c1.Locals);
 
         Assert.AreEqual(StorageKind.Local, c1.Locals[r]);
     }
@@ -282,7 +282,7 @@ public class AnalyzerTests
 
         var a = Analyzer.Analyze(e, methodTable: null);
 
-        Assert.AreEqual(2, a.Count);
+        Assert.HasCount(2, a);
 
         var l1 = a[e];
 
@@ -290,7 +290,7 @@ public class AnalyzerTests
         Assert.IsNull(l1.Parent);
         Assert.IsFalse(l1.NeedsClosure);
         Assert.IsFalse(l1.HasHoistedLocals);
-        Assert.AreEqual(1, l1.Locals.Count);
+        Assert.HasCount(1, l1.Locals);
 
         Assert.AreEqual(StorageKind.Local, l1.Locals[x]);
 
@@ -300,7 +300,7 @@ public class AnalyzerTests
         Assert.AreSame(l1, c1.Parent);
         Assert.IsFalse(c1.NeedsClosure);
         Assert.IsFalse(c1.HasHoistedLocals);
-        Assert.AreEqual(0, c1.Locals.Count);
+        Assert.IsEmpty(c1.Locals);
     }
 
     private sealed class Extension : Expression

--- a/Nuqleon/Pearls/LINQ/ExpressionJit/Tests.Nuqleon.Linq.Expressions.Jit/System/Linq/Expressions/UnboundVariableScannerTests.cs
+++ b/Nuqleon/Pearls/LINQ/ExpressionJit/Tests.Nuqleon.Linq.Expressions.Jit/System/Linq/Expressions/UnboundVariableScannerTests.cs
@@ -18,7 +18,7 @@ public class UnboundVariableScannerTests
 
         uvs.Visit(e);
 
-        Assert.AreEqual(0, uvs.UnboundVariables.Count);
+        Assert.IsEmpty(uvs.UnboundVariables);
     }
 
     [TestMethod]
@@ -31,7 +31,7 @@ public class UnboundVariableScannerTests
 
         uvs.Visit(e);
 
-        Assert.AreEqual(0, uvs.UnboundVariables.Count);
+        Assert.IsEmpty(uvs.UnboundVariables);
     }
 
     [TestMethod]
@@ -44,7 +44,7 @@ public class UnboundVariableScannerTests
 
         uvs.Visit(e);
 
-        Assert.AreEqual(0, uvs.UnboundVariables.Count);
+        Assert.IsEmpty(uvs.UnboundVariables);
     }
 
     [TestMethod]

--- a/Nuqleon/Pearls/LINQ/ExpressionJit/Tests.Nuqleon.Linq.Expressions.Jit/System/Runtime/CompilerServices/RuntimeOpsExTests.cs
+++ b/Nuqleon/Pearls/LINQ/ExpressionJit/Tests.Nuqleon.Linq.Expressions.Jit/System/Runtime/CompilerServices/RuntimeOpsExTests.cs
@@ -103,7 +103,7 @@ public class RuntimeOpsExTests
         r[1] = true;
         r[2] = "foo";
         Assert.AreEqual(43, c.Item2);
-        Assert.AreEqual(true, c.Item1);
+        Assert.IsTrue(c.Item1);
         Assert.AreEqual("foo", c.Item3);
         Assert.AreEqual(c.Item2, r[0]);
         Assert.AreEqual(c.Item1, r[1]);

--- a/Nuqleon/Pearls/LINQ/ExpressionJit/Tests.Nuqleon.Linq.Expressions.Jit/System/Runtime/CompilerServices/ThunkFactoryTests.cs
+++ b/Nuqleon/Pearls/LINQ/ExpressionJit/Tests.Nuqleon.Linq.Expressions.Jit/System/Runtime/CompilerServices/ThunkFactoryTests.cs
@@ -19,20 +19,20 @@ public class ThunkFactoryTests
 
         var g = t.GetGenericTypeDefinition();
         var a = g.GetGenericArguments();
-        Assert.AreEqual(4, a.Length);
+        Assert.HasCount(4, a);
 
         Assert.AreEqual(GenericParameterAttributes.NotNullableValueTypeConstraint | GenericParameterAttributes.DefaultConstructorConstraint, a[1].GenericParameterAttributes);
         var c1 = a[1].GetGenericParameterConstraints();
-        Assert.AreEqual(1, c1.Length);
+        Assert.HasCount(1, c1);
         Assert.AreEqual(typeof(ValueType), c1[0]);
 
         Assert.AreEqual(GenericParameterAttributes.DefaultConstructorConstraint, a[2].GenericParameterAttributes);
         var c2 = a[2].GetGenericParameterConstraints();
-        Assert.AreEqual(0, c2.Length);
+        Assert.IsEmpty(c2);
 
         Assert.AreEqual(GenericParameterAttributes.ReferenceTypeConstraint, a[3].GenericParameterAttributes);
         var c3 = a[3].GetGenericParameterConstraints();
-        Assert.AreEqual(1, c3.Length);
+        Assert.HasCount(1, c3);
         Assert.AreEqual(typeof(IBar<>).MakeGenericType(a[1]), c3[0]);
     }
 
@@ -133,11 +133,11 @@ public class ThunkFactoryTests
         // Assert we got only one constructor.
         //
         var ctors = t.GetConstructors();
-        Assert.AreEqual(1, ctors.Length);
+        Assert.HasCount(1, ctors);
 
         var ctor = ctors[0];
         var ctorParams = ctor.GetParameters();
-        Assert.AreEqual(1, ctorParams.Length);
+        Assert.HasCount(1, ctorParams);
 
         //
         // Obtain the expression tree type passed to the constructor.
@@ -209,7 +209,7 @@ public class ThunkFactoryTests
         Assert.IsTrue(createDelegate.IsPublic);
         Assert.AreEqual(delegateType, createDelegate.ReturnType);
         var createDelegateParams = createDelegate.GetParameters();
-        Assert.AreEqual(1, createDelegateParams.Length);
+        Assert.HasCount(1, createDelegateParams);
         Assert.AreEqual(closureType, createDelegateParams[0].ParameterType);
 
         //
@@ -325,7 +325,7 @@ internal sealed class AssertiveClosure
     {
         Assert.AreEqual(flag, _flag);
 
-        Assert.AreEqual(args.Length, _args.Count);
+        Assert.HasCount(args.Length, _args);
 
         for (var i = 0; i < args.Length; i++)
         {

--- a/Nuqleon/Pearls/LINQ/PartialExpressionEvaluator/PartialTreeEvaluator/Program.cs
+++ b/Nuqleon/Pearls/LINQ/PartialExpressionEvaluator/PartialTreeEvaluator/Program.cs
@@ -26,7 +26,9 @@ public static class Program
             ((Expression<Func<Bar>>)(() => new Bar { Foo = "bar".Length, Qux = { int.Parse("42") }, Baz = "foo".Length })).Body,
             ((Expression<Func<int>>)(() => Enumerable.Range(0, 10).Sum())).Body,
             ((Expression<Func<int>>)(() => Enumerable.Range(0, 10).Sum(x => x))).Body,
+#pragma warning disable CA1861 // The array is a NewArrayExpression node inside the demonstrated expression tree, not a runtime argument; hoisting it to a static field would change the tree this sample evaluates.
             ((Expression<Func<int>>)(() => new[] { 1, 2, 3 }.Sum())).Body,
+#pragma warning restore CA1861
             ((Expression<Func<string>>)(() => Console.ReadLine())).Body, // side-effect
         })
         {

--- a/Nuqleon/Pearls/LINQ/PartialExpressionEvaluator/Test/Tests.cs
+++ b/Nuqleon/Pearls/LINQ/PartialExpressionEvaluator/Test/Tests.cs
@@ -91,7 +91,7 @@ public class Tests
                 Expression.Constant(3.0)
             },
             {
-                E(() => "bar".StartsWith("b") ? 42 : 43),
+                E(() => "bar".StartsWith('b') ? 42 : 43),
                 Expression.Constant(42)
             },
             {
@@ -145,7 +145,7 @@ public class Tests
                 E(() => 6 + "bar".Length)
             },
             {
-                E(() => "bar".StartsWith("b") ? Value(2) * Value(3) : 1 + "bar".Length),
+                E(() => "bar".StartsWith('b') ? Value(2) * Value(3) : 1 + "bar".Length),
                 //
                 // NB: Hand-rolled expression tree below due to breaking change in Roslyn where the conditional reduces to `6` prior to quotation.
                 //

--- a/Reaqtive/Core/Reaqtive.Scheduler/Reaqtive/Scheduler/NativeMethods.cs
+++ b/Reaqtive/Core/Reaqtive.Scheduler/Reaqtive/Scheduler/NativeMethods.cs
@@ -9,7 +9,7 @@ namespace Reaqtive.Scheduler;
 /// <summary>
 /// Provides access to a set of native methods.
 /// </summary>
-internal static class NativeMethods
+internal static partial class NativeMethods
 {
     private static bool s_failedToLoadKernel32 = false;
 
@@ -49,10 +49,10 @@ internal static class NativeMethods
     /// <param name="threadHandle">A handle to the thread.</param>
     /// <param name="cycleTime">The number of CPU clock cycles used by the thread. This value includes cycles spent in both user mode and kernel mode.</param>
     /// <returns><c>true</c> if the function succeeds; otherwise, <c>false</c>.</returns>
-    [DllImport("kernel32.dll", SetLastError = true)]
+    [LibraryImport("kernel32.dll", SetLastError = true)]
     [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
     [return: MarshalAs(UnmanagedType.Bool)]
-    private static extern bool QueryThreadCycleTime(IntPtr threadHandle, out ulong cycleTime);
+    private static partial bool QueryThreadCycleTime(IntPtr threadHandle, out ulong cycleTime);
 
     /// <summary>
     /// A pseudo-handle representing the current thread.

--- a/Reaqtive/Core/Reaqtive.Testing/ReactiveAssert.cs
+++ b/Reaqtive/Core/Reaqtive.Testing/ReactiveAssert.cs
@@ -13,6 +13,11 @@ using Reaqtive.Linq;
 
 namespace Reaqtive.Testing;
 
+// MSTEST0058 (no asserts in catch blocks) is a false positive for this file: ReactiveAssert.Throws<T>
+// is itself a custom exception-assertion helper, so the Assert.Fail/Assert.AreSame in its catch blocks
+// are the intended verification logic, and the "no exception thrown" case is guarded by a 'failed' flag.
+#pragma warning disable MSTEST0058
+
 /// <summary>
 /// Helper class to write asserts in unit tests for applications and libraries built using Reactive Extensions.
 /// </summary>

--- a/Reaqtive/Core/Tests.Reaqtive.Core/Reaqtive/Operators/StatefulUnaryOperatorTests.cs
+++ b/Reaqtive/Core/Tests.Reaqtive.Core/Reaqtive/Operators/StatefulUnaryOperatorTests.cs
@@ -141,7 +141,7 @@ public class StatefulUnaryOperatorTests
 
         // Seems a bit inconsistent that the subscription has zero inputs
         // but it returns a nop subscription from its unary property..
-        Assert.AreEqual(0, mo.Inputs.Count());
+        Assert.IsEmpty(mo.Inputs);
         Assert.IsNotNull(mo.Input);
     }
 

--- a/Reaqtive/Core/Tests.Reaqtive.Core/Reaqtive/Subjects/MultiSubjectBaseTests.cs
+++ b/Reaqtive/Core/Tests.Reaqtive.Core/Reaqtive/Subjects/MultiSubjectBaseTests.cs
@@ -35,7 +35,7 @@ public class MultiSubjectBaseTests
     public void MultiSubjectBase_OperatorDefaults()
     {
         var subject = new TestMultiSubject();
-        Assert.AreEqual(0, subject.Inputs.Count());
+        Assert.IsEmpty(subject.Inputs);
     }
 
     [TestMethod]

--- a/Reaqtive/Core/Tests.Reaqtive.Core/Reaqtive/Subscribables/SubscribableBaseTests.cs
+++ b/Reaqtive/Core/Tests.Reaqtive.Core/Reaqtive/Subscribables/SubscribableBaseTests.cs
@@ -39,11 +39,11 @@ public class SubscribableBaseTests
         sub.Observer.OnCompleted();
 
         var ex2 = Assert.ThrowsExactly<InvalidOperationException>(() => sub.Observer.OnNext(42));
-        Assert.IsTrue(ex2.Message.Contains("terminated"));
+        Assert.Contains("terminated", ex2.Message);
         var ex3 = Assert.ThrowsExactly<InvalidOperationException>(() => sub.Observer.OnError(new Exception()));
-        Assert.IsTrue(ex3.Message.Contains("terminated"));
+        Assert.Contains("terminated", ex3.Message);
         var ex4 = Assert.ThrowsExactly<InvalidOperationException>(() => sub.Observer.OnCompleted());
-        Assert.IsTrue(ex4.Message.Contains("terminated"));
+        Assert.Contains("terminated", ex4.Message);
 
         Assert.AreEqual(42, res);
     }
@@ -62,7 +62,7 @@ public class SubscribableBaseTests
             },
             ex =>
             {
-                Assert.IsTrue(ex.Message == "foo");
+                Assert.AreEqual("foo", ex.Message);
                 res *= -1;
             },
             () =>
@@ -77,11 +77,11 @@ public class SubscribableBaseTests
         sub.Observer.OnError(new Exception("foo"));
 
         var ex2 = Assert.ThrowsExactly<InvalidOperationException>(() => sub.Observer.OnNext(42));
-        Assert.IsTrue(ex2.Message.Contains("terminated"));
+        Assert.Contains("terminated", ex2.Message);
         var ex3 = Assert.ThrowsExactly<InvalidOperationException>(() => sub.Observer.OnError(new Exception()));
-        Assert.IsTrue(ex3.Message.Contains("terminated"));
+        Assert.Contains("terminated", ex3.Message);
         var ex4 = Assert.ThrowsExactly<InvalidOperationException>(() => sub.Observer.OnCompleted());
-        Assert.IsTrue(ex4.Message.Contains("terminated"));
+        Assert.Contains("terminated", ex4.Message);
 
         Assert.AreEqual(42, res);
     }
@@ -116,11 +116,11 @@ public class SubscribableBaseTests
         s.WaitOne();
 
         var ex2 = Assert.ThrowsExactly<InvalidOperationException>(() => sub.Observer.OnNext(43));
-        Assert.IsTrue(ex2.Message.Contains("processing"));
+        Assert.Contains("processing", ex2.Message);
         var ex3 = Assert.ThrowsExactly<InvalidOperationException>(() => sub.Observer.OnError(new Exception()));
-        Assert.IsTrue(ex3.Message.Contains("processing"));
+        Assert.Contains("processing", ex3.Message);
         var ex4 = Assert.ThrowsExactly<InvalidOperationException>(() => sub.Observer.OnCompleted());
-        Assert.IsTrue(ex4.Message.Contains("processing"));
+        Assert.Contains("processing", ex4.Message);
 
         e.Set();
         t.Wait();
@@ -159,21 +159,21 @@ public class SubscribableBaseTests
         s.WaitOne();
 
         var ex2 = Assert.ThrowsExactly<InvalidOperationException>(() => sub.Observer.OnNext(43));
-        Assert.IsTrue(ex2.Message.Contains("processing"));
+        Assert.Contains("processing", ex2.Message);
         var ex3 = Assert.ThrowsExactly<InvalidOperationException>(() => sub.Observer.OnError(new Exception()));
-        Assert.IsTrue(ex3.Message.Contains("processing"));
+        Assert.Contains("processing", ex3.Message);
         var ex4 = Assert.ThrowsExactly<InvalidOperationException>(() => sub.Observer.OnCompleted());
-        Assert.IsTrue(ex4.Message.Contains("processing"));
+        Assert.Contains("processing", ex4.Message);
 
         e.Set();
         t.Wait();
 
         var ex5 = Assert.ThrowsExactly<InvalidOperationException>(() => sub.Observer.OnNext(42));
-        Assert.IsTrue(ex5.Message.Contains("terminated"));
+        Assert.Contains("terminated", ex5.Message);
         var ex6 = Assert.ThrowsExactly<InvalidOperationException>(() => sub.Observer.OnError(new Exception()));
-        Assert.IsTrue(ex6.Message.Contains("terminated"));
+        Assert.Contains("terminated", ex6.Message);
         var ex7 = Assert.ThrowsExactly<InvalidOperationException>(() => sub.Observer.OnCompleted());
-        Assert.IsTrue(ex7.Message.Contains("terminated"));
+        Assert.Contains("terminated", ex7.Message);
     }
 
     [TestMethod]
@@ -206,21 +206,21 @@ public class SubscribableBaseTests
         s.WaitOne();
 
         var ex2 = Assert.ThrowsExactly<InvalidOperationException>(() => sub.Observer.OnNext(43));
-        Assert.IsTrue(ex2.Message.Contains("processing"));
+        Assert.Contains("processing", ex2.Message);
         var ex3 = Assert.ThrowsExactly<InvalidOperationException>(() => sub.Observer.OnError(new Exception()));
-        Assert.IsTrue(ex3.Message.Contains("processing"));
+        Assert.Contains("processing", ex3.Message);
         var ex4 = Assert.ThrowsExactly<InvalidOperationException>(() => sub.Observer.OnCompleted());
-        Assert.IsTrue(ex4.Message.Contains("processing"));
+        Assert.Contains("processing", ex4.Message);
 
         e.Set();
         t.Wait();
 
         var ex5 = Assert.ThrowsExactly<InvalidOperationException>(() => sub.Observer.OnNext(42));
-        Assert.IsTrue(ex5.Message.Contains("terminated"));
+        Assert.Contains("terminated", ex5.Message);
         var ex6 = Assert.ThrowsExactly<InvalidOperationException>(() => sub.Observer.OnError(new Exception()));
-        Assert.IsTrue(ex6.Message.Contains("terminated"));
+        Assert.Contains("terminated", ex6.Message);
         var ex7 = Assert.ThrowsExactly<InvalidOperationException>(() => sub.Observer.OnCompleted());
-        Assert.IsTrue(ex7.Message.Contains("terminated"));
+        Assert.Contains("terminated", ex7.Message);
     }
 
     private sealed class MySubscribable : SubscribableBase<int>

--- a/Reaqtive/Core/Tests.Reaqtive.Core/Reaqtive/Subscriptions/CompositeSubscriptionTests.cs
+++ b/Reaqtive/Core/Tests.Reaqtive.Core/Reaqtive/Subscriptions/CompositeSubscriptionTests.cs
@@ -167,7 +167,7 @@ public class CompositeSubscriptionTests
             --n;
 
             Assert.AreEqual(n, cs.Count);
-            Assert.AreEqual(n, cs.Count());
+            Assert.HasCount(n, cs);
         }
 
         var ds2 = Enumerable.Range(0, N).Select(i => (i, s: new MySub())).ToList();
@@ -207,7 +207,7 @@ public class CompositeSubscriptionTests
             --n;
 
             Assert.AreEqual(n, cs.Count);
-            Assert.AreEqual(n, cs.Count());
+            Assert.HasCount(n, cs);
         }
 
         var ts = es.Skip(Q).ToList();

--- a/Reaqtive/Core/Tests.Reaqtive.Linq/Operators/SkipUntil.cs
+++ b/Reaqtive/Core/Tests.Reaqtive.Linq/Operators/SkipUntil.cs
@@ -92,15 +92,15 @@ public partial class SkipUntil : OperatorTestBase
         Assert.IsNotNull(operatorName);
 
         var operatorVersionMajor = reader.Read<int>();
-        Assert.IsTrue(operatorVersionMajor > 0);
+        Assert.IsGreaterThan(0, operatorVersionMajor);
 
         var operatorVersionMinor = reader.Read<int>();
-        Assert.IsTrue(operatorVersionMinor >= 0);
+        Assert.IsGreaterThanOrEqualTo(0, operatorVersionMinor);
 
         var operatorVersionBuild = reader.Read<int>();
-        Assert.IsTrue(operatorVersionBuild >= 0);
+        Assert.IsGreaterThanOrEqualTo(0, operatorVersionBuild);
 
         var operatorVersionRevision = reader.Read<int>();
-        Assert.IsTrue(operatorVersionRevision >= 0);
+        Assert.IsGreaterThanOrEqualTo(0, operatorVersionRevision);
     }
 }

--- a/Reaqtive/Core/Tests.Reaqtive.Linq/Operators/ToSubscribable.cs
+++ b/Reaqtive/Core/Tests.Reaqtive.Linq/Operators/ToSubscribable.cs
@@ -372,7 +372,7 @@ public class ToSubscribable : TestBase
 
     private static void AssertSchedulerThread()
     {
-        Assert.IsTrue(Thread.CurrentThread.Name.StartsWith("Reaqtive.Scheduler.Worker"));
+        Assert.StartsWith("Reaqtive.Scheduler.Worker", Thread.CurrentThread.Name);
     }
 
     private static IObservable<T> Hide<T>(IObservable<T> observable)

--- a/Reaqtive/Core/Tests.Reaqtive.Scheduler/Reaqtive/AccountingTests.cs
+++ b/Reaqtive/Core/Tests.Reaqtive.Scheduler/Reaqtive/AccountingTests.cs
@@ -99,8 +99,8 @@ public class AccountingTests
         Assert.AreEqual(N, childCounters.TaskExecutionCount);
         Assert.AreEqual(0, childCounters.TimerTickCount);
 
-        Assert.IsTrue(childCounters.Uptime > TimeSpan.Zero);
-        Assert.IsTrue(childCounters.PausedTime > TimeSpan.Zero);
+        Assert.IsGreaterThan(TimeSpan.Zero, childCounters.Uptime);
+        Assert.IsGreaterThan(TimeSpan.Zero, childCounters.PausedTime);
 
         //
         // Check the counters of the root scheduler.
@@ -191,8 +191,8 @@ public class AccountingTests
         Assert.AreEqual(N, childCounters.TaskExecutionCount);
         AssertTimerTickCount(childCounters.TimerTickCount);
 
-        Assert.IsTrue(childCounters.Uptime > TimeSpan.Zero);
-        Assert.IsTrue(childCounters.PausedTime > TimeSpan.Zero);
+        Assert.IsGreaterThan(TimeSpan.Zero, childCounters.Uptime);
+        Assert.IsGreaterThan(TimeSpan.Zero, childCounters.PausedTime);
 
         //
         // Check the counters of the root scheduler.

--- a/Reaqtive/Core/Tests.Reaqtive.Scheduler/Reaqtive/EpsilonSchedulerTests.cs
+++ b/Reaqtive/Core/Tests.Reaqtive.Scheduler/Reaqtive/EpsilonSchedulerTests.cs
@@ -603,7 +603,7 @@ public sealed class EpsilonSchedulerTests
             }
             else
             {
-                Assert.AreEqual(true, Volatile.Read(ref firstHasCalled));
+                Assert.IsTrue(Volatile.Read(ref firstHasCalled));
             }
 
             while (!q.IsEmpty)

--- a/Reaqtive/Core/Tests.Reaqtive.Scheduler/Reaqtive/EpsilonSchedulerTests.cs
+++ b/Reaqtive/Core/Tests.Reaqtive.Scheduler/Reaqtive/EpsilonSchedulerTests.cs
@@ -991,7 +991,7 @@ public sealed class EpsilonSchedulerTests
                     0));
         }
 
-        Assert.IsTrue(!ev.WaitOne(1000));
+        Assert.IsFalse(ev.WaitOne(1000));
     }
 
     private static void WaitForVerySoon(WaitHandle e) => WaitForExpected(e, ExpectedVerySoon);

--- a/Reaqtive/Core/Tests.Reaqtive.Scheduler/Reaqtive/NopSchedulerTests.cs
+++ b/Reaqtive/Core/Tests.Reaqtive.Scheduler/Reaqtive/NopSchedulerTests.cs
@@ -57,7 +57,7 @@ public class NopSchedulerTests
         Assert.IsFalse(hasError);
 
         var d = o.Now - DateTimeOffset.UtcNow;
-        Assert.IsTrue(d < TimeSpan.FromMinutes(1));
+        Assert.IsLessThan(TimeSpan.FromMinutes(1), d);
 
         n.Dispose();
         o.Dispose();

--- a/Reaqtor/Core/Client/Tests.Reaqtor.Client.Core/Reaqtor/QbserverTests.cs
+++ b/Reaqtor/Core/Client/Tests.Reaqtor.Client.Core/Reaqtor/QbserverTests.cs
@@ -66,7 +66,7 @@ public class QbserverTests
 
         Assert.IsNotNull(ioe);
 
-        Assert.IsTrue(ioe.Message.Contains("Concurrent calls"));
+        Assert.Contains("Concurrent calls", ioe.Message);
 
         var ex2 = Assert.ThrowsExactly<AggregateException>(() =>
             {
@@ -76,7 +76,7 @@ public class QbserverTests
 
         Assert.IsNotNull(ioe2);
 
-        Assert.IsTrue(ioe2.Message.Contains("Concurrent calls"));
+        Assert.Contains("Concurrent calls", ioe2.Message);
 
         var ex3 = Assert.ThrowsExactly<AggregateException>(() =>
             {
@@ -86,7 +86,7 @@ public class QbserverTests
 
         Assert.IsNotNull(ioe3);
 
-        Assert.IsTrue(ioe3.Message.Contains("Concurrent calls"));
+        Assert.Contains("Concurrent calls", ioe3.Message);
 
         var iv = new MyObserver<int>();
 

--- a/Reaqtor/Core/Engine/Tests.Reaqtor.QueryEngine/CheckpointingTests.cs
+++ b/Reaqtor/Core/Engine/Tests.Reaqtor.QueryEngine/CheckpointingTests.cs
@@ -29,6 +29,11 @@ using Reaqtor.Reliable;
 
 namespace Tests.Reaqtor.QueryEngine;
 
+// MSTEST0058 (no asserts in catch blocks) is a false positive for this file: the expected-exception
+// tests use a 'failed' flag with Assert.IsTrue(failed) after the try, so the catch-block asserts (on
+// ex.Message) run only on the expected throw and the test still fails if no exception is thrown.
+#pragma warning disable MSTEST0058
+
 [TestClass]
 public partial class CheckpointingTests : PhysicalTimeEngineTest
 {

--- a/Reaqtor/Core/Engine/Tests.Reaqtor.QueryEngine/CheckpointingTests.cs
+++ b/Reaqtor/Core/Engine/Tests.Reaqtor.QueryEngine/CheckpointingTests.cs
@@ -841,10 +841,10 @@ public partial class CheckpointingTests : PhysicalTimeEngineTest
 
         var dir1 = Dir(chkpt1);
 
-        Assert.AreEqual(1, dir1["Subscriptions"].Count(s => s.StartsWith("rx://bridge")));
-        Assert.AreEqual(1, dir1["Subjects"].Count(s => s.StartsWith("rx://bridge")));
-        Assert.AreEqual(1, dir1["Subjects"].Count(s => s.StartsWith("rx://tunnel")));
-        Assert.AreEqual(1, dir1["Subjects"].Count(s => s.StartsWith("rx://tollbooth")));
+        Assert.ContainsSingle(s => s.StartsWith("rx://bridge"), dir1["Subscriptions"]);
+        Assert.ContainsSingle(s => s.StartsWith("rx://bridge"), dir1["Subjects"]);
+        Assert.ContainsSingle(s => s.StartsWith("rx://tunnel"), dir1["Subjects"]);
+        Assert.ContainsSingle(s => s.StartsWith("rx://tollbooth"), dir1["Subjects"]);
 
         // Clear state ------------------------------------------------------------
 
@@ -882,10 +882,10 @@ public partial class CheckpointingTests : PhysicalTimeEngineTest
 
         var dir2 = Dir(chkpt2);
 
-        Assert.AreEqual(1, dir2["Subscriptions"].Count(s => s.StartsWith("rx://bridge")));
-        Assert.AreEqual(1, dir2["Subjects"].Count(s => s.StartsWith("rx://bridge")));
-        Assert.AreEqual(1, dir2["Subjects"].Count(s => s.StartsWith("rx://tunnel")));
-        Assert.AreEqual(1, dir2["Subjects"].Count(s => s.StartsWith("rx://tollbooth")));
+        Assert.ContainsSingle(s => s.StartsWith("rx://bridge"), dir2["Subscriptions"]);
+        Assert.ContainsSingle(s => s.StartsWith("rx://bridge"), dir2["Subjects"]);
+        Assert.ContainsSingle(s => s.StartsWith("rx://tunnel"), dir2["Subjects"]);
+        Assert.ContainsSingle(s => s.StartsWith("rx://tollbooth"), dir2["Subjects"]);
 
         // Clear state ------------------------------------------------------------
 
@@ -2087,7 +2087,7 @@ public partial class CheckpointingTests : PhysicalTimeEngineTest
         Assert.AreEqual(0, obv.Count(x => !x.StartsWith("mgmt"))); // none
 
         Assert.IsTrue(final.TryGetItemKeys("Subjects", out var str));
-        Assert.AreEqual(1, str.Count(x => !x.StartsWith("mgmt"))); // bridge
+        Assert.ContainsSingle(x => !x.StartsWith("mgmt"), str); // bridge
 
         Assert.IsTrue(final.TryGetItemKeys("Subscriptions", out var sub));
         Assert.AreEqual(2, sub.Count(x => !x.StartsWith("mgmt"))); // upstream + test
@@ -2409,7 +2409,7 @@ public partial class CheckpointingTests : PhysicalTimeEngineTest
         s2s.OnNext(4);
 
         var res = s3.Values;
-        Assert.AreEqual(1, res.Count);
+        Assert.HasCount(1, res);
         Assert.AreEqual(7, res[0]);
 
         // Checkpoint -------------------------------------------------------------
@@ -2645,7 +2645,7 @@ public partial class CheckpointingTests : PhysicalTimeEngineTest
         var s1 = mgr1.GetReliableObserver<int>("s1");
         var s1s = s1.Synchronize(qe1.Scheduler);
         s1s.OnNext(42, 1L);
-        Assert.AreEqual(1, mv1.Values.Count);
+        Assert.HasCount(1, mv1.Values);
         Assert.AreEqual(42, mv1.Values[0]);
 
         // Checkpoint -------------------------------------------------------------
@@ -2677,7 +2677,7 @@ public partial class CheckpointingTests : PhysicalTimeEngineTest
         s2s.OnNext(43, 2L);
 
         // Note that the `Crash()` caused the MockObserver to be cleared
-        Assert.AreEqual(1, mv2.Values.Count);
+        Assert.HasCount(1, mv2.Values);
         Assert.AreEqual(43, mv2.Values[0]);
 
         Crash();
@@ -2719,9 +2719,9 @@ public partial class CheckpointingTests : PhysicalTimeEngineTest
         var s1 = mgr1.GetReliableObserver<int>("s1");
         var s1s = s1.Synchronize(qe1.Scheduler);
         s1s.OnNext(42, 1L);
-        Assert.AreEqual(1, mv1.Values.Count);
+        Assert.HasCount(1, mv1.Values);
         Assert.AreEqual(44, mv1.Values[0]);
-        Assert.AreEqual(1, mv2.Values.Count);
+        Assert.HasCount(1, mv2.Values);
         Assert.AreEqual(42, mv2.Values[0]);
 
         // Checkpoint -------------------------------------------------------------
@@ -2754,9 +2754,9 @@ public partial class CheckpointingTests : PhysicalTimeEngineTest
         s2s.OnNext(43, 2L);
 
         // Note that the `Crash()` caused the MockObserver to be cleared
-        Assert.AreEqual(1, mv3.Values.Count);
+        Assert.HasCount(1, mv3.Values);
         Assert.AreEqual(45, mv3.Values[0]);
-        Assert.AreEqual(1, mv4.Values.Count);
+        Assert.HasCount(1, mv4.Values);
         Assert.AreEqual(43, mv4.Values[0]);
 
         Crash();
@@ -2791,7 +2791,7 @@ public partial class CheckpointingTests : PhysicalTimeEngineTest
         var s1 = mgr1.GetObserver<int>("s1");
         var s1s = s1.Synchronize(qe1.Scheduler);
         s1s.OnNext(42);
-        Assert.AreEqual(1, mv1.Values.Count);
+        Assert.HasCount(1, mv1.Values);
         Assert.AreEqual(42, mv1.Values[0]);
 
         // Checkpoint -------------------------------------------------------------
@@ -2823,7 +2823,7 @@ public partial class CheckpointingTests : PhysicalTimeEngineTest
         s2s.OnNext(43);
 
         // Note that the `Crash()` caused the MockObserver to be cleared
-        Assert.AreEqual(1, mv2.Values.Count);
+        Assert.HasCount(1, mv2.Values);
         Assert.AreEqual(43, mv2.Values[0]);
 
         Crash();
@@ -2865,9 +2865,9 @@ public partial class CheckpointingTests : PhysicalTimeEngineTest
         var s1 = mgr1.GetObserver<int>("s1");
         var s1s = s1.Synchronize(qe1.Scheduler);
         s1s.OnNext(42);
-        Assert.AreEqual(1, mv1.Values.Count);
+        Assert.HasCount(1, mv1.Values);
         Assert.AreEqual(44, mv1.Values[0]);
-        Assert.AreEqual(1, mv2.Values.Count);
+        Assert.HasCount(1, mv2.Values);
         Assert.AreEqual(42, mv2.Values[0]);
 
         // Checkpoint -------------------------------------------------------------
@@ -2900,9 +2900,9 @@ public partial class CheckpointingTests : PhysicalTimeEngineTest
         s2s.OnNext(43);
 
         // Note that the `Crash()` caused the MockObserver to be cleared
-        Assert.AreEqual(1, mv3.Values.Count);
+        Assert.HasCount(1, mv3.Values);
         Assert.AreEqual(45, mv3.Values[0]);
-        Assert.AreEqual(1, mv4.Values.Count);
+        Assert.HasCount(1, mv4.Values);
         Assert.AreEqual(43, mv4.Values[0]);
 
         Crash();
@@ -3231,7 +3231,7 @@ public partial class CheckpointingTests : PhysicalTimeEngineTest
         var in1 = v1.Synchronize(qe1.Scheduler);
         in1.OnNext(42);
 
-        Assert.AreEqual(1, mv1.Values.Count);
+        Assert.HasCount(1, mv1.Values);
         Assert.AreEqual(42, mv1.Values[0]);
 
         // Checkpoint -------------------------------------------------------------
@@ -3259,7 +3259,7 @@ public partial class CheckpointingTests : PhysicalTimeEngineTest
         in2.OnNext(43);
 
         // Note that the `Crash()` caused the MockObserver to be cleared
-        Assert.AreEqual(1, mv2.Values.Count);
+        Assert.HasCount(1, mv2.Values);
         Assert.AreEqual(43, mv2.Values[0]);
 
         Crash();
@@ -3397,7 +3397,7 @@ public partial class CheckpointingTests : PhysicalTimeEngineTest
         Assert.IsTrue(LockManager.Wait(l));
 
         var mv1 = GetMockObserver<int>("v1");
-        Assert.AreEqual(0, mv1.Values.Count);
+        Assert.IsEmpty(mv1.Values);
 
         var state = Checkpoint(qe1);
         RemoveQueryEngine(qe1);
@@ -3410,7 +3410,7 @@ public partial class CheckpointingTests : PhysicalTimeEngineTest
         Recover(qe2, state);
 
         // No state is recovered on first transition, so no values are pushed.
-        Assert.AreEqual(0, mv1.Values.Count);
+        Assert.IsEmpty(mv1.Values);
 
         var newState = Checkpoint(qe2);
         RemoveQueryEngine(qe2);
@@ -3462,7 +3462,7 @@ public partial class CheckpointingTests : PhysicalTimeEngineTest
         s2s.OnNext(4);
 
         var res = s3.Values;
-        Assert.AreEqual(1, res.Count);
+        Assert.HasCount(1, res);
         Assert.AreEqual(7, res[0]);
 
         // Checkpoint -------------------------------------------------------------
@@ -3568,7 +3568,7 @@ public partial class CheckpointingTests : PhysicalTimeEngineTest
         s2s.OnNext(4);
 
         var res = s3.Values;
-        Assert.AreEqual(1, res.Count);
+        Assert.HasCount(1, res);
         Assert.AreEqual(7, res[0]);
 
         // Checkpoint -------------------------------------------------------------
@@ -3861,7 +3861,7 @@ public partial class CheckpointingTests : PhysicalTimeEngineTest
 
         Recover(qe, store);
 
-        Assert.IsTrue(failedUris.Contains(new Uri("rx://bridge/v2/e2d763c7-a0a1-4680-9020-a51e39576915/upstream-subscription")));
+        Assert.Contains(new Uri("rx://bridge/v2/e2d763c7-a0a1-4680-9020-a51e39576915/upstream-subscription"), failedUris);
 
         store = Checkpoint(qe);
 
@@ -3931,7 +3931,7 @@ public partial class CheckpointingTests : PhysicalTimeEngineTest
 
         // The upstream subscription will be reachable through any delete APIs for cleanup, but not through the metadata API.
         Assert.IsNotNull(upstreamSubscriptionUri);
-        Assert.IsFalse(ctx.Subscriptions.AsEnumerable().Any(kv => kv.Key == upstreamSubscriptionUri));
+        Assert.DoesNotContain(kv => kv.Key == upstreamSubscriptionUri, ctx.Subscriptions.AsEnumerable());
 
         // Does not throw KeyNotFoundException...
         ctx.GetSubscription(upstreamSubscriptionUri).Dispose();
@@ -4013,22 +4013,22 @@ public partial class CheckpointingTests : PhysicalTimeEngineTest
         // Ensure we can't use these artifacts in subscriptions
         var failed = false;
         try { ctx.GetObservable<int>(intReturnUri).Subscribe(nopObserver, new Uri("test://subscription/2"), null); }
-        catch (InvalidOperationException ex) { failed = true; Assert.IsTrue(ex.Message.Contains(intReturnUri.ToCanonicalString())); }
+        catch (InvalidOperationException ex) { failed = true; Assert.Contains(intReturnUri.ToCanonicalString(), ex.Message); }
         Assert.IsTrue(failed);
 
         failed = false;
         try { ctx.Never<int>().Subscribe(ctx.GetObserver<int>(intNopUri), new Uri("test://subscription/2"), null); }
-        catch (InvalidOperationException ex) { failed = true; Assert.IsTrue(ex.Message.Contains(intNopUri.ToCanonicalString())); }
+        catch (InvalidOperationException ex) { failed = true; Assert.Contains(intNopUri.ToCanonicalString(), ex.Message); }
         Assert.IsTrue(failed);
 
         failed = false;
         try { ctx.GetObservable<int>(intStreamUri).Subscribe(nopObserver, new Uri("test://subscription/2"), null); }
-        catch (InvalidOperationException ex) { failed = true; Assert.IsTrue(ex.Message.Contains(intStreamUri.ToCanonicalString())); }
+        catch (InvalidOperationException ex) { failed = true; Assert.Contains(intStreamUri.ToCanonicalString(), ex.Message); }
         Assert.IsTrue(failed);
 
         failed = false;
         try { ctx.Never<int>().Subscribe(ctx.GetObserver<int>(intStreamUri), new Uri("test://subscription/2"), null); }
-        catch (InvalidOperationException ex) { failed = true; Assert.IsTrue(ex.Message.Contains(intStreamUri.ToCanonicalString())); }
+        catch (InvalidOperationException ex) { failed = true; Assert.Contains(intStreamUri.ToCanonicalString(), ex.Message); }
         Assert.IsTrue(failed);
 
         // Can remove still...
@@ -4182,32 +4182,32 @@ public partial class CheckpointingTests : PhysicalTimeEngineTest
         // Ensure we can't use these artifacts in subscriptions
         var failed = false;
         try { await ctx.GetObservable<int>(intReturnUri).SubscribeAsync(nopObserver, new Uri("test://subscription/2"), null, CancellationToken.None); }
-        catch (InvalidOperationException ex) { failed = true; Assert.IsTrue(ex.Message.Contains(intReturnUri.ToCanonicalString())); }
+        catch (InvalidOperationException ex) { failed = true; Assert.Contains(intReturnUri.ToCanonicalString(), ex.Message); }
         Assert.IsTrue(failed);
 
         failed = false;
         try { await ctx.Never<int>().SubscribeAsync(ctx.GetObserver<int>(intNopUri), new Uri("test://subscription/2"), null, CancellationToken.None); }
-        catch (InvalidOperationException ex) { failed = true; Assert.IsTrue(ex.Message.Contains(intNopUri.ToCanonicalString())); }
+        catch (InvalidOperationException ex) { failed = true; Assert.Contains(intNopUri.ToCanonicalString(), ex.Message); }
         Assert.IsTrue(failed);
 
         failed = false;
         try { await ctx.GetObservable<int>(intStreamUri).SubscribeAsync(nopObserver, new Uri("test://subscription/2"), null, CancellationToken.None); }
-        catch (InvalidOperationException ex) { failed = true; Assert.IsTrue(ex.Message.Contains(intStreamUri.ToCanonicalString())); }
+        catch (InvalidOperationException ex) { failed = true; Assert.Contains(intStreamUri.ToCanonicalString(), ex.Message); }
         Assert.IsTrue(failed);
 
         failed = false;
         try { await ctx.Never<int>().SubscribeAsync(ctx.GetObserver<int>(intStream2Uri), new Uri("test://subscription/2"), null, CancellationToken.None); }
-        catch (InvalidOperationException ex) { failed = true; Assert.IsTrue(ex.Message.Contains(intStream2Uri.ToCanonicalString())); }
+        catch (InvalidOperationException ex) { failed = true; Assert.Contains(intStream2Uri.ToCanonicalString(), ex.Message); }
         Assert.IsTrue(failed);
 
         failed = false;
         try { await ctx.GetObservable<int>(intStream2Uri).SubscribeAsync(nopObserver, new Uri("test://subscription/2"), null, CancellationToken.None); }
-        catch (InvalidOperationException ex) { failed = true; Assert.IsTrue(ex.Message.Contains(intStream2Uri.ToCanonicalString())); }
+        catch (InvalidOperationException ex) { failed = true; Assert.Contains(intStream2Uri.ToCanonicalString(), ex.Message); }
         Assert.IsTrue(failed);
 
         failed = false;
         try { await ctx.Never<int>().SubscribeAsync(ctx.GetObserver<int>(intStreamUri), new Uri("test://subscription/2"), null, CancellationToken.None); }
-        catch (InvalidOperationException ex) { failed = true; Assert.IsTrue(ex.Message.Contains(intStreamUri.ToCanonicalString())); }
+        catch (InvalidOperationException ex) { failed = true; Assert.Contains(intStreamUri.ToCanonicalString(), ex.Message); }
         Assert.IsTrue(failed);
 
         // Can remove still...
@@ -4489,8 +4489,8 @@ public partial class CheckpointingTests : PhysicalTimeEngineTest
 
             foreach (var subUri in subUris)
             {
-                Assert.IsTrue(blobLogData.Contains("Subscriptions\t" + subUri), "Missing subscription for " + subUri);
-                Assert.IsTrue(blobLogData.Contains("SubscriptionsRuntimeState\t" + subUri), "Missing subscription runtime state for " + subUri);
+                Assert.Contains("Subscriptions\t" + subUri, blobLogData, "Missing subscription for " + subUri);
+                Assert.Contains("SubscriptionsRuntimeState\t" + subUri, blobLogData, "Missing subscription runtime state for " + subUri);
             }
 
             try
@@ -4535,24 +4535,24 @@ public partial class CheckpointingTests : PhysicalTimeEngineTest
 
         Recover(qe, store);
 
-        Assert.AreEqual(0, undefined.Count);
+        Assert.IsEmpty(undefined);
 
         Checkpoint(qe, CheckpointKind.Full);
 
-        Assert.AreEqual(1, undefined.Count);
+        Assert.HasCount(1, undefined);
 
         var final = Checkpoint(qe, CheckpointKind.Full);
 
-        Assert.AreEqual(2, undefined.Count);
+        Assert.HasCount(2, undefined);
 
         Assert.IsTrue(final.TryGetItemKeys("Observables", out var obs));
-        Assert.AreEqual(1, obs.Count(x => !x.StartsWith("mgmt"))); // upstream
+        Assert.ContainsSingle(x => !x.StartsWith("mgmt"), obs); // upstream
 
         Assert.IsTrue(final.TryGetItemKeys("Observers", out var obv));
         Assert.AreEqual(0, obv.Count(x => !x.StartsWith("mgmt"))); // none
 
         Assert.IsTrue(final.TryGetItemKeys("Subjects", out var str));
-        Assert.AreEqual(1, str.Count(x => !x.StartsWith("mgmt"))); // bridge
+        Assert.ContainsSingle(x => !x.StartsWith("mgmt"), str); // bridge
 
         Assert.IsTrue(final.TryGetItemKeys("Subscriptions", out var sub));
         Assert.AreEqual(2, sub.Count(x => !x.StartsWith("mgmt"))); // upstream + test
@@ -4842,7 +4842,7 @@ public partial class CheckpointingTests : PhysicalTimeEngineTest
                 }
                 catch (AggregateException ex)
                 {
-                    Assert.AreEqual(1, ex.InnerExceptions.Count);
+                    Assert.HasCount(1, ex.InnerExceptions);
                     throw ex.InnerException;
                 }
             }

--- a/Reaqtor/Core/Engine/Tests.Reaqtor.QueryEngine/EntityMetricsTrackerTests.cs
+++ b/Reaqtor/Core/Engine/Tests.Reaqtor.QueryEngine/EntityMetricsTrackerTests.cs
@@ -47,7 +47,7 @@ public class EntityMetricsTrackerTests
         var elapsed = stopwatch.Elapsed;
         var metrics = Get(entity);
         var metric = metrics[Metric];
-        Assert.IsTrue(elapsed > metric);
+        Assert.IsGreaterThan(metric, elapsed);
         Set(entity, Metric, elapsed);
         metrics = Get(entity);
         metric = metrics[Metric];
@@ -59,7 +59,7 @@ public class EntityMetricsTrackerTests
     {
         var entity = new DummyResource();
         var metrics = Get(entity);
-        Assert.AreEqual(0, metrics.Count);
+        Assert.IsEmpty(metrics);
     }
 
     [TestMethod]
@@ -73,7 +73,7 @@ public class EntityMetricsTrackerTests
         entity.EndMetric(Metric);
         entity.SetMetric(Metric2, TimeSpan.Zero);
         var metrics = entity.GetMetrics();
-        Assert.AreEqual(0, metrics.Count);
+        Assert.IsEmpty(metrics);
 
         EntityMetricsTracker.ShouldTrack = wasTracking;
     }
@@ -85,7 +85,7 @@ public class EntityMetricsTrackerTests
         Set(entity, Metric, TimeSpan.Zero);
         End(entity, Metric);
         var metrics = Get(entity);
-        Assert.AreEqual(1, metrics.Count);
+        Assert.HasCount(1, metrics);
         Assert.AreEqual(TimeSpan.Zero, metrics[Metric]);
     }
 
@@ -95,7 +95,7 @@ public class EntityMetricsTrackerTests
         var entity = new DummyResource();
         Begin(entity, Metric);
         var metrics = Get(entity);
-        Assert.AreEqual(0, metrics.Count);
+        Assert.IsEmpty(metrics);
     }
 
     private static void Begin(IReactiveResource entity, EntityMetric metric)

--- a/Reaqtor/Core/Engine/Tests.Reaqtor.QueryEngine/ExceptionTests.cs
+++ b/Reaqtor/Core/Engine/Tests.Reaqtor.QueryEngine/ExceptionTests.cs
@@ -35,7 +35,7 @@ public class ExceptionTests
         Assert.AreSame(qe, ex.QueryEngineUri);
         Assert.AreEqual(ReactiveEntityKind.Observable, ex.EntityType);
         Assert.AreEqual(param, ex.ParamName);
-        Assert.IsTrue(ex.Message.Contains("already exists"));
+        Assert.Contains("already exists", ex.Message);
     }
 
     [TestMethod]
@@ -53,7 +53,7 @@ public class ExceptionTests
         Assert.AreSame(qe, ex.QueryEngineUri);
         Assert.AreEqual(ReactiveEntityKind.Observable, ex.EntityType);
         Assert.AreEqual(param, ex.ParamName);
-        Assert.IsTrue(ex.Message.Contains("already exists"));
+        Assert.Contains("already exists", ex.Message);
         Assert.AreSame(inner, ex.InnerException);
     }
 
@@ -85,7 +85,7 @@ public class ExceptionTests
         Assert.AreSame(qe, ex.QueryEngineUri);
         Assert.AreEqual(ReactiveEntityKind.Observable, ex.EntityType);
         Assert.AreEqual(param, ex.ParamName);
-        Assert.IsTrue(ex.Message.Contains("could not be found"));
+        Assert.Contains("could not be found", ex.Message);
     }
 
     [TestMethod]
@@ -103,7 +103,7 @@ public class ExceptionTests
         Assert.AreSame(qe, ex.QueryEngineUri);
         Assert.AreEqual(ReactiveEntityKind.Observable, ex.EntityType);
         Assert.AreEqual(param, ex.ParamName);
-        Assert.IsTrue(ex.Message.Contains("could not be found"));
+        Assert.Contains("could not be found", ex.Message);
         Assert.AreSame(inner, ex.InnerException);
     }
 
@@ -130,7 +130,7 @@ public class ExceptionTests
 
         Assert.AreSame(id, ex.EntityUri);
         Assert.AreEqual(ReactiveEntityKind.Observable, ex.EntityType);
-        Assert.IsTrue(ex.Message.Contains("failed to load"));
+        Assert.Contains("failed to load", ex.Message);
     }
 
     [TestMethod]
@@ -144,7 +144,7 @@ public class ExceptionTests
 
         Assert.AreSame(id, ex.EntityUri);
         Assert.AreEqual(ReactiveEntityKind.Observable, ex.EntityType);
-        Assert.IsTrue(ex.Message.Contains("failed to load"));
+        Assert.Contains("failed to load", ex.Message);
         Assert.AreSame(inner, ex.InnerException);
     }
 
@@ -171,7 +171,7 @@ public class ExceptionTests
 
         Assert.AreSame(id, ex.EntityUri);
         Assert.AreEqual(ReactiveEntityKind.Observable, ex.EntityType);
-        Assert.IsTrue(ex.Message.Contains("failed to save"));
+        Assert.Contains("failed to save", ex.Message);
     }
 
     [TestMethod]
@@ -185,7 +185,7 @@ public class ExceptionTests
 
         Assert.AreSame(id, ex.EntityUri);
         Assert.AreEqual(ReactiveEntityKind.Observable, ex.EntityType);
-        Assert.IsTrue(ex.Message.Contains("failed to save"));
+        Assert.Contains("failed to save", ex.Message);
         Assert.AreSame(inner, ex.InnerException);
     }
 
@@ -199,7 +199,7 @@ public class ExceptionTests
     {
         var ex = new EngineUnloadedException();
 
-        Assert.IsTrue(ex.Message.Contains("unloaded"));
+        Assert.Contains("unloaded", ex.Message);
     }
 
     [TestMethod]
@@ -217,7 +217,7 @@ public class ExceptionTests
         var ex = new EngineUnloadedException(ie);
 
         Assert.AreSame(ie, ex.InnerException);
-        Assert.IsTrue(ex.Message.Contains("unloaded"));
+        Assert.Contains("unloaded", ex.Message);
     }
 
     [TestMethod]

--- a/Reaqtor/Core/Engine/Tests.Reaqtor.QueryEngine/InMemoryKeyValueStoreTests.cs
+++ b/Reaqtor/Core/Engine/Tests.Reaqtor.QueryEngine/InMemoryKeyValueStoreTests.cs
@@ -37,7 +37,7 @@ public class InMemoryKeyValueTableTests
 
             var contents = table.ToList();
 
-            Assert.AreEqual(1, contents.Count);
+            Assert.HasCount(1, contents);
             Assert.AreEqual("A", contents[0].Key);
             CollectionAssert.AreEquivalent(contents[0].Value, new byte[] { 2 });
 
@@ -52,7 +52,7 @@ public class InMemoryKeyValueTableTests
         {
             var table = subtable.Enter(tx);
 
-            Assert.AreEqual(0, table.Count());
+            Assert.IsEmpty(table);
         }
     }
 
@@ -192,7 +192,7 @@ public class InMemoryKeyValueTableTests
 
             var contents = table.ToList();
 
-            Assert.AreEqual(1, contents.Count);
+            Assert.HasCount(1, contents);
             Assert.AreEqual("A", contents[0].Key);
             CollectionAssert.AreEquivalent(contents[0].Value, new byte[] { 2 });
 
@@ -227,7 +227,7 @@ public class InMemoryKeyValueTableTests
         {
             var table = subtable.Enter(tx);
 
-            Assert.AreEqual(0, table.Count());
+            Assert.IsEmpty(table);
         }
     }
 

--- a/Reaqtor/Core/Engine/Tests.Reaqtor.QueryEngine/InnerSubjectTests.cs
+++ b/Reaqtor/Core/Engine/Tests.Reaqtor.QueryEngine/InnerSubjectTests.cs
@@ -86,7 +86,7 @@ public class InnerSubjectTests
 
         var subject = GetSubject(id, svc);
 
-        Assert.AreEqual(0, subject.Inputs.Count());
+        Assert.IsEmpty(subject.Inputs);
     }
 
     [TestMethod]
@@ -191,7 +191,7 @@ public class InnerSubjectTests
 
         subject.Seal();
 
-        Assert.IsTrue(svc.DeletedStreams.Count == 0);
+        Assert.IsEmpty(svc.DeletedStreams);
 
         observer.OnNext(42);
         observer.OnNext(43);
@@ -200,7 +200,7 @@ public class InnerSubjectTests
         Assert.IsTrue(new[] { 42, 43 }.SequenceEqual(res));
         Assert.IsTrue(done);
 
-        Assert.IsTrue(svc.DeletedStreams.Count == 0);
+        Assert.IsEmpty(svc.DeletedStreams);
 
         sub.Dispose();
 
@@ -270,19 +270,19 @@ public class InnerSubjectTests
 
         subject.Seal();
 
-        Assert.IsTrue(svc.DeletedStreams.Count == 0);
+        Assert.IsEmpty(svc.DeletedStreams);
 
         observer.OnNext(42);
 
         subs[1].Dispose();
 
-        Assert.IsTrue(svc.DeletedStreams.Count == 0);
+        Assert.IsEmpty(svc.DeletedStreams);
 
         observer.OnNext(43);
 
         subs[0].Dispose();
 
-        Assert.IsTrue(svc.DeletedStreams.Count == 0);
+        Assert.IsEmpty(svc.DeletedStreams);
 
         var err = new Exception();
 

--- a/Reaqtor/Core/Engine/Tests.Reaqtor.QueryEngine/InnerSubjectTests.cs
+++ b/Reaqtor/Core/Engine/Tests.Reaqtor.QueryEngine/InnerSubjectTests.cs
@@ -121,7 +121,8 @@ public class InnerSubjectTests
         subject.Seal();
 
         var ctx = CreateOperatorContext(new Uri("tests://qux/1"), svc, new MiniScheduler());
-        Assert.ThrowsExactly<InvalidOperationException>(() => new SubscriptionInitializeVisitor(s1).Initialize(ctx));
+        var visitor = new SubscriptionInitializeVisitor(s1);
+        Assert.ThrowsExactly<InvalidOperationException>(() => visitor.Initialize(ctx));
 
         Assert.ThrowsExactly<InvalidOperationException>(() => subject.Subscribe(Observer.Nop<int>()));
     }

--- a/Reaqtor/Core/Engine/Tests.Reaqtor.QueryEngine/InnerSubjectTests.cs
+++ b/Reaqtor/Core/Engine/Tests.Reaqtor.QueryEngine/InnerSubjectTests.cs
@@ -120,11 +120,8 @@ public class InnerSubjectTests
 
         subject.Seal();
 
-        Assert.ThrowsExactly<InvalidOperationException>(() =>
-        {
-            var ctx = CreateOperatorContext(new Uri("tests://qux/1"), svc, new MiniScheduler());
-            new SubscriptionInitializeVisitor(s1).Initialize(ctx);
-        });
+        var ctx = CreateOperatorContext(new Uri("tests://qux/1"), svc, new MiniScheduler());
+        Assert.ThrowsExactly<InvalidOperationException>(() => new SubscriptionInitializeVisitor(s1).Initialize(ctx));
 
         Assert.ThrowsExactly<InvalidOperationException>(() => subject.Subscribe(Observer.Nop<int>()));
     }

--- a/Reaqtor/Core/Engine/Tests.Reaqtor.QueryEngine/InvertedLookupReactiveEntityCollectionTests.cs
+++ b/Reaqtor/Core/Engine/Tests.Reaqtor.QueryEngine/InvertedLookupReactiveEntityCollectionTests.cs
@@ -51,7 +51,7 @@ public class InvertedLookupReactiveEntityCollectionTests
 
         Assert.IsTrue(collection.RemovedKeys.SequenceEqual(["foo"]));
         collection.ClearRemovedKeys(["foo"]);
-        Assert.AreEqual(0, collection.RemovedKeys.Count());
+        Assert.IsEmpty(collection.RemovedKeys);
 
         collection.Add("foo", 1);
         collection.Add("qux", 3);
@@ -62,7 +62,7 @@ public class InvertedLookupReactiveEntityCollectionTests
             .SequenceEqual(new Dictionary<string, int> { { "foo", 1 }, { "bar", 2 }, { "qux", 3 }, { "baz", 4 } }.OrderBy(kv => kv.Value)));
 
         collection.Clear();
-        Assert.AreEqual(0, collection.Count());
+        Assert.IsEmpty(collection);
     }
 
     [TestMethod]

--- a/Reaqtor/Core/Engine/Tests.Reaqtor.QueryEngine/OneQueryEngineSanityTests.cs
+++ b/Reaqtor/Core/Engine/Tests.Reaqtor.QueryEngine/OneQueryEngineSanityTests.cs
@@ -557,7 +557,7 @@ public class OneQueryEngineSanityTests : PhysicalTimeEngineTest
         Assert.IsNotNull(v1);
         Assert.IsFalse(v1.Completed);
         Assert.IsFalse(v1.Error);
-        Assert.AreEqual(0, v1.Values.Count);
+        Assert.IsEmpty(v1.Values);
 
         var o1s = o1.Synchronize(qe.Scheduler);
 
@@ -578,7 +578,7 @@ public class OneQueryEngineSanityTests : PhysicalTimeEngineTest
 
         Assert.AreEqual(0, o1.SubscriptionCount);
 
-        Assert.AreEqual(10, v1.Values.Count);
+        Assert.HasCount(10, v1.Values);
 
         for (int i = 0; i < 10; i++)
         {
@@ -654,7 +654,7 @@ public class OneQueryEngineSanityTests : PhysicalTimeEngineTest
 
         Assert.IsTrue(res.Completed);
         Assert.IsFalse(res.Error);
-        Assert.AreEqual(1, res.Values.Count);
+        Assert.HasCount(1, res.Values);
     }
 
     [TestMethod]
@@ -679,7 +679,7 @@ public class OneQueryEngineSanityTests : PhysicalTimeEngineTest
 
         Assert.IsFalse(res.Completed);
         Assert.IsFalse(res.Error);
-        Assert.AreEqual(1, res.Values.Count);
+        Assert.HasCount(1, res.Values);
     }
 
     [TestMethod]
@@ -715,7 +715,7 @@ public class OneQueryEngineSanityTests : PhysicalTimeEngineTest
         s2s.OnNext(4);
 
         var res = s3.Values;
-        Assert.AreEqual(1, res.Count);
+        Assert.HasCount(1, res);
         Assert.AreEqual(7, res[0]);
 
         sub1.Dispose();
@@ -759,12 +759,12 @@ public class OneQueryEngineSanityTests : PhysicalTimeEngineTest
         s2v.OnNext(99);  // throttle signal
         s1v.OnNext(4);
 
-        Assert.AreEqual(1, s3.Values.Count);
+        Assert.HasCount(1, s3.Values);
         Assert.AreEqual(3, s3.Values[0]);
 
         s1v.OnCompleted();
 
-        Assert.AreEqual(2, s3.Values.Count);
+        Assert.HasCount(2, s3.Values);
         Assert.AreEqual(4, s3.Values[1]);
 
         sub1.Dispose();
@@ -949,12 +949,12 @@ public class OneQueryEngineSanityTests : PhysicalTimeEngineTest
 
             var ios = qe.ReactiveService.Observables.ToList();
             var upstreamObservables = ios.Where(io => io.Value.Uri.ToCanonicalString().StartsWith("rx://bridge")).ToList();
-            Assert.AreEqual(1, upstreamObservables.Count);
+            Assert.HasCount(1, upstreamObservables);
             var upstreamSubscriptions = subs.Where(s => s.Value.Uri.ToCanonicalString().StartsWith("rx://bridge")).ToList();
-            Assert.AreEqual(1, upstreamSubscriptions.Count);
+            Assert.HasCount(1, upstreamSubscriptions);
             var streams = qe.ReactiveService.Streams.ToList();
             var bridges = streams.Where(s => s.Value.Uri.ToCanonicalString().StartsWith("rx://bridge")).ToList();
-            Assert.AreEqual(1, bridges.Count);
+            Assert.HasCount(1, bridges);
             var ivs = qe.ReactiveService.Observers.ToList();
             var testObserver = ivs.Where(kv => kv.Value.Uri == testIvUri).Select(kv => kv.Value).SingleOrDefault();
             Assert.IsNotNull(testObserver);

--- a/Reaqtor/Core/Engine/Tests.Reaqtor.QueryEngine/PhysicalTimeEngineTest.cs
+++ b/Reaqtor/Core/Engine/Tests.Reaqtor.QueryEngine/PhysicalTimeEngineTest.cs
@@ -115,7 +115,7 @@ public abstract class PhysicalTimeEngineTest : QueryEngineTest
         {
             Assert.IsFalse(v.Completed);
             Assert.IsFalse(v.Error);
-            Assert.AreEqual(0, v.Values.Count);
+            Assert.IsEmpty(v.Values);
         }
 
         return v;
@@ -123,7 +123,7 @@ public abstract class PhysicalTimeEngineTest : QueryEngineTest
 
     internal static void AssertResult<T>(MockObserver<T> observer, int expectedCount, Action<int, T> validator)
     {
-        Assert.AreEqual(expectedCount, observer.Values.Count);
+        Assert.HasCount(expectedCount, observer.Values);
         for (int i = 0; i < expectedCount; i++)
         {
             validator(i, observer.Values[i]);
@@ -132,7 +132,7 @@ public abstract class PhysicalTimeEngineTest : QueryEngineTest
 
     internal static void AssertResultSequence<T>(MockObserver<T> observer, IEnumerable<T> expected)
     {
-        Assert.AreEqual(expected.Count(), observer.Values.Count);
+        Assert.HasCount(expected.Count(), observer.Values);
         foreach (var (Expected, Actual) in expected.Zip(observer.Values, (e, a) => (Expected: e, Actual: a)))
         {
             Assert.AreEqual(Expected, Actual);
@@ -141,7 +141,7 @@ public abstract class PhysicalTimeEngineTest : QueryEngineTest
 
     internal static void AssertResultSequenceSet<T>(MockObserver<T> observer, IEnumerable<T> expected)
     {
-        Assert.AreEqual(expected.Count(), observer.Values.Count);
+        Assert.HasCount(expected.Count(), observer.Values);
 
         var obs = new HashSet<T>(observer.Values);
 

--- a/Reaqtor/Core/Engine/Tests.Reaqtor.QueryEngine/ProgressTests.cs
+++ b/Reaqtor/Core/Engine/Tests.Reaqtor.QueryEngine/ProgressTests.cs
@@ -478,7 +478,7 @@ public class ProgressTests
 
         var p = Progress.Create<int>(x => { res = x; }).SplitWeight();
 
-        Assert.AreEqual(0, p.Length);
+        Assert.IsEmpty(p);
     }
 
     [TestMethod]
@@ -488,7 +488,7 @@ public class ProgressTests
 
         var p = Progress.Create<int>(x => { res = x; }).SplitWeight(20, 30, 40, 10);
 
-        Assert.AreEqual(4, p.Length);
+        Assert.HasCount(4, p);
         var p1 = p[0];
         var p2 = p[1];
         var p3 = p[2];

--- a/Reaqtor/Core/Engine/Tests.Reaqtor.QueryEngine/QueryEngineRegistryTemplatizerTests.cs
+++ b/Reaqtor/Core/Engine/Tests.Reaqtor.QueryEngine/QueryEngineRegistryTemplatizerTests.cs
@@ -24,7 +24,7 @@ public class QueryEngineRegistryTemplatizerTests
         var registry = CreateRegistry();
         var templatizer = CreateTemplatizer(registry);
 
-        Assert.AreEqual(0, registry.Templates.Count());
+        Assert.IsEmpty(registry.Templates);
 
         var templatized = (InvocationExpression)templatizer.Templatize(SimpleExpression);
         Assert.AreEqual(SimpleExpression.Type, templatized.Type);
@@ -34,7 +34,7 @@ public class QueryEngineRegistryTemplatizerTests
 
         Assert.IsNotNull(templatizedBody);
         Assert.AreEqual(template.Key, templatizedBody.Name);
-        Assert.AreEqual(1, templatized.Arguments.Count);
+        Assert.HasCount(1, templatized.Arguments);
         Assert.AreEqual(Tuple.Create(42), templatized.Arguments.First().Evaluate());
     }
 
@@ -44,7 +44,7 @@ public class QueryEngineRegistryTemplatizerTests
         var registry = CreateRegistry();
         var templatizer = CreateTemplatizer(registry);
 
-        Assert.AreEqual(0, registry.Templates.Count());
+        Assert.IsEmpty(registry.Templates);
 
         var templatized = (InvocationExpression)templatizer.Templatize(SimpleExpression);
         var template = registry.Templates.First();
@@ -52,11 +52,11 @@ public class QueryEngineRegistryTemplatizerTests
 
         Assert.IsNotNull(templatizedBody);
         Assert.AreEqual(template.Key, templatizedBody.Name);
-        Assert.AreEqual(1, templatized.Arguments.Count);
+        Assert.HasCount(1, templatized.Arguments);
         Assert.AreEqual(Tuple.Create(42), templatized.Arguments.First().Evaluate());
 
         _ = templatizer.Templatize(SimpleExpression2);
-        Assert.AreEqual(1, registry.Templates.Count());
+        Assert.HasCount(1, registry.Templates);
     }
 
     [TestMethod]
@@ -103,7 +103,7 @@ public class QueryEngineRegistryTemplatizerTests
             var t2 = ((InvocationExpression)r2).Expression;
 
             Assert.AreEqual(((ParameterExpression)t1).Name, ((ParameterExpression)t2).Name);
-            Assert.AreEqual(1, registry.Templates.Count());
+            Assert.HasCount(1, registry.Templates);
         }
     }
 
@@ -116,7 +116,7 @@ public class QueryEngineRegistryTemplatizerTests
         Assert.AreNotSame(IdentityExpression, templated);
         var f = templatizer.Detemplatize(templated);
         AssertEquals(IdentityExpression, f);
-        Assert.AreEqual(1, registry.Templates.Count());
+        Assert.HasCount(1, registry.Templates);
     }
 
     [TestMethod]

--- a/Reaqtor/Core/Engine/Tests.Reaqtor.QueryEngine/TemplatizationHelpersTests.cs
+++ b/Reaqtor/Core/Engine/Tests.Reaqtor.QueryEngine/TemplatizationHelpersTests.cs
@@ -58,7 +58,7 @@ public class TemplatizationHelpersTests
         var appliedTemplate = withConstants.TemplatizeAndIdentify();
         Assert.AreNotSame(withConstants, appliedTemplate.Expression);
         Assert.AreEqual(typeof(Func<Tuple<int>, Func<string>>), appliedTemplate.Template.Type);
-        Assert.IsTrue(appliedTemplate.TemplateId.StartsWith(TemplatizationHelpers.TemplateBase));
+        Assert.StartsWith(TemplatizationHelpers.TemplateBase, appliedTemplate.TemplateId);
     }
 
     [TestMethod]

--- a/Reaqtor/Core/Engine/Tests.Reaqtor.QueryEngine/Utils/TestableEntityFactory.cs
+++ b/Reaqtor/Core/Engine/Tests.Reaqtor.QueryEngine/Utils/TestableEntityFactory.cs
@@ -19,40 +19,42 @@ public static class TestableEntityFactory
 
     public static IObserver<T> CreateObserver<T>(string id)
     {
-        if (!Observers.ContainsKey(id))
+        if (!Observers.TryGetValue(id, out var observer))
         {
-            Observers.Add(id, Scheduler.CreateObserver<T>());
+            observer = Scheduler.CreateObserver<T>();
+            Observers.Add(id, observer);
         }
-        return Observers[id] as IObserver<T>;
+        return observer as IObserver<T>;
     }
 
     public static ITestableObserver<T> GetObserver<T>(string id)
     {
-        if (!Observers.ContainsKey(id))
+        if (!Observers.TryGetValue(id, out var observer))
         {
             return null;
         }
 
-        return Observers[id] as ITestableObserver<T>;
+        return observer as ITestableObserver<T>;
     }
 
     public static ISubscribable<T> CreateColdSubscribable<T>(string id, Recorded<Notification<T>>[] messages)
     {
-        if (!Subscribables.ContainsKey(id))
+        if (!Subscribables.TryGetValue(id, out var subscribable))
         {
-            Subscribables.Add(id, Scheduler.CreateColdObservable(messages));
+            subscribable = Scheduler.CreateColdObservable(messages);
+            Subscribables.Add(id, subscribable);
         }
-        return Subscribables[id] as ISubscribable<T>;
+        return subscribable as ISubscribable<T>;
     }
 
     public static ITestableSubscribable<T> GetSubscribable<T>(string id)
     {
-        if (!Subscribables.ContainsKey(id))
+        if (!Subscribables.TryGetValue(id, out var subscribable))
         {
             return null;
         }
 
-        return Subscribables[id] as ITestableSubscribable<T>;
+        return subscribable as ITestableSubscribable<T>;
     }
 
     public static void Clear()

--- a/Reaqtor/Core/Engine/Tests.Reaqtor.QueryEngine/VirtualTimeEngineTest.cs
+++ b/Reaqtor/Core/Engine/Tests.Reaqtor.QueryEngine/VirtualTimeEngineTest.cs
@@ -15,7 +15,6 @@ namespace Tests.Reaqtor.QueryEngine;
 
 using TestScheduler = global::Reaqtive.TestingFramework.TestScheduler;
 
-[TestClass]
 public abstract class VirtualTimeEngineTest : QueryEngineTest
 {
     internal static readonly Uri TestableObservableUri = new("a:/TestableObservable");

--- a/Reaqtor/Core/Hosting/Tests.Reaqtor.Hosting.Service/Internal/DataModelTypeUnifierTests.cs
+++ b/Reaqtor/Core/Hosting/Tests.Reaqtor.Hosting.Service/Internal/DataModelTypeUnifierTests.cs
@@ -25,32 +25,32 @@ public class DataModelTypeUnifierTests
     [TestMethod]
     public void DataModelTypeUnifier_UnifySimple_NoMappings()
     {
-        Assert.AreEqual(0, Unify(typeof(IAsyncReactiveQbservable<int>), typeof(IReactiveQbservable<int>)).ToArray().Length);
+        Assert.IsEmpty(Unify(typeof(IAsyncReactiveQbservable<int>), typeof(IReactiveQbservable<int>)).ToArray());
     }
 
     [TestMethod]
     public void DataModelTypeUnifier_UnifyEnum_NoMappings()
     {
-        Assert.AreEqual(0, Unify(typeof(IAsyncReactiveQbservable<int>), typeof(IReactiveQbservable<FooEnum>)).ToArray().Length);
+        Assert.IsEmpty(Unify(typeof(IAsyncReactiveQbservable<int>), typeof(IReactiveQbservable<FooEnum>)).ToArray());
     }
 
     [TestMethod]
     public void DataModelTypeUnifier_UnifyOther_NoMappings()
     {
-        Assert.AreEqual(0, Unify(typeof(IAsyncReactiveQbservable<int>), typeof(List<int>)).ToArray().Length);
-        Assert.AreEqual(0, Unify(typeof(IAsyncReactiveQbservable<int>), typeof(List<int>)).ToArray().Length);
+        Assert.IsEmpty(Unify(typeof(IAsyncReactiveQbservable<int>), typeof(List<int>)).ToArray());
+        Assert.IsEmpty(Unify(typeof(IAsyncReactiveQbservable<int>), typeof(List<int>)).ToArray());
     }
 
     [TestMethod]
     public void DataModelTypeUnifier_UnifyDataModelFromStructural()
     {
         var record = RuntimeCompiler.CreateRecordType(new Dictionary<string, Type> { { "bar", typeof(int) } }, valueEquality: true);
-        Assert.AreEqual(1, Unify(typeof(IAsyncReactiveQbservable<>).MakeGenericType(record), typeof(IReactiveQbservable<Foo>)).ToArray().Length);
-        Assert.AreEqual(1, Unify(typeof(IAsyncReactiveQbserver<>).MakeGenericType(record), typeof(IReactiveQbserver<Foo>)).ToArray().Length);
-        Assert.AreEqual(1, Unify(typeof(IAsyncReactiveQubjectFactory<,>).MakeGenericType(record, record), typeof(IReactiveQubjectFactory<Foo, Foo>)).ToArray().Length);
-        Assert.AreEqual(1, Unify(typeof(IAsyncReactiveQubscriptionFactory<>).MakeGenericType(record), typeof(IReactiveQubscriptionFactory<Foo>)).ToArray().Length);
-        Assert.AreEqual(1, Unify(typeof(IAsyncReactiveQubject<>).MakeGenericType(record), typeof(IReactiveQubject<Foo>)).ToArray().Length);
-        Assert.AreEqual(1, Unify(typeof(IAsyncReactiveQubject<,>).MakeGenericType(record, record), typeof(IReactiveQubject<Foo, Foo>)).ToArray().Length);
+        Assert.HasCount(1, Unify(typeof(IAsyncReactiveQbservable<>).MakeGenericType(record), typeof(IReactiveQbservable<Foo>)).ToArray());
+        Assert.HasCount(1, Unify(typeof(IAsyncReactiveQbserver<>).MakeGenericType(record), typeof(IReactiveQbserver<Foo>)).ToArray());
+        Assert.HasCount(1, Unify(typeof(IAsyncReactiveQubjectFactory<,>).MakeGenericType(record, record), typeof(IReactiveQubjectFactory<Foo, Foo>)).ToArray());
+        Assert.HasCount(1, Unify(typeof(IAsyncReactiveQubscriptionFactory<>).MakeGenericType(record), typeof(IReactiveQubscriptionFactory<Foo>)).ToArray());
+        Assert.HasCount(1, Unify(typeof(IAsyncReactiveQubject<>).MakeGenericType(record), typeof(IReactiveQubject<Foo>)).ToArray());
+        Assert.HasCount(1, Unify(typeof(IAsyncReactiveQubject<,>).MakeGenericType(record, record), typeof(IReactiveQubject<Foo, Foo>)).ToArray());
     }
 
     [TestMethod]
@@ -58,14 +58,14 @@ public class DataModelTypeUnifierTests
     {
         var record1 = RuntimeCompiler.CreateRecordType(new Dictionary<string, Type> { { "bar", typeof(int) } }, valueEquality: true);
         var record2 = RuntimeCompiler.CreateRecordType(new Dictionary<string, Type> { { "qux", typeof(int) } }, valueEquality: true);
-        Assert.AreEqual(2, Unify(typeof(Func<,>).MakeGenericType(record2, typeof(IAsyncReactiveQbservable<>).MakeGenericType(record1)), typeof(Func<Bar, IReactiveQbservable<Foo>>)).ToArray().Length);
+        Assert.HasCount(2, Unify(typeof(Func<,>).MakeGenericType(record2, typeof(IAsyncReactiveQbservable<>).MakeGenericType(record1)), typeof(Func<Bar, IReactiveQbservable<Foo>>)).ToArray());
     }
 
     [TestMethod]
     public void DataModelTypeUnifier_UnifyRecursive()
     {
         var record = RuntimeCompiler.CreateRecordType(new Dictionary<string, Type> { { "bar", typeof(int) } }, valueEquality: true);
-        Assert.AreEqual(1, Unify(typeof(IAsyncReactiveQbservable<>).MakeGenericType(typeof(IAsyncReactiveQbservable<>).MakeGenericType(record)), typeof(IReactiveQbservable<IReactiveQbservable<Foo>>)).ToArray().Length);
+        Assert.HasCount(1, Unify(typeof(IAsyncReactiveQbservable<>).MakeGenericType(typeof(IAsyncReactiveQbservable<>).MakeGenericType(record)), typeof(IReactiveQbservable<IReactiveQbservable<Foo>>)).ToArray());
     }
 
     [TestMethod]
@@ -78,15 +78,15 @@ public class DataModelTypeUnifierTests
         // Unfortunately, the type unifier is only informed of the expressible variants of the Reactive entity types. It
         // is not aware of implementation specific types, such as ISubscribable, which would more likely be found in
         // structural types.
-        Assert.AreEqual(2, Unify(typeof(IAsyncReactiveQbservable<>).MakeGenericType(record2), typeof(IReactiveQbservable<Rec>)).ToArray().Length);
+        Assert.HasCount(2, Unify(typeof(IAsyncReactiveQbservable<>).MakeGenericType(record2), typeof(IReactiveQbservable<Rec>)).ToArray());
     }
 
     [TestMethod]
     public void DataModelTypeUnifier_UnifyByPropertyName()
     {
         var record = RuntimeCompiler.CreateRecordType(new Dictionary<string, Type> { { "Bar", typeof(int) } }, valueEquality: true);
-        Assert.AreEqual(1, Unify(typeof(IAsyncReactiveQbservable<>).MakeGenericType(record), typeof(IReactiveQbservable<FooNoDM>)).ToArray().Length);
-        Assert.AreEqual(1, Unify(typeof(IAsyncReactiveQbservable<>).MakeGenericType(record), typeof(IReactiveQbservable<Foo>)).ToArray().Length);
+        Assert.HasCount(1, Unify(typeof(IAsyncReactiveQbservable<>).MakeGenericType(record), typeof(IReactiveQbservable<FooNoDM>)).ToArray());
+        Assert.HasCount(1, Unify(typeof(IAsyncReactiveQbservable<>).MakeGenericType(record), typeof(IReactiveQbservable<Foo>)).ToArray());
     }
 
     public enum FooEnum

--- a/Reaqtor/Core/Hosting/Tests.Reaqtor.Hosting.Service/Serialization/UnifyingSerializationHelpersTests.cs
+++ b/Reaqtor/Core/Hosting/Tests.Reaqtor.Hosting.Service/Serialization/UnifyingSerializationHelpersTests.cs
@@ -98,7 +98,7 @@ public class UnifyingSerializationHelpersTests
 
         var parameter = ExpressionSlim.Parameter(typeof(Func<int, IAsyncReactiveQbservable<int>>).ToTypeSlim(), uri.ToCanonicalString());
         var mappings = UnifyingSerializationHelpers.FindAndUnify(parameter, metadata);
-        Assert.AreEqual(0, mappings.Count());
+        Assert.IsEmpty(mappings);
     }
 
     [TestMethod]

--- a/Reaqtor/Core/Hosting/Tests.Reaqtor.Hosting.Service/Serialization/UnifyingSerializationHelpersTests.cs
+++ b/Reaqtor/Core/Hosting/Tests.Reaqtor.Hosting.Service/Serialization/UnifyingSerializationHelpersTests.cs
@@ -113,7 +113,7 @@ public class UnifyingSerializationHelpersTests
         var observerableType = TypeSlim.Generic(((GenericDefinitionTypeSlim)typeof(IAsyncReactiveQbservable<>).ToTypeSlim()), new TypeSlim[] { structuralType }.ToReadOnly());
         var parameter = ExpressionSlim.Parameter(observerableType, uri.ToCanonicalString());
         var mappings = UnifyingSerializationHelpers.FindAndUnify(parameter, metadata);
-        Assert.AreEqual(1, mappings.Count());
+        Assert.HasCount(1, mappings);
     }
 
     [TestMethod]

--- a/Reaqtor/Core/Hosting/Tests.Reaqtor.Hosting.Service/Serialization/UnifyingSerializationHelpersTests.cs
+++ b/Reaqtor/Core/Hosting/Tests.Reaqtor.Hosting.Service/Serialization/UnifyingSerializationHelpersTests.cs
@@ -26,7 +26,7 @@ public class UnifyingSerializationHelpersTests
 
         var parameter = ExpressionSlim.Parameter(typeof(IAsyncReactiveQbservable<int>).ToTypeSlim(), uri.ToCanonicalString());
         var mappings = UnifyingSerializationHelpers.FindAndUnify(parameter, metadata);
-        Assert.AreEqual(0, mappings.Count());
+        Assert.IsEmpty(mappings);
     }
 
     [TestMethod]
@@ -38,7 +38,7 @@ public class UnifyingSerializationHelpersTests
 
         var parameter = ExpressionSlim.Parameter(typeof(IAsyncReactiveQbserver<int>).ToTypeSlim(), uri.ToCanonicalString());
         var mappings = UnifyingSerializationHelpers.FindAndUnify(parameter, metadata);
-        Assert.AreEqual(0, mappings.Count());
+        Assert.IsEmpty(mappings);
     }
 
     [TestMethod]
@@ -50,7 +50,7 @@ public class UnifyingSerializationHelpersTests
 
         var parameter = ExpressionSlim.Parameter(typeof(IAsyncReactiveQubjectFactory<int, int>).ToTypeSlim(), uri.ToCanonicalString());
         var mappings = UnifyingSerializationHelpers.FindAndUnify(parameter, metadata);
-        Assert.AreEqual(0, mappings.Count());
+        Assert.IsEmpty(mappings);
     }
 
     [TestMethod]
@@ -62,7 +62,7 @@ public class UnifyingSerializationHelpersTests
 
         var parameter = ExpressionSlim.Parameter(typeof(IAsyncReactiveQubscriptionFactory).ToTypeSlim(), uri.ToCanonicalString());
         var mappings = UnifyingSerializationHelpers.FindAndUnify(parameter, metadata);
-        Assert.AreEqual(0, mappings.Count());
+        Assert.IsEmpty(mappings);
     }
 
     [TestMethod]
@@ -74,7 +74,7 @@ public class UnifyingSerializationHelpersTests
 
         var parameter = ExpressionSlim.Parameter(typeof(IAsyncReactiveQubject<int, int>).ToTypeSlim(), uri.ToCanonicalString());
         var mappings = UnifyingSerializationHelpers.FindAndUnify(parameter, metadata);
-        Assert.AreEqual(0, mappings.Count());
+        Assert.IsEmpty(mappings);
     }
 
     [TestMethod]
@@ -86,7 +86,7 @@ public class UnifyingSerializationHelpersTests
 
         var parameter = ExpressionSlim.Parameter(typeof(IAsyncReactiveQubscription).ToTypeSlim(), uri.ToCanonicalString());
         var mappings = UnifyingSerializationHelpers.FindAndUnify(parameter, metadata);
-        Assert.AreEqual(0, mappings.Count());
+        Assert.IsEmpty(mappings);
     }
 
     [TestMethod]

--- a/Reaqtor/Core/Hosting/Tests.Reaqtor.Hosting.Shared/Tools/ReactiveEntityFinderTests.cs
+++ b/Reaqtor/Core/Hosting/Tests.Reaqtor.Hosting.Shared/Tools/ReactiveEntityFinderTests.cs
@@ -94,7 +94,7 @@ public class ReactiveEntityFinderTests
         var comparer = new ExpressionEqualityComparer(() => new Comparator());
         var found = ReactiveEntityFinder.Find(expression.ToExpressionSlim());
         var total = found.SelectMany(kv => kv.Value).Count();
-        Assert.AreEqual(total, results.Length);
+        Assert.HasCount(total, results);
         foreach (var result in results)
         {
             Assert.IsTrue(found.ContainsKey(result.Item1));

--- a/Reaqtor/Core/Reactive/Tests.Reaqtor.Reactive.HigherOrder/Reaqtor/Reactive/Expressions/QuotationTests.cs
+++ b/Reaqtor/Core/Reactive/Tests.Reaqtor.Reactive.HigherOrder/Reaqtor/Reactive/Expressions/QuotationTests.cs
@@ -47,7 +47,7 @@ public class QuotationTests
 
         Assert.IsFalse(c.HasAccessed);
 
-        Assert.IsTrue(q.ToString().Contains("42"));
+        Assert.Contains("42", q.ToString());
     }
 
     [TestMethod]
@@ -68,7 +68,7 @@ public class QuotationTests
 
         Assert.IsTrue(c.HasAccessed);
 
-        Assert.IsTrue(q.ToString().Contains("42"));
+        Assert.Contains("42", q.ToString());
     }
 
     [TestMethod]

--- a/Reaqtor/Core/Reactive/Tests.Reaqtor.Reactive.Linq.Hosted/GroupBy.cs
+++ b/Reaqtor/Core/Reactive/Tests.Reaqtor.Reactive.Linq.Hosted/GroupBy.cs
@@ -185,8 +185,8 @@ public partial class GroupBy : TestBase
                 }).Apply(s);
 
                 Assert.IsNotNull(ds);
-                Assert.AreEqual(1, ds.Count(d => d.OriginalString.StartsWith("rx://tollbooth")));
-                Assert.AreEqual(1, ds.Count(d => d.OriginalString.StartsWith("rx://collector")));
+                Assert.ContainsSingle(d => d.OriginalString.StartsWith("rx://tollbooth"), ds);
+                Assert.ContainsSingle(d => d.OriginalString.StartsWith("rx://collector"), ds);
                 Assert.AreEqual(0, ds.Count(d => d.OriginalString.StartsWith("rx://tunnel/group")));
             });
 
@@ -200,9 +200,9 @@ public partial class GroupBy : TestBase
                 }).Apply(s);
 
                 Assert.IsNotNull(ds);
-                Assert.AreEqual(1, ds.Count(d => d.OriginalString.StartsWith("rx://tollbooth")));
-                Assert.AreEqual(1, ds.Count(d => d.OriginalString.StartsWith("rx://collector")));
-                Assert.AreEqual(1, ds.Count(d => d.OriginalString.StartsWith("rx://tunnel/group")));
+                Assert.ContainsSingle(d => d.OriginalString.StartsWith("rx://tollbooth"), ds);
+                Assert.ContainsSingle(d => d.OriginalString.StartsWith("rx://collector"), ds);
+                Assert.ContainsSingle(d => d.OriginalString.StartsWith("rx://tunnel/group"), ds);
             });
 
             for (var t = 225; t < 300; t += 10)
@@ -217,8 +217,8 @@ public partial class GroupBy : TestBase
                     }).Apply(s);
 
                     Assert.IsNotNull(ds);
-                    Assert.AreEqual(1, ds.Count(d => d.OriginalString.StartsWith("rx://tollbooth")));
-                    Assert.AreEqual(1, ds.Count(d => d.OriginalString.StartsWith("rx://collector")));
+                    Assert.ContainsSingle(d => d.OriginalString.StartsWith("rx://tollbooth"), ds);
+                    Assert.ContainsSingle(d => d.OriginalString.StartsWith("rx://collector"), ds);
                     Assert.AreEqual(2, ds.Count(d => d.OriginalString.StartsWith("rx://tunnel/group")));
                 });
             }

--- a/Reaqtor/Core/Reactive/Tests.Reaqtor.Reactive.Linq.Hosted/Window.cs
+++ b/Reaqtor/Core/Reactive/Tests.Reaqtor.Reactive.Linq.Hosted/Window.cs
@@ -137,9 +137,9 @@ public partial class Window : TestBase
                     }).Apply(s);
 
                     Assert.IsNotNull(ds);
-                    Assert.AreEqual(1, ds.Count(d => d.OriginalString.StartsWith("rx://tollbooth")));
-                    Assert.AreEqual(1, ds.Count(d => d.OriginalString.StartsWith("rx://collector")));
-                    Assert.AreEqual(1, ds.Count(d => d.OriginalString.StartsWith("rx://tunnel/window")));
+                    Assert.ContainsSingle(d => d.OriginalString.StartsWith("rx://tollbooth"), ds);
+                    Assert.ContainsSingle(d => d.OriginalString.StartsWith("rx://collector"), ds);
+                    Assert.ContainsSingle(d => d.OriginalString.StartsWith("rx://tunnel/window"), ds);
                 });
             }
 
@@ -187,9 +187,9 @@ public partial class Window : TestBase
                 }).Apply(s);
 
                 Assert.IsNotNull(ds);
-                Assert.AreEqual(1, ds.Count(d => d.OriginalString.StartsWith("rx://tollbooth")));
-                Assert.AreEqual(1, ds.Count(d => d.OriginalString.StartsWith("rx://collector")));
-                Assert.AreEqual(1, ds.Count(d => d.OriginalString.StartsWith("rx://tunnel/window")));
+                Assert.ContainsSingle(d => d.OriginalString.StartsWith("rx://tollbooth"), ds);
+                Assert.ContainsSingle(d => d.OriginalString.StartsWith("rx://collector"), ds);
+                Assert.ContainsSingle(d => d.OriginalString.StartsWith("rx://tunnel/window"), ds);
             });
 
             foreach (var t in new[] { 235, 255, 275 })
@@ -204,8 +204,8 @@ public partial class Window : TestBase
                     }).Apply(s);
 
                     Assert.IsNotNull(ds);
-                    Assert.AreEqual(1, ds.Count(d => d.OriginalString.StartsWith("rx://tollbooth")));
-                    Assert.AreEqual(1, ds.Count(d => d.OriginalString.StartsWith("rx://collector")));
+                    Assert.ContainsSingle(d => d.OriginalString.StartsWith("rx://tollbooth"), ds);
+                    Assert.ContainsSingle(d => d.OriginalString.StartsWith("rx://collector"), ds);
                     Assert.AreEqual(2, ds.Count(d => d.OriginalString.StartsWith("rx://tunnel/window")));
                 });
             }
@@ -256,9 +256,9 @@ public partial class Window : TestBase
                     }).Apply(s);
 
                     Assert.IsNotNull(ds);
-                    Assert.AreEqual(1, ds.Count(d => d.OriginalString.StartsWith("rx://tollbooth")));
-                    Assert.AreEqual(1, ds.Count(d => d.OriginalString.StartsWith("rx://collector")));
-                    Assert.AreEqual(1, ds.Count(d => d.OriginalString.StartsWith("rx://tunnel/window")));
+                    Assert.ContainsSingle(d => d.OriginalString.StartsWith("rx://tollbooth"), ds);
+                    Assert.ContainsSingle(d => d.OriginalString.StartsWith("rx://collector"), ds);
+                    Assert.ContainsSingle(d => d.OriginalString.StartsWith("rx://tunnel/window"), ds);
                 });
             }
 
@@ -306,9 +306,9 @@ public partial class Window : TestBase
                 }).Apply(s);
 
                 Assert.IsNotNull(ds);
-                Assert.AreEqual(1, ds.Count(d => d.OriginalString.StartsWith("rx://tollbooth")));
-                Assert.AreEqual(1, ds.Count(d => d.OriginalString.StartsWith("rx://collector")));
-                Assert.AreEqual(1, ds.Count(d => d.OriginalString.StartsWith("rx://tunnel/window")));
+                Assert.ContainsSingle(d => d.OriginalString.StartsWith("rx://tollbooth"), ds);
+                Assert.ContainsSingle(d => d.OriginalString.StartsWith("rx://collector"), ds);
+                Assert.ContainsSingle(d => d.OriginalString.StartsWith("rx://tunnel/window"), ds);
             });
 
             foreach (var t in new[] { 235, 255, 275 })
@@ -323,8 +323,8 @@ public partial class Window : TestBase
                     }).Apply(s);
 
                     Assert.IsNotNull(ds);
-                    Assert.AreEqual(1, ds.Count(d => d.OriginalString.StartsWith("rx://tollbooth")));
-                    Assert.AreEqual(1, ds.Count(d => d.OriginalString.StartsWith("rx://collector")));
+                    Assert.ContainsSingle(d => d.OriginalString.StartsWith("rx://tollbooth"), ds);
+                    Assert.ContainsSingle(d => d.OriginalString.StartsWith("rx://collector"), ds);
                     Assert.AreEqual(2, ds.Count(d => d.OriginalString.StartsWith("rx://tunnel/window")));
                 });
             }

--- a/Reaqtor/Core/Shared/Tests.Reaqtor.Shared.Core/Reaqtor/StructuralSubstitutingTypeComparatorTests.cs
+++ b/Reaqtor/Core/Shared/Tests.Reaqtor.Shared.Core/Reaqtor/StructuralSubstitutingTypeComparatorTests.cs
@@ -49,10 +49,10 @@ public class StructuralSubstitutingTypeComparatorTests
         var comparer = new StructuralSubstitutingTypeComparator();
 
         Assert.IsTrue(comparer.Equals(type1, type1));
-        Assert.AreEqual(0, comparer.Substitutions.Count);
+        Assert.IsEmpty(comparer.Substitutions);
         Assert.IsTrue(comparer.Equals(type1, type2));
         Assert.AreEqual(type1, comparer.Substitutions[type2]);
-        Assert.AreEqual(1, comparer.Substitutions.Count);
+        Assert.HasCount(1, comparer.Substitutions);
     }
 
     [TestMethod]

--- a/Reaqtor/Core/Shared/Tests.Reaqtor.Shared.Core/System/Collections/Generic/ReadOnlyChainedDictionaryTests.cs
+++ b/Reaqtor/Core/Shared/Tests.Reaqtor.Shared.Core/System/Collections/Generic/ReadOnlyChainedDictionaryTests.cs
@@ -14,14 +14,14 @@ public class ReadOnlyChainedDictionaryTests
     {
         var ch = GetChainedDictionary();
 
-        Assert.IsTrue(ch.Contains(new KeyValuePair<string, int>("bar", 42)));
-        Assert.IsTrue(ch.Contains(new KeyValuePair<string, int>("foo", 43)));
-        Assert.IsTrue(ch.Contains(new KeyValuePair<string, int>("qux", 44)));
+        Assert.Contains(new KeyValuePair<string, int>("bar", 42), ch);
+        Assert.Contains(new KeyValuePair<string, int>("foo", 43), ch);
+        Assert.Contains(new KeyValuePair<string, int>("qux", 44), ch);
 
-        Assert.IsFalse(ch.Contains(new KeyValuePair<string, int>("bar", 45)));
-        Assert.IsFalse(ch.Contains(new KeyValuePair<string, int>("foo", 45)));
-        Assert.IsFalse(ch.Contains(new KeyValuePair<string, int>("qux", 45)));
-        Assert.IsFalse(ch.Contains(new KeyValuePair<string, int>("baz", 45)));
+        Assert.DoesNotContain(new KeyValuePair<string, int>("bar", 45), ch);
+        Assert.DoesNotContain(new KeyValuePair<string, int>("foo", 45), ch);
+        Assert.DoesNotContain(new KeyValuePair<string, int>("qux", 45), ch);
+        Assert.DoesNotContain(new KeyValuePair<string, int>("baz", 45), ch);
     }
 
     [TestMethod]
@@ -80,7 +80,7 @@ public class ReadOnlyChainedDictionaryTests
     {
         var ch = GetChainedDictionary();
 
-        Assert.AreEqual(3, ch.Count);
+        Assert.HasCount(3, ch);
     }
 
     [TestMethod]

--- a/Reaqtor/Pearls/OperatorLocalStorage/Tests/LinkedListTests.cs
+++ b/Reaqtor/Pearls/OperatorLocalStorage/Tests/LinkedListTests.cs
@@ -3419,7 +3419,7 @@ public class LinkedListTests : PersistedTestBase
         //
         foreach (var value in values)
         {
-            Assert.IsTrue(list.Contains(value));
+            Assert.Contains(value, list);
         }
     }
 }

--- a/Reaqtor/Pearls/OperatorLocalStorage/Tests/PersistedTestBase.cs
+++ b/Reaqtor/Pearls/OperatorLocalStorage/Tests/PersistedTestBase.cs
@@ -88,7 +88,7 @@ public class PersistedTestBase
 #pragma warning disable CA1822 // Mark members as static
         public void AssertEdits(StateWriterOperation[] actual, params (StateWriterOperationKind kind, string category, string key)[] expected)
         {
-            Assert.AreEqual(expected.Length, actual.Length);
+            Assert.HasCount(expected.Length, actual);
 
             for (var i = 0; i < actual.Length; i++)
             {

--- a/Reaqtor/Pearls/OperatorLocalStorage/Tests/QueueTests.cs
+++ b/Reaqtor/Pearls/OperatorLocalStorage/Tests/QueueTests.cs
@@ -305,7 +305,7 @@ public class QueueTest : PersistedTestBase
         // Assert the queue element count.
         //
 
-        Assert.AreEqual(0, bar.Count);
+        Assert.IsEmpty(bar);
     });
 
     [TestMethod]
@@ -347,7 +347,7 @@ public class QueueTest : PersistedTestBase
         {
             var queue = s.Space.GetQueue<int>("bar");
 
-            Assert.AreEqual(4, queue.Count);
+            Assert.HasCount(4, queue);
             Assert.IsTrue(new[] { 2, 3, 5, 7 }.SequenceEqual(queue));
         }
     });
@@ -400,7 +400,7 @@ public class QueueTest : PersistedTestBase
         {
             var queue = s.Space.GetQueue<int>("bar");
 
-            Assert.AreEqual(4, queue.Count);
+            Assert.HasCount(4, queue);
             Assert.IsTrue(new[] { 2, 3, 5, 7 }.SequenceEqual(queue));
         }
     });
@@ -469,7 +469,7 @@ public class QueueTest : PersistedTestBase
         {
             var queue = s.Space.GetQueue<int>("bar");
 
-            Assert.AreEqual(4, queue.Count);
+            Assert.HasCount(4, queue);
             Assert.IsTrue(new[] { 2, 3, 5, 7 }.SequenceEqual(queue));
         }
     });
@@ -533,7 +533,7 @@ public class QueueTest : PersistedTestBase
         {
             var queue = s.Space.GetQueue<int>("bar");
 
-            Assert.AreEqual(4, queue.Count);
+            Assert.HasCount(4, queue);
             Assert.IsTrue(new[] { 2, 3, 5, 7 }.SequenceEqual(queue));
         }
     });
@@ -600,7 +600,7 @@ public class QueueTest : PersistedTestBase
         {
             var queue = s.Space.GetQueue<int>("bar");
 
-            Assert.AreEqual(2, queue.Count);
+            Assert.HasCount(2, queue);
             Assert.IsTrue(new[] { 3, 5 }.SequenceEqual(queue));
         }
     });
@@ -664,7 +664,7 @@ public class QueueTest : PersistedTestBase
         {
             var queue = s.Space.GetQueue<int>("bar");
 
-            Assert.AreEqual(2, queue.Count);
+            Assert.HasCount(2, queue);
             Assert.IsTrue(new[] { 3, 5 }.SequenceEqual(queue));
         }
     });
@@ -737,7 +737,7 @@ public class QueueTest : PersistedTestBase
         {
             var queue = s.Space.GetQueue<int>("bar");
 
-            Assert.AreEqual(4, queue.Count);
+            Assert.HasCount(4, queue);
             Assert.IsTrue(new[] { 5, 7, 11, 13 }.SequenceEqual(queue));
         }
     });
@@ -810,7 +810,7 @@ public class QueueTest : PersistedTestBase
         {
             var queue = s.Space.GetQueue<int>("bar");
 
-            Assert.AreEqual(4, queue.Count);
+            Assert.HasCount(4, queue);
             Assert.IsTrue(new[] { 5, 7, 11, 13 }.SequenceEqual(queue));
         }
     });

--- a/Reaqtor/Pearls/OperatorLocalStorage/Tests/SortedSetTests.cs
+++ b/Reaqtor/Pearls/OperatorLocalStorage/Tests/SortedSetTests.cs
@@ -17,7 +17,6 @@ using Utilities;
 namespace Tests;
 
 [TestClass]
-[System.Diagnostics.CodeAnalysis.SuppressMessage("Performance", "CA1861:Avoid constant arrays as arguments", Justification = "Not needed for this test suite.")]
 public class SortedSetTests : PersistedTestBase
 {
     [TestMethod]

--- a/Reaqtor/Pearls/OperatorLocalStorage/Tests/SortedSetTests.cs
+++ b/Reaqtor/Pearls/OperatorLocalStorage/Tests/SortedSetTests.cs
@@ -17,6 +17,7 @@ using Utilities;
 namespace Tests;
 
 [TestClass]
+[System.Diagnostics.CodeAnalysis.SuppressMessage("Performance", "CA1861:Avoid constant arrays as arguments", Justification = "Not needed for this test suite.")]
 public class SortedSetTests : PersistedTestBase
 {
     [TestMethod]

--- a/Reaqtor/Pearls/OperatorLocalStorage/Tests/StackTests.cs
+++ b/Reaqtor/Pearls/OperatorLocalStorage/Tests/StackTests.cs
@@ -304,7 +304,7 @@ public class StackTest : PersistedTestBase
         // Assert the stack element count.
         //
 
-        Assert.AreEqual(0, bar.Count);
+        Assert.IsEmpty(bar);
     });
 
     [TestMethod]
@@ -345,7 +345,7 @@ public class StackTest : PersistedTestBase
         {
             var stack = s.Space.GetStack<int>("bar");
 
-            Assert.AreEqual(4, stack.Count);
+            Assert.HasCount(4, stack);
             Assert.IsTrue(new[] { 7, 5, 3, 2 }.SequenceEqual(stack));
         }
     });
@@ -397,7 +397,7 @@ public class StackTest : PersistedTestBase
         {
             var stack = s.Space.GetStack<int>("bar");
 
-            Assert.AreEqual(4, stack.Count);
+            Assert.HasCount(4, stack);
             Assert.IsTrue(new[] { 7, 5, 3, 2 }.SequenceEqual(stack));
         }
     });
@@ -464,7 +464,7 @@ public class StackTest : PersistedTestBase
         {
             var stack = s.Space.GetStack<int>("bar");
 
-            Assert.AreEqual(4, stack.Count);
+            Assert.HasCount(4, stack);
             Assert.IsTrue(new[] { 7, 5, 3, 2 }.SequenceEqual(stack));
         }
     });
@@ -527,7 +527,7 @@ public class StackTest : PersistedTestBase
         {
             var stack = s.Space.GetStack<int>("bar");
 
-            Assert.AreEqual(4, stack.Count);
+            Assert.HasCount(4, stack);
             Assert.IsTrue(new[] { 7, 5, 3, 2 }.SequenceEqual(stack));
         }
     });
@@ -596,7 +596,7 @@ public class StackTest : PersistedTestBase
         {
             var stack = s.Space.GetStack<int>("bar");
 
-            Assert.AreEqual(5, stack.Count);
+            Assert.HasCount(5, stack);
             Assert.IsTrue(new[] { 11, 7, 5, 3, 2 }.SequenceEqual(stack));
         }
     });
@@ -661,7 +661,7 @@ public class StackTest : PersistedTestBase
         {
             var stack = s.Space.GetStack<int>("bar");
 
-            Assert.AreEqual(5, stack.Count);
+            Assert.HasCount(5, stack);
             Assert.IsTrue(new[] { 11, 7, 5, 3, 2 }.SequenceEqual(stack));
         }
     });
@@ -730,7 +730,7 @@ public class StackTest : PersistedTestBase
         {
             var stack = s.Space.GetStack<int>("bar");
 
-            Assert.AreEqual(4, stack.Count);
+            Assert.HasCount(4, stack);
             Assert.IsTrue(new[] { 7, 5, 3, 2 }.SequenceEqual(stack));
         }
     });
@@ -795,7 +795,7 @@ public class StackTest : PersistedTestBase
         {
             var stack = s.Space.GetStack<int>("bar");
 
-            Assert.AreEqual(4, stack.Count);
+            Assert.HasCount(4, stack);
             Assert.IsTrue(new[] { 7, 5, 3, 2 }.SequenceEqual(stack));
         }
     });
@@ -860,7 +860,7 @@ public class StackTest : PersistedTestBase
         {
             var stack = s.Space.GetStack<int>("bar");
 
-            Assert.AreEqual(2, stack.Count);
+            Assert.HasCount(2, stack);
             Assert.IsTrue(new[] { 3, 2 }.SequenceEqual(stack));
         }
     });
@@ -923,7 +923,7 @@ public class StackTest : PersistedTestBase
         {
             var stack = s.Space.GetStack<int>("bar");
 
-            Assert.AreEqual(2, stack.Count);
+            Assert.HasCount(2, stack);
             Assert.IsTrue(new[] { 3, 2 }.SequenceEqual(stack));
         }
     });
@@ -988,7 +988,7 @@ public class StackTest : PersistedTestBase
         {
             var stack = s.Space.GetStack<int>("bar");
 
-            Assert.AreEqual(1, stack.Count);
+            Assert.HasCount(1, stack);
             Assert.IsTrue(new[] { 2 }.SequenceEqual(stack));
         }
     });
@@ -1053,7 +1053,7 @@ public class StackTest : PersistedTestBase
         {
             var stack = s.Space.GetStack<int>("bar");
 
-            Assert.AreEqual(1, stack.Count);
+            Assert.HasCount(1, stack);
             Assert.IsTrue(new[] { 2 }.SequenceEqual(stack));
         }
     });
@@ -1120,7 +1120,7 @@ public class StackTest : PersistedTestBase
         {
             var stack = s.Space.GetStack<int>("bar");
 
-            Assert.AreEqual(2, stack.Count);
+            Assert.HasCount(2, stack);
             Assert.IsTrue(new[] { 7, 2 }.SequenceEqual(stack));
         }
     });
@@ -1186,7 +1186,7 @@ public class StackTest : PersistedTestBase
         {
             var stack = s.Space.GetStack<int>("bar");
 
-            Assert.AreEqual(2, stack.Count);
+            Assert.HasCount(2, stack);
             Assert.IsTrue(new[] { 7, 2 }.SequenceEqual(stack));
         }
     });
@@ -1257,7 +1257,7 @@ public class StackTest : PersistedTestBase
         {
             var stack = s.Space.GetStack<int>("bar");
 
-            Assert.AreEqual(4, stack.Count);
+            Assert.HasCount(4, stack);
             Assert.IsTrue(new[] { 13, 7, 3, 2 }.SequenceEqual(stack));
         }
     });
@@ -1325,7 +1325,7 @@ public class StackTest : PersistedTestBase
         {
             var stack = s.Space.GetStack<int>("bar");
 
-            Assert.AreEqual(4, stack.Count);
+            Assert.HasCount(4, stack);
             Assert.IsTrue(new[] { 13, 7, 3, 2 }.SequenceEqual(stack));
         }
     });

--- a/Reaqtor/Pearls/OperatorLocalStorage/Tests/StateChangeManagerTests.cs
+++ b/Reaqtor/Pearls/OperatorLocalStorage/Tests/StateChangeManagerTests.cs
@@ -234,7 +234,7 @@ public class StateChangeManagerTests
         //
         // Empty edit page.
         //
-        Assert.AreEqual(0, s.State.Count);
+        Assert.IsEmpty(s.State);
 
         //
         // Add to most recent edit page.
@@ -269,7 +269,7 @@ public class StateChangeManagerTests
         //
         // Most recent edit page is empty.
         //
-        Assert.AreEqual(0, s.State.Count);
+        Assert.IsEmpty(s.State);
 
         //
         // Add to most recent edit page.

--- a/Reaqtor/Pearls/OperatorLocalStorage/Tests/TransactionalDictionaryTests.cs
+++ b/Reaqtor/Pearls/OperatorLocalStorage/Tests/TransactionalDictionaryTests.cs
@@ -32,7 +32,7 @@ public class TransactionalDictionaryTests
         Assert.ThrowsExactly<KeyNotFoundException>(() => _ = d[1]);
         Assert.ThrowsExactly<KeyNotFoundException>(() => _ = d[2]);
 
-        Assert.IsFalse(d.Any());
+        Assert.IsEmpty(d);
 
         Assert.IsFalse(d.Remove(0));
         Assert.IsFalse(d.Remove(1));
@@ -75,7 +75,7 @@ public class TransactionalDictionaryTests
 
         Assert.ThrowsExactly<KeyNotFoundException>(() => _ = d[42]);
 
-        Assert.IsFalse(d.Any());
+        Assert.IsEmpty(d);
     }
 
     [TestMethod]

--- a/Reaqtor/Pearls/OperatorLocalStorage/Tests/Utilities/LoggingStateReaderTests.cs
+++ b/Reaqtor/Pearls/OperatorLocalStorage/Tests/Utilities/LoggingStateReaderTests.cs
@@ -58,7 +58,7 @@ public class LoggingStateReaderTests
             "Dispose()/Stop",
         })
         {
-            Assert.IsTrue(log.Contains(entry), "Not found: '" + entry + "'");
+            Assert.Contains(entry, log, "Not found: '" + entry + "'");
         }
     }
 
@@ -101,7 +101,7 @@ public class LoggingStateReaderTests
             "Dispose()/Stop",
         })
         {
-            Assert.IsTrue(log.Contains(entry), "Not found: '" + entry + "'");
+            Assert.Contains(entry, log, "Not found: '" + entry + "'");
         }
     }
 

--- a/Reaqtor/Pearls/OperatorLocalStorage/Tests/Utilities/LoggingStateWriterTests.cs
+++ b/Reaqtor/Pearls/OperatorLocalStorage/Tests/Utilities/LoggingStateWriterTests.cs
@@ -61,7 +61,7 @@ public class LoggingStateWriterTests
             "Dispose()/Stop",
         })
         {
-            Assert.IsTrue(log.Contains(entry), "Not found: '" + entry + "'");
+            Assert.Contains(entry, log, "Not found: '" + entry + "'");
         }
     }
 
@@ -109,7 +109,7 @@ public class LoggingStateWriterTests
             "Dispose()/Stop",
         })
         {
-            Assert.IsTrue(log.Contains(entry), "Not found: '" + entry + "'");
+            Assert.Contains(entry, log, "Not found: '" + entry + "'");
         }
     }
 

--- a/eng/Run-DotnetFormat.ps1
+++ b/eng/Run-DotnetFormat.ps1
@@ -79,8 +79,12 @@ try {
         'Nuqleon/Core/LINQ/Tests.Nuqleon.Linq.CompilerServices/Expressions/Rewriters/Misc/ExpressionTupletizerTests.cs'
     )
 
-    # Excluded for performance (IDE0001 is pathologically slow), plus the linked files above.
-    $excludes = @('Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Optimizers') + $linkedFiles
+    # Only the linked files above are excluded. Nuqleon.Linq.Expressions.Optimizers used to be excluded
+    # for performance - IDE0001 took ~15 minutes on PureMemberCatalog.cs, whose collection initializers
+    # full of lambdas defeat Roslyn's per-statement semantic caching. That was fixed at the source in
+    # #166 (the initializers became Add calls in a static constructor, and the lambdas became static),
+    # so the project is analyzed again: a full-solution style scan including it takes ~1m30s.
+    $excludes = $linkedFiles
 
     $formatArgs = @('format', 'style', $solution, '--exclude') + $excludes + @('--verbosity', 'diagnostic')
     if ($Verify)    { $formatArgs += '--verify-no-changes' }


### PR DESCRIPTION
> **Status:** `dotnet build All.slnx` 0 warnings / 0 errors · a solution-wide `--severity info` analyzer
> scan reports **0 remaining** (every rule in the wave is fixed or excluded with a documented rationale) ·
> affected test projects green · stacked on the .NET 10 migration.

This PR is the follow-up to the **info/suggestion-severity analyzer cleanup** after the .NET 10 migration.
`MIGRATION-NET10.md` cleared the *warning/error*-level analyzer debt; raising `AnalysisLevel=latest` and
moving to **MSTest 4** then left a wave of **info-severity** diagnostics (the ones that show in the IDE
Error List per-open-file but **never in a build**). This PR triages that wave: it applies the safe,
valuable fixes and **excludes or suppresses the rest with a documented rationale** (in `.editorconfig` or
in-code, each explained below).

> **Read "Deliberately left as-is" before concluding anything is missing.** Most of the remaining
> suggestions are intentional, unsafe to bulk-apply, or false positives — the reasoning is below so
> the *absences* (which don't appear in the diff) are reviewable too.

## Why these never showed up in the build
They are `info`/`suggestion` severity. `dotnet build` — even with this repo's
`EnforceCodeStyleInBuild=true` — only promotes style rules to the build at *warning*/*error*
severity. A `dotnet format analyzers <slnx> --verify-no-changes --severity info` scan enumerates
them (~2,110 at the start of this work).

## What was fixed

| Rule | Meaning | Sites | Commit(s) |
|---|---|---:|---|
| **MSTEST0037** | Use the specific assert (`IsEmpty`/`HasCount`/`Contains`/`DoesNotContain`/`IsTrue`/…) instead of `AreEqual`/`IsTrue(!x)`-style | ~789 | `0ee363db`, `e95cf5b8` |
| **MSTEST0023** | Avoid negated-boolean asserts (`IsTrue(!x)` → `IsFalse(x)`) | 14 | `c3f4c79f` |
| **MSTEST0058** | Don't assert in a `catch` (`try { act(); Assert.Fail(); } catch (T e) { … }` → `Assert.ThrowsExactly<T>`) | 28 | `93db6eb8`, `d7176139` |
| **MSTEST0051** | `Assert.Throws` should wrap a single statement (hoist setup out of the lambda) | 17 | `ff537ffa`, `99f6edff` |
| **MSTEST0016** | Drop the redundant `[TestClass]` on the abstract `VirtualTimeEngineTest` base | 1 | `ff537ffa` |

All fixes are **behaviour-preserving**; each commit built 0/0 and ran the affected test projects green.

**Tooling:** the MSTest code fixes were applied with `dotnet format analyzers --diagnostics <ID>
--severity info` (MSTest ships working `CodeFixProvider`s). MSTEST0037's FixAll needs **two passes**
(fixing one assert exposes the next) — hence the two commits. MSTEST0058/0051/0016 have **no headless
code fix** and were done by hand. Any tools used (`roslynator`, `dotnet-t4`) were **global installs**;
nothing tool-related is committed.

## Deliberately left as-is — and why

### MSTEST0049 (~600 sites) — pass a `CancellationToken` to async test calls
**Not applied. This is the most important thing to understand in this PR.** The MSTest fixer for
MSTEST0049 rewrites `x.FooAsync(args)` → `x.FooAsync(args, TestContext.CancellationToken)` — but in a
codebase full of **distinct overloads** that silently *changes which overload is called*. It rewrote
`engine.CheckpointAsync(sw)` (the no-progress overload) into `CheckpointAsync(sw, token)`, changing the
traced operation sequence and **breaking two QueryEngine tests** (`Checkpointable_CheckpointAsync1`,
`Checkpointable_RecoverAsync1`, which assert on `msgs.SequenceEqual(...)`). Those two are only the
failures a test happened to catch — every no-token call it touched had its overload silently switched,
so unrelated behaviour changes could sit anywhere a test doesn't assert on exact behaviour. It also
threads tokens into argument-checking asserts (`Assert.ThrowsExactly(() => x.Foo(null))`), where the
token is meaningless and collapses overload coverage. For a payoff of "tests cancel on timeout" on
fast, blocking `.Wait()`/`.Result` calls, that trade is not worth the risk. **It is therefore now
excluded** — `dotnet_diagnostic.MSTEST0049.severity = none` in `.editorconfig` (Option C in the tracking
issue), grouped with the CA-rule exclusions and carrying the same rationale.
**[#164](https://github.com/reaqtive/reaqtor/issues/164)** tracks the full analysis — the
overload-switching hazard, the `TestContext`/`static`-helper plumbing gaps, and the T4 dimension — plus a
possible future safe adoption.

### CA rules (the CA tail)
The **code-fix providers for CA rules ship only inside Visual Studio** — they are not in the .NET SDK
analyzer directory nor in the `Microsoft.CodeAnalysis.NetAnalyzers` NuGet package (both ship analyzers
only), so no headless tool (`dotnet format` or `roslynator`) can apply them. They were handled as follows:

- **Fixed by hand** (safe, unambiguous, behaviour-preserving — build 0/0 + affected tests green):
  **CA1866** (14 — `string.StartsWith` char overload, `c4cd1c80`), **CA1854** (5 — `TryGetValue` over
  `ContainsKey`+indexer, `ef3370d7`), **CA1864** (1 — `TryAdd` over `ContainsKey`+`Add`, `161c7761`).
- **CA2263** (10) — **deliberately kept, not a "fix":** these tests exercise the **non-generic,
  runtime-`Type`-based overloads on purpose**, so the generic overload CA2263 suggests would defeat the
  test's intent. Suppressed with a per-file `#pragma warning disable CA2263` + justification. Use cases:
  - `ServiceProviderExtensionsTests` — verifies `GetService<T>()` **and** `GetService(Type)` behave
    identically; both overloads are the subject of the test.
  - `DataModelSerializerFactoryTests` — exercises `DataTypeBinarySerializer`'s `Serialize(Type, Stream,
    object)` / `Deserialize(Type, Stream)` public API, including its NotSupported and cyclic-type error paths.
  - `DataModelSerializerFactory.TestCases` — a hand-rolled expression-serializer fixture built on the
    runtime-`Type` `DataSerializer` API (it also serializes payloads by runtime `Type`), so its `typeof(T)`
    calls stay consistent with that contract.
- **CA1861** (~328) — hoist constant-array args to `static readonly`; a hot-path perf rule with
  negligible value in tests, where the constant arrays are one-shot test data. **Excluded for all unit
  test projects** via `<NoWarn>$(NoWarn);CA1861</NoWarn>` scoped to `IsTestProject` in
  `Directory.Build.props`; this superseded (and removed) the earlier per-file `SortedSetTests`
  `[SuppressMessage]`. It stays active for shipping code, where hoisting is worth acting on. The single
  non-test site — `PartialTreeEvaluator/Program.cs` in the PartialExpressionTreeEvaluator **Playground** —
  is a **false positive**: the flagged `new[] { 1, 2, 3 }` sits inside an `Expression<Func<int>>` lambda,
  so it is a `NewArrayExpression` node in the sample's demonstrated tree, not a runtime array argument, and
  hoisting it to a `static readonly` field would change the very expression tree the sample evaluates. It is
  **suppressed inline** with a `#pragma warning disable CA1861` + justification, so **no CA1861 remains
  anywhere**. (The `CacheEntryTests` CA1866 char fix landed earlier in `c838f08d`.)
- **SYSLIB1054** (1) — **fixed:** the production `NativeMethods.cs` `QueryThreadCycleTime` P/Invoke was
  converted to source-generated `[LibraryImport]` (class + method made `partial`; kept `[return:
  MarshalAs(UnmanagedType.Bool)]` — bool isn't blittable — plus `SetLastError` and
  `[DefaultDllImportSearchPaths(System32)]`; the project already sets `AllowUnsafeBlocks`, which
  LibraryImport's generated code requires). Verified by a forced `--no-incremental` rebuild, the
  scheduler tests (46; `Accountant`/`PerformanceCounters` call it during accounting), and a direct
  runtime P/Invoke check (returns `true` with a non-zero cycle count).
- **SYSLIB1045** (6) — **handled:** the four static `Regex.Replace` calls in comparison-normalization
  helpers (`ConstantHoisterTests`, Bonsai `Tests`) are converted to `[GeneratedRegex]` `partial` methods;
  the two `new Regex("literal")` sites **inside expression trees** (`ConstantHoisterTests` constant-hoisting
  data, `PureMemberCatalogTests` pure-member-fold data) are **suppressed with justification** — converting
  them to a method call would change the expression tree under test. Build 0/0; the three affected test
  projects pass.

### CA1859 (223) — use concrete types for performance
**Intentional** and pre-dating this PR — each of the ~220 sites is a deliberate API-shape judgment
(interface vs concrete return type), and #143 already decided applying the rule wholesale is churn
without measured benefit. It was previously pinned to `suggestion` in `.editorconfig`; this PR takes
the final step and **excludes it** (`dotnet_diagnostic.CA1859.severity = none`, alongside the existing
`none` entries for CA1805/CA1508) with an expanded comment, so it no longer shows as persistent
per-file IDE/scan noise. Re-enable per hot path if a benchmark ever justifies a specific site.

### MSTEST0058 remainder (~43) — false positives, suppressed in-code
Only two files had the real anti-pattern (`EnumDictionaryTests`, `EnumDictionaryFactoryTests` — fixed
above). The rest are correct-by-construction patterns the rule flags spuriously; each is now
**self-documented with a class-scoped `#pragma warning disable MSTEST0058` + a file-specific
justification** (rather than converted):
- **`Reaqtive.Testing/ReactiveAssert.cs`** (6) — the implementation of the custom
  `ReactiveAssert.Throws<T>` helper; the `Assert.Fail`/`Assert.AreSame` in its `catch` blocks are the
  intended logic (the "no exception thrown" case is guarded by a `failed` flag).
- **`CacheEntryTests.cs`** (20) — `try { throw new Exception(); } catch (ex) { … }` deliberately
  obtains a real exception instance (with a stack trace) as test data; the whole test body runs in the
  `catch`.
- **`CheckpointingTests.cs`** — expected-exception tests guarded by a `failed` flag +
  `Assert.IsTrue(failed)`, so the `catch`-block asserts run only on the expected throw.
- **`ExpressionOptimizerTests.cs`** — `AssertEval` is a dual-path helper: the `catch` verifies the
  throwing-expression case, the code after the `try` verifies the value case.
- **`AnonymizationTests.cs`, `PureMemberCatalogTests.cs`, `Tests.cs`** — the `catch`'s `Assert.Fail`
  reports an *unexpected* exception/regression with context (the test expects no throw).

### One MSTEST0037 declined (`IndexedTests.cs`)
`Assert.AreNotEqual<object>(null, i1)` is kept with a scoped `#pragma warning disable MSTEST0037`: the
suggested `Assert.IsNotNull(i1)` is **always-true** (and trips the build-breaking MSTEST0032) because
`Indexed<T>` is a value type. The `#pragma` documents this inline.

## How it was verified
- `dotnet build All.slnx` → **0 warnings / 0 errors** after every commit.
- The affected test projects were run (MTP executables) after each change — all green (e.g. QueryEngine
  493, CompilerServices 1047, Reaqtive.Storage 261, Json 76, …).
- A **generated-file guard** ran after each bulk `dotnet format` pass: the set of T4 outputs (from each
  `.csproj` `<LastGenOutput>`) was intersected with `git diff` and required to be empty, so no generated
  `.cs` was hand-edited.

## Why there are no T4 template changes
The only findings in genuinely T4-generated files were **MSTEST0049** (`ReactiveClientContextHigherArityTests`
448, and two `AsyncReactive…FactoryBaseTests` arity files 42 each) — which is now excluded (see above),
so those templates need no change. `EnumDictionaryFactoryTests.cs` (4 MSTEST0058) is the **hand-written** partial
class, not the T4 output (`EnumDictionaryFactoryTests.generated.cs`, which has no such pattern), so it
was fixed directly.

## Notes for reviewers
- In-diff suppressions are intentional and carry their rationale inline: the `IndexedTests` `#pragma`
  (MSTEST0037), the `MemoizedDelegateCacheTests` `#pragma` (MSTEST0037 — see follow-up below),
  the `PartialTreeEvaluator/Program.cs` `#pragma` (CA1861 — expression-tree false positive),
  the seven MSTEST0058 `#pragma`s, and the three CA2263 `#pragma`s — each with a per-site justification.
- **Nothing is left active as an info-hint.** Every rule in the wave is either fixed at its sites or
  turned off with a documented rationale, so a fresh solution-wide `--severity info` scan reports **0**:
  **MSTEST0049** is now **excluded** in `.editorconfig` (`severity = none`, Option C in
  [#164](https://github.com/reaqtive/reaqtor/issues/164), which tracks a possible future safe adoption);
  **CA1859** is excluded in `.editorconfig` (`severity = none`); test-project **CA1861** is excluded via
  `Directory.Build.props` and its one non-test site is suppressed in-code.
  Everything we set out to modernize — MSTEST0037/0023/0058/0051/0016, CA1866/1854/1864, SYSLIB1054, and
  the convertible SYSLIB1045 sites — is fixed in the diff; the MSTEST0049 / CA1859 / CA1861 exclusions are
  in the diff too; MSTEST0058, CA2263, and the expression-tree SYSLIB1045 sites are documented in-code.
- Follows `MIGRATION-NET10.md` §2/§3, which resolved the *warning/error*-level analyzer and MSTest work;
  this PR handles the *info*-level residue.

## Follow-up after initial review

Four commits landed after the description above was first written — two responding to review
feedback, two hardening the result so this wave can't silently re-accumulate.

- **Review response — MSTEST0051 (`99f6edff`).** The original `ff537ffa` pass fixed some sites by
  *collapsing* a two-statement `create + call` lambda into a single chained expression
  (`new JsonExpressionWriter().WriteEndArray()`). That satisfies the rule's letter but not its intent
  — a chained `new X().Method()` is exactly as ambiguous about *which* call throws as the two
  statements it replaced. Reworked all five such sites (`JsonExpressionWriterTests` ×4,
  `InnerSubjectTests` ×1) to hoist construction **out** of the lambda, leaving only the throwing
  call inside. Verified with a scoped `--diagnostics MSTEST0051 --severity info --verify-no-changes`
  scan (the rule is genuinely satisfied, not merely quiet) plus Json.Interop 65 / QueryEngine 493 green.
- **Review response — MSTEST0037 operator asserts (`1b4580a9`).** The MSTEST0037 FixAll had collapsed
  the `==`/`!=` operator-pair checks in `MemoizedDelegateCacheTests` into duplicate
  `Assert.AreEqual`/`AreNotEqual` calls, which also quietly dropped operator coverage (`AreEqual` goes
  through `object.Equals`, already covered by the `.Equals()` asserts above). Restored the operator-form
  assertions and scoped a `#pragma warning disable MSTEST0037` with a rationale (matching the
  suppression style used elsewhere here). `Tests.Nuqleon.Memory` builds 0/0; all 672 tests pass.
- **MSTEST0001 — declare test parallelization policy (`d771ca9d`).** MSTEST0001 reports at
  *compilation* level with no source span, so `dotnet format` can't see it and the build gate didn't
  promote it — it was IDE-only. Added a central, explicit `DoNotParallelize` assembly attribute for all
  test projects in `Directory.Build.props`/`.targets` (opt-in `Parallelize` per project where it ever
  pays), stating the policy rather than leaving it at the package default.
- **Regression guard (`4284f29f`).** Closed the two gaps that let this whole wave accumulate unnoticed:
  (a) `MSTestAnalysisMode=Recommended` for test projects, which — with `TreatWarningsAsErrors` — turns
  MSTEST0001-class suggestion rules into **build errors** so they can no longer hide (`All` mode is *not*
  adopted: it reports 610 more, a separate triage); and (b) restored the
  `Nuqleon.Linq.Expressions.Optimizers` project to the `eng/Run-DotnetFormat.ps1` gate now that #166
  fixed the IDE0001 slowness that had forced its exclusion. The remaining linked-file exclusions (#138)
  stay. Solution-wide build remains 0/0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

