### PR TITLE
Factor reusable expression services out of the archived Remoting client library

### DIFF
--- a/Common/TestUtilities/ExpressionAssert.cs
+++ b/Common/TestUtilities/ExpressionAssert.cs
@@ -1,0 +1,37 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT License.
+// See the LICENSE file in the project root for more information.
+
+using System.Linq.CompilerServices;
+using System.Linq.Expressions;
+
+namespace Microsoft.VisualStudio.TestTools.UnitTesting;
+
+/// <summary>
+/// Provides assertions for expression tree equality, treating global (unbound) parameters as equal
+/// when they agree on name and type.
+/// </summary>
+/// <remarks>
+/// This file is linked into test projects that need it via an explicit Compile Include; unlike
+/// AssertEx.cs it is not linked globally because it requires a reference to Nuqleon.Linq.CompilerServices.
+/// </remarks>
+public static class ExpressionAssert
+{
+    public static void AreEqual(Expression expected, Expression actual)
+    {
+        Assert.IsTrue(new ExpressionEqualityComparer(() => new GlobalParameterComparator()).Equals(expected, actual));
+    }
+
+    public static void AreNotEqual(Expression expected, Expression actual)
+    {
+        Assert.IsFalse(new ExpressionEqualityComparer(() => new GlobalParameterComparator()).Equals(expected, actual));
+    }
+
+    private sealed class GlobalParameterComparator : ExpressionEqualityComparator
+    {
+        protected override bool EqualsGlobalParameter(ParameterExpression x, ParameterExpression y)
+        {
+            return x.Name == y.Name && Equals(x.Type, y.Type);
+        }
+    }
+}

--- a/Reaqtor/Core/Client/Reaqtor.Client.Core/Reaqtor.Client.Core.csproj
+++ b/Reaqtor/Core/Client/Reaqtor.Client.Core/Reaqtor.Client.Core.csproj
@@ -13,6 +13,8 @@
     <ProjectReference Include="..\..\Metadata\Reaqtor.Metadata.Model\Reaqtor.Metadata.Model.csproj" />
     <ProjectReference Include="..\..\Shared\Reaqtor.Shared.Core\Reaqtor.Shared.Core.csproj" />
     <ProjectReference Include="..\..\Shared\Reaqtor.Shared.Model\Reaqtor.Shared.Model.csproj" />
+    <ProjectReference Include="..\..\..\..\Nuqleon\Core\DataModel\Nuqleon.DataModel\Nuqleon.DataModel.csproj" />
+    <ProjectReference Include="..\..\..\..\Nuqleon\Core\DataModel\Nuqleon.DataModel.CompilerServices\Nuqleon.DataModel.CompilerServices.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Reaqtor/Core/Client/Reaqtor.Client.Core/Reaqtor/CheckedReactiveExpressionServices.cs
+++ b/Reaqtor/Core/Client/Reaqtor.Client.Core/Reaqtor/CheckedReactiveExpressionServices.cs
@@ -254,11 +254,11 @@ public class CheckedReactiveExpressionServices : ReactiveExpressionServices
         /// </summary>
         /// <param name="initializer">The initializer expression to resolve.</param>
         /// <param name="visit">Function to visit the element initializer.</param>
-        /// <returns>Original element initializer (see remarks).</returns>
-        /// <remarks>We allow element initializers with no questions asked, under the assumption that the containing ListInitExpression or ListMemberBinding node was allowed based on its collection type.</remarks>
+        /// <returns>The element initializer with its arguments visited (see remarks).</returns>
+        /// <remarks>We allow the add method with no questions asked, under the assumption that the containing ListInitExpression or ListMemberBinding node was allowed based on its collection type, but continue the visit so the initializer's arguments remain subject to allow list scanning. (The archived Remoting client library this code was factored out of returned the initializer without visiting its arguments, leaving them unscanned.)</remarks>
         protected override ElementInit ResolveElementInit(ElementInit initializer, Func<ElementInit, ElementInit> visit)
         {
-            return initializer;
+            return visit(initializer);
         }
 
         /// <summary>
@@ -267,11 +267,11 @@ public class CheckedReactiveExpressionServices : ReactiveExpressionServices
         /// <typeparam name="T">The concrete subtype of the binding expression.</typeparam>
         /// <param name="binding">The binding expression to resolve.</param>
         /// <param name="visit">Function to visit the member binding.</param>
-        /// <returns>Original member binding (see remarks).</returns>
-        /// <remarks>We allow member bindings with no questions asked, under the assumption that the containing MemberInitExpression or MemberBinding node was allowed based on its constructor's declaring type.</remarks>
+        /// <returns>The member binding with its child expressions visited (see remarks).</returns>
+        /// <remarks>We allow the bound member with no questions asked, under the assumption that the containing MemberInitExpression or MemberBinding node was allowed based on its constructor's declaring type, but continue the visit so the binding's child expressions remain subject to allow list scanning. (The archived Remoting client library this code was factored out of returned the binding without visiting its children, leaving them unscanned.)</remarks>
         protected override MemberBinding ResolveMemberBinding<T>(T binding, Func<T, MemberBinding> visit)
         {
-            return binding;
+            return visit(binding);
         }
 
         /// <summary>

--- a/Reaqtor/Core/Client/Reaqtor.Client.Core/Reaqtor/CheckedReactiveExpressionServices.cs
+++ b/Reaqtor/Core/Client/Reaqtor.Client.Core/Reaqtor/CheckedReactiveExpressionServices.cs
@@ -1,0 +1,295 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT License.
+// See the LICENSE file in the project root for more information.
+
+//
+// Revision history:
+//
+// ER - October 2013 - Created this code in the Remoting sample's client library.
+// HvR - July 2026 - Factored out of the archived Remoting sample (see #158).
+//
+
+using System.Linq.CompilerServices;
+using System.Linq.Expressions;
+using System.Reflection;
+
+using Nuqleon.DataModel;
+
+namespace Reaqtor;
+
+/// <summary>
+/// Expression tree rewriting services for reactive service clients that check expressions against
+/// an allow list of members prior to submission to a service, evaluating rejected subexpressions
+/// locally and inlining their results as constants.
+/// </summary>
+public class CheckedReactiveExpressionServices : ReactiveExpressionServices
+{
+    /// <summary>
+    /// The member allow list.
+    /// </summary>
+    /// <remarks><para>
+    /// Especially uses of “Now” are tricky, because it’s going to use the
+    /// server’s clock, reveal its offset from UTC, and whatnot. Rx as we
+    /// have it today is making the assumption that absolute time is
+    /// observed as the machine sees it, which includes taking DST into
+    /// account, by observing system clock change events from the system and
+    /// monitoring for clock drift. We never have situations where a system
+    /// executes a query on behalf of a remote user who may expect his or
+    /// her time zone to be taken into account.
+    /// </para><para>
+    /// All of DateTimeOffset and DateTime (except for Now and UtcNow) are on
+    /// the allow list. This enables queries which perform DateTimeOffset
+    /// arithmetic. The reason for excluding [Utc]Now is twofold:
+    ///     Ties to the system clock of the query evaluator, as discussed above.
+    ///     Not pure functions, so defeating all sorts of optimizations
+    /// (e.g. we can’t hoist the sub-expression out of a SelectMany
+    /// collection selector, because timing would change).
+    /// </para><para>
+    /// All of TimeSpan is included as well (no exclusions needed).
+    /// </para><para>
+    /// Note that DateTime and DateTimeOffset are valid data model types, so <see cref="IsAllowedMember"/>
+    /// blesses all of their members before this table is consulted; the [Utc]Now exclusions expressed here
+    /// only take effect if that blessing is narrowed. This matches the behavior of the archived Remoting
+    /// client library this code was factored out of.
+    /// </para></remarks>
+    private static readonly IList<MemberInfo> MemberAllowList = new Func<IList<MemberInfo>>(
+        () =>
+        {
+            var members = from type in new[] { typeof(DateTime), typeof(DateTimeOffset) }
+                          from member in type.GetMembers()
+                          select member;
+
+            members = members.Except(
+            [
+                ReflectionHelpers.InfoOf(() => DateTime.Now),
+                ReflectionHelpers.InfoOf(() => DateTime.UtcNow),
+                ReflectionHelpers.InfoOf(() => DateTimeOffset.Now),
+                ReflectionHelpers.InfoOf(() => DateTimeOffset.UtcNow),
+            ]);
+
+            return [.. members];
+        })();
+
+    /// <summary>
+    /// Allow list scanner to prevent remote execution of client-side only constructs.
+    /// </summary>
+    private readonly AllowListScanner _allowListScanner;
+
+    /// <summary>
+    /// Creates a new checked expression service provider instance.
+    /// </summary>
+    /// <param name="reactiveClientInterfaceType">Interface type of the IReactiveClient variant used to obtain reactive resources.</param>
+    public CheckedReactiveExpressionServices(Type reactiveClientInterfaceType)
+        : base(reactiveClientInterfaceType)
+    {
+        _allowListScanner = CreateAllowListScanner();
+    }
+
+    /// <summary>
+    /// Normalizes the specified expression prior to submission to the service.
+    /// </summary>
+    /// <param name="expression">The expression to normalize.</param>
+    /// <returns>The normalized expression.</returns>
+    public override Expression Normalize(Expression expression)
+    {
+        // Runs a standard set of rewrites, causing callbacks to the Funcletize method below.
+        var normalized = base.Normalize(expression);
+
+        // Replaces compiler-generated anonymous types, e.g. for transparent identifiers, by tuples which don't need reconstruction in the service.
+        var tupletized = AnonymousTypeTupletizer.Tupletize(normalized, Expression.Constant(null), excludeVisibleTypes: true);
+
+        return tupletized;
+    }
+
+    /// <summary>
+    /// Funcletizes the specified expression.
+    /// </summary>
+    /// <param name="expression">The expression to funcletize.</param>
+    /// <returns>The funcletized expression.</returns>
+    protected override Expression Funcletize(Expression expression)
+    {
+        var res = base.Funcletize(expression);
+        res = _allowListScanner.Visit(res);
+        return res;
+    }
+
+    /// <summary>
+    /// Checks whether the specified member is allowed to occur in expressions submitted to the service,
+    /// prior to consulting the declarative allow list table. Derived classes can override this method to
+    /// bless additional members, e.g. types provided by a serialization library available on the service.
+    /// </summary>
+    /// <param name="member">Member to check against the allow list.</param>
+    /// <returns><c>true</c> if usage of the member is allowed; otherwise, <c>false</c>.</returns>
+    /// <remarks>
+    /// The default implementation allows members declared on types annotated with
+    /// <see cref="KnownTypeAttribute"/>, members declared on valid data model types, members annotated
+    /// with <see cref="KnownResourceAttribute"/>, and members declared in Reaqtive or Reaqtor assemblies.
+    /// The assembly name based check is to be refined using a curated list of assemblies once all layering
+    /// and factoring of client-side components is complete.
+    /// </remarks>
+    protected virtual bool IsAllowedMember(MemberInfo member)
+    {
+        ArgumentNullException.ThrowIfNull(member);
+
+        var d = member.DeclaringType;
+
+        // Annotation used for types that are deployed to the service and are well-known. This should be used sparingly, e.g. for custom feed adapters etc.
+        if (d.IsDefined(typeof(KnownTypeAttribute)))
+        {
+            return true;
+        }
+
+        // Main check to allow any of the members on any of the data model types with no further questions asked. This includes things like int, string, DateTime, etc.
+        if (DataModelHelpers.IsDataModelType(d))
+        {
+            return true;
+        }
+
+        // Members annotated with the KnownResourceAttribute will get rewritten to invocation expressions and are allowed. It is assumed the service will know how to bind those.
+        if (member.IsDefined(typeof(KnownResourceAttribute)))
+        {
+            return true;
+        }
+
+        if (d.Assembly.FullName.StartsWith("Reaqtive", StringComparison.Ordinal) ||
+            d.Assembly.FullName.StartsWith("Reaqtor", StringComparison.Ordinal))
+        {
+            return true;
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Gets the allow list scanner used to detect client-side only constructs that should not be run on the service.
+    /// </summary>
+    /// <returns>Allow list scanner used to detect client-side only constructs that should not be run on the service.</returns>
+    private AllowListScanner CreateAllowListScanner()
+    {
+        // The following is a declarative table of allowed constructs whose expression tree representation can be
+        // sent to the service for remote execution. This also allows to detect user code, such as reads from local
+        // fields, which end up in the expression tree representation of a query or a define operation. Use this
+        // table with EXTREME caution! In particular, only allowed BCL functionality should be added here. Under no
+        // circumstance whatsoever should this table contain reactive interfaces, query operators, and whatnot. If
+        // such a need is suspected, something else is wrong higher up the expression rewrite stack. While the use
+        // of the allow list scanner will throw exceptions for invalid constructs encountered, the fix is (almost)
+        // never to extend the table.
+        var allowListScanner = new AllowListScanner(this)
+        {
+            // Allowing use of all members on the following types:
+            DeclaringTypes =
+            {
+                typeof(Math),
+                typeof(TimeSpan),
+                typeof(System.Text.Json.Nodes.JsonNode),
+                typeof(System.Text.Json.Nodes.JsonObject),
+                typeof(System.Text.Json.Nodes.JsonArray),
+                typeof(System.Text.Json.Nodes.JsonValue),
+                typeof(Enumerable),
+                typeof(Queryable),
+                typeof(KeyValuePair<,>),
+                typeof(Tuple<>),
+                typeof(Tuple<,>),
+                typeof(Tuple<,,>),
+                typeof(Tuple<,,,>),
+                typeof(Tuple<,,,,>),
+                typeof(Tuple<,,,,,>),
+                typeof(Tuple<,,,,,,>),
+                typeof(Tuple<,,,,,,,>),
+            },
+
+            // Allowing use of the following members:
+            Members =
+            {
+                ReflectionHelpers.InfoOf(() => Environment.MachineName), // used for diagnostics
+
+                // Enable e.g. new JsonObject { ... }.ToString()
+                typeof(object).GetMethod(nameof(ToString), Type.EmptyTypes),
+            },
+        };
+
+        // Allowing use of the following specific members:
+        foreach (var memberInfo in MemberAllowList)
+        {
+            allowListScanner.Members.Add(memberInfo);
+        }
+
+        return allowListScanner;
+    }
+
+    /// <summary>
+    /// Implementation of an allow list scanner used to detect client-side only constructs that should not be run on the service, with default policies to deal with unsupported constructs.
+    /// </summary>
+    private sealed class AllowListScanner : ExpressionMemberAllowListScanner
+    {
+        /// <summary>
+        /// The expression services whose <see cref="IsAllowedMember"/> policy is consulted during scanning.
+        /// </summary>
+        private readonly CheckedReactiveExpressionServices _parent;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AllowListScanner"/> class.
+        /// </summary>
+        /// <param name="parent">The expression services whose <see cref="IsAllowedMember"/> policy is consulted during scanning.</param>
+        public AllowListScanner(CheckedReactiveExpressionServices parent) => _parent = parent;
+
+        /// <summary>
+        /// Checks whether the specified member is allowed by the allow list.
+        /// </summary>
+        /// <param name="member">Member to check against the allow list.</param>
+        /// <returns><c>true</c> if usage of the member is allowed by the allow list; otherwise, <c>false</c>.</returns>
+        protected override bool Check(MemberInfo member)
+        {
+            if (_parent.IsAllowedMember(member))
+            {
+                return true;
+            }
+
+            // Checks against the declarative allow list (see CreateAllowListScanner to extend this list).
+            return base.Check(member);
+        }
+
+        /// <summary>
+        /// Resolves an element initializer expression which was rejected by the allow list scanner.
+        /// </summary>
+        /// <param name="initializer">The initializer expression to resolve.</param>
+        /// <param name="visit">Function to visit the element initializer.</param>
+        /// <returns>Original element initializer (see remarks).</returns>
+        /// <remarks>We allow element initializers with no questions asked, under the assumption that the containing ListInitExpression or ListMemberBinding node was allowed based on its collection type.</remarks>
+        protected override ElementInit ResolveElementInit(ElementInit initializer, Func<ElementInit, ElementInit> visit)
+        {
+            return initializer;
+        }
+
+        /// <summary>
+        /// Resolves a member binding expression which was rejected by the allow list scanner.
+        /// </summary>
+        /// <typeparam name="T">The concrete subtype of the binding expression.</typeparam>
+        /// <param name="binding">The binding expression to resolve.</param>
+        /// <param name="visit">Function to visit the member binding.</param>
+        /// <returns>Original member binding (see remarks).</returns>
+        /// <remarks>We allow member bindings with no questions asked, under the assumption that the containing MemberInitExpression or MemberBinding node was allowed based on its constructor's declaring type.</remarks>
+        protected override MemberBinding ResolveMemberBinding<T>(T binding, Func<T, MemberBinding> visit)
+        {
+            return binding;
+        }
+
+        /// <summary>
+        /// Resolves an expression which was rejected by the allow list scanner.
+        /// </summary>
+        /// <typeparam name="T">The concrete subtype of the expression.</typeparam>
+        /// <param name="expression">The expression to resolve.</param>
+        /// <param name="member">The member used by the expression, which caused it to be rejected.</param>
+        /// <param name="visit">Function to visit the expression.</param>
+        /// <returns>Expression holding the result of local evaluation of the expression.</returns>
+        protected override Expression ResolveExpression<T>(T expression, MemberInfo member, Func<T, Expression> visit)
+        {
+            // Note that this method will throw if the expression contains unbound parameters that are only available on the service. This is
+            // by design and almost never indicates that something is wrong with the allow list scanner. Instead, another rewrite higher up the
+            // stack is likely going haywire.
+            var value = expression.Evaluate();
+
+            return Expression.Constant(value, expression.Type);
+        }
+    }
+}

--- a/Reaqtor/Core/Client/Reaqtor.Client.Core/Reaqtor/CheckedReactiveExpressionServices.cs
+++ b/Reaqtor/Core/Client/Reaqtor.Client.Core/Reaqtor/CheckedReactiveExpressionServices.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 
@@ -59,13 +59,18 @@ public class CheckedReactiveExpressionServices : ReactiveExpressionServices
                           from member in type.GetMembers()
                           select member;
 
-            members = members.Except(
-            [
-                ReflectionHelpers.InfoOf(() => DateTime.Now),
-                ReflectionHelpers.InfoOf(() => DateTime.UtcNow),
-                ReflectionHelpers.InfoOf(() => DateTimeOffset.Now),
-                ReflectionHelpers.InfoOf(() => DateTimeOffset.UtcNow),
-            ]);
+            // NB: GetMembers() returns both the PropertyInfo and its accessor MethodInfo, and expression
+            //     trees can reference either form (a MemberExpression on the property or a MethodCallExpression
+            //     on get_Now), so both must be excluded for the exclusion to be effective.
+            var excludedProperties = new[]
+            {
+                (PropertyInfo)ReflectionHelpers.InfoOf(() => DateTime.Now),
+                (PropertyInfo)ReflectionHelpers.InfoOf(() => DateTime.UtcNow),
+                (PropertyInfo)ReflectionHelpers.InfoOf(() => DateTimeOffset.Now),
+                (PropertyInfo)ReflectionHelpers.InfoOf(() => DateTimeOffset.UtcNow),
+            };
+
+            members = members.Except(excludedProperties.SelectMany(property => new MemberInfo[] { property, property.GetMethod }));
 
             return [.. members];
         })();
@@ -133,6 +138,14 @@ public class CheckedReactiveExpressionServices : ReactiveExpressionServices
 
         var d = member.DeclaringType;
 
+        // Members without a declaring type (e.g. DynamicMethod-backed methods or module-global methods)
+        // cannot be vetted by any of the type-based rules below and are rejected here, causing the scanner
+        // to fall back to local evaluation of the containing subexpression.
+        if (d is null)
+        {
+            return false;
+        }
+
         // Annotation used for types that are deployed to the service and are well-known. This should be used sparingly, e.g. for custom feed adapters etc.
         if (d.IsDefined(typeof(KnownTypeAttribute)))
         {
@@ -151,13 +164,32 @@ public class CheckedReactiveExpressionServices : ReactiveExpressionServices
             return true;
         }
 
-        if (d.Assembly.FullName.StartsWith("Reaqtive", StringComparison.Ordinal) ||
-            d.Assembly.FullName.StartsWith("Reaqtor", StringComparison.Ordinal))
+        if (IsInKnownAssembly(d))
         {
             return true;
         }
 
         return false;
+    }
+
+    /// <summary>
+    /// Checks whether the specified type is declared in a Reaqtive or Reaqtor assembly.
+    /// </summary>
+    /// <param name="type">The type to check.</param>
+    /// <returns><c>true</c> if the type is declared in a Reaqtive or Reaqtor assembly; otherwise, <c>false</c>.</returns>
+    /// <remarks>
+    /// The match requires a name boundary after the prefix, so unrelated assemblies whose names merely
+    /// start with these prefixes (e.g. <c>ReaqtorContrib</c>) are not blessed.
+    /// </remarks>
+    private static bool IsInKnownAssembly(Type type)
+    {
+        var fullName = type.Assembly.FullName;
+
+        return IsMatch(fullName, "Reaqtive") || IsMatch(fullName, "Reaqtor");
+
+        static bool IsMatch(string fullName, string name) =>
+            fullName.StartsWith(name, StringComparison.Ordinal) &&
+            (fullName.Length == name.Length || fullName[name.Length] is '.' or ',');
     }
 
     /// <summary>
@@ -243,6 +275,13 @@ public class CheckedReactiveExpressionServices : ReactiveExpressionServices
             if (_parent.IsAllowedMember(member))
             {
                 return true;
+            }
+
+            // Members without a declaring type cannot appear on the declarative list, and the base
+            // implementation assumes a non-null declaring type when chasing interface implementations.
+            if (member.DeclaringType is null)
+            {
+                return false;
             }
 
             // Checks against the declarative allow list (see CreateAllowListScanner to extend this list).

--- a/Reaqtor/Core/Client/Reaqtor.Client.Core/Reaqtor/CheckedReactiveExpressionServices.cs
+++ b/Reaqtor/Core/Client/Reaqtor.Client.Core/Reaqtor/CheckedReactiveExpressionServices.cs
@@ -52,33 +52,48 @@ public class CheckedReactiveExpressionServices : ReactiveExpressionServices
     /// only take effect if that blessing is narrowed. This matches the behavior of the archived Remoting
     /// client library this code was factored out of.
     /// </para></remarks>
-    private static readonly IList<MemberInfo> MemberAllowList = new Func<IList<MemberInfo>>(
-        () =>
-        {
-            var members = from type in new[] { typeof(DateTime), typeof(DateTimeOffset) }
-                          from member in type.GetMembers()
-                          select member;
+    private static readonly IReadOnlyList<MemberInfo> MemberAllowList = CreateMemberAllowList();
 
-            // NB: GetMembers() returns both the PropertyInfo and its accessor MethodInfo, and expression
-            //     trees can reference either form (a MemberExpression on the property or a MethodCallExpression
-            //     on get_Now), so both must be excluded for the exclusion to be effective.
-            var excludedProperties = new[]
-            {
-                (PropertyInfo)ReflectionHelpers.InfoOf(() => DateTime.Now),
-                (PropertyInfo)ReflectionHelpers.InfoOf(() => DateTime.UtcNow),
-                (PropertyInfo)ReflectionHelpers.InfoOf(() => DateTimeOffset.Now),
-                (PropertyInfo)ReflectionHelpers.InfoOf(() => DateTimeOffset.UtcNow),
-            };
+    /// <summary>
+    /// Unit value substituted for anonymous type instances during tupletization in <see cref="Normalize"/>.
+    /// </summary>
+    private static readonly ConstantExpression s_nullConstant = Expression.Constant(null);
 
-            members = members.Except(excludedProperties.SelectMany(property => new MemberInfo[] { property, property.GetMethod }));
-
-            return [.. members];
-        })();
+    /// <summary>
+    /// The parameterless <see cref="object.ToString"/> method, allowed as a member (see <see cref="CreateAllowListScanner"/>).
+    /// </summary>
+    private static readonly MethodInfo s_objectToString = typeof(object).GetMethod(nameof(ToString), Type.EmptyTypes);
 
     /// <summary>
     /// Allow list scanner to prevent remote execution of client-side only constructs.
     /// </summary>
     private readonly AllowListScanner _allowListScanner;
+
+    /// <summary>
+    /// Creates the member allow list.
+    /// </summary>
+    /// <returns>The member allow list.</returns>
+    private static MemberInfo[] CreateMemberAllowList()
+    {
+        var members = from type in new[] { typeof(DateTime), typeof(DateTimeOffset) }
+                      from member in type.GetMembers()
+                      select member;
+
+        // NB: GetMembers() returns both the PropertyInfo and its accessor MethodInfo, and expression
+        //     trees can reference either form (a MemberExpression on the property or a MethodCallExpression
+        //     on get_Now), so both must be excluded for the exclusion to be effective.
+        var excludedProperties = new[]
+        {
+            (PropertyInfo)ReflectionHelpers.InfoOf(() => DateTime.Now),
+            (PropertyInfo)ReflectionHelpers.InfoOf(() => DateTime.UtcNow),
+            (PropertyInfo)ReflectionHelpers.InfoOf(() => DateTimeOffset.Now),
+            (PropertyInfo)ReflectionHelpers.InfoOf(() => DateTimeOffset.UtcNow),
+        };
+
+        members = members.Except(excludedProperties.SelectMany(property => new MemberInfo[] { property, property.GetMethod }));
+
+        return [.. members];
+    }
 
     /// <summary>
     /// Creates a new checked expression service provider instance.
@@ -101,7 +116,7 @@ public class CheckedReactiveExpressionServices : ReactiveExpressionServices
         var normalized = base.Normalize(expression);
 
         // Replaces compiler-generated anonymous types, e.g. for transparent identifiers, by tuples which don't need reconstruction in the service.
-        var tupletized = AnonymousTypeTupletizer.Tupletize(normalized, Expression.Constant(null), excludeVisibleTypes: true);
+        var tupletized = AnonymousTypeTupletizer.Tupletize(normalized, s_nullConstant, excludeVisibleTypes: true);
 
         return tupletized;
     }
@@ -236,7 +251,7 @@ public class CheckedReactiveExpressionServices : ReactiveExpressionServices
                 ReflectionHelpers.InfoOf(() => Environment.MachineName), // used for diagnostics
 
                 // Enable e.g. new JsonObject { ... }.ToString()
-                typeof(object).GetMethod(nameof(ToString), Type.EmptyTypes),
+                s_objectToString,
             },
         };
 

--- a/Reaqtor/Core/Client/Reaqtor.Client.Core/Reaqtor/DetupletizingReactiveExpressionServices.cs
+++ b/Reaqtor/Core/Client/Reaqtor.Client.Core/Reaqtor/DetupletizingReactiveExpressionServices.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Client/Reaqtor.Client.Core/Reaqtor/DetupletizingReactiveExpressionServices.cs
+++ b/Reaqtor/Core/Client/Reaqtor.Client.Core/Reaqtor/DetupletizingReactiveExpressionServices.cs
@@ -1,0 +1,49 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT License.
+// See the LICENSE file in the project root for more information.
+
+//
+// Revision history:
+//
+// ER - August 2014 - Created this code in the Remoting sample's client library.
+// HvR - July 2026 - Factored out of the archived Remoting sample (see #158).
+//
+
+using System.Linq.Expressions;
+
+namespace Reaqtor;
+
+/// <summary>
+/// Expression tree rewriting services for reactive service clients, which, after normalization,
+/// convert all invocation expressions and the root level lambda expression from a form using unary
+/// lambdas with tuple arguments to n-ary lambdas with the tuple arguments unpacked.
+/// </summary>
+/// <remarks>
+/// Unlike <see cref="TupletizingReactiveExpressionServices"/>, this type derives from
+/// <see cref="ReactiveExpressionServices"/> rather than <see cref="CheckedReactiveExpressionServices"/>.
+/// Detupletization takes place on the receiving side of an expression exchange, where allow list
+/// scanning and local evaluation of rejected subexpressions - which are submission concerns - do not
+/// apply.
+/// </remarks>
+public class DetupletizingReactiveExpressionServices : ReactiveExpressionServices
+{
+    /// <summary>
+    /// Creates a new detupletizing expression service provider instance.
+    /// </summary>
+    /// <param name="reactiveClientInterfaceType">Interface type of the IReactiveClient variant used to obtain reactive resources.</param>
+    public DetupletizingReactiveExpressionServices(Type reactiveClientInterfaceType)
+        : base(reactiveClientInterfaceType)
+    {
+    }
+
+    /// <summary>
+    /// Normalizes the specified expression prior to submission to the service.
+    /// </summary>
+    /// <param name="expression">The expression to normalize.</param>
+    /// <returns>The normalized expression.</returns>
+    public override Expression Normalize(Expression expression)
+    {
+        var normalized = base.Normalize(expression);
+        return ExpressionTupletization.Detupletize(normalized);
+    }
+}

--- a/Reaqtor/Core/Client/Reaqtor.Client.Core/Reaqtor/Internal/DataModelHelpers.cs
+++ b/Reaqtor/Core/Client/Reaqtor.Client.Core/Reaqtor/Internal/DataModelHelpers.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Client/Reaqtor.Client.Core/Reaqtor/Internal/DataModelHelpers.cs
+++ b/Reaqtor/Core/Client/Reaqtor.Client.Core/Reaqtor/Internal/DataModelHelpers.cs
@@ -1,0 +1,39 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT License.
+// See the LICENSE file in the project root for more information.
+
+//
+// Revision history:
+//
+// ER - October 2013 - Created this code in the Remoting sample's client library.
+// HvR - July 2026 - Factored out of the archived Remoting sample (see #158).
+//
+
+using System.Runtime.CompilerServices;
+
+using Nuqleon.DataModel.TypeSystem;
+
+namespace Reaqtor;
+
+/// <summary>
+/// Provides helper methods used to enforce data model constraints on used CLR types.
+/// </summary>
+internal static class DataModelHelpers
+{
+    private static readonly ConditionalWeakTable<Type, StrongBox<bool>> s_isDataModelTypeCache = [];
+
+    /// <summary>
+    /// Determines whether the specified type is a valid data model type.
+    /// </summary>
+    /// <param name="type">The type to check for data model type validity.</param>
+    /// <returns>
+    ///   <c>true</c> if the specified type is a valid data model type; otherwise, <c>false</c>.
+    /// </returns>
+    internal static bool IsDataModelType(Type type)
+    {
+        return s_isDataModelTypeCache.GetValue(type, t =>
+        {
+            return new StrongBox<bool>(DataType.TryCheck(t, out _));
+        }).Value;
+    }
+}

--- a/Reaqtor/Core/Client/Reaqtor.Client.Core/Reaqtor/TupletizingReactiveExpressionServices.cs
+++ b/Reaqtor/Core/Client/Reaqtor.Client.Core/Reaqtor/TupletizingReactiveExpressionServices.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Client/Reaqtor.Client.Core/Reaqtor/TupletizingReactiveExpressionServices.cs
+++ b/Reaqtor/Core/Client/Reaqtor.Client.Core/Reaqtor/TupletizingReactiveExpressionServices.cs
@@ -1,0 +1,42 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT License.
+// See the LICENSE file in the project root for more information.
+
+//
+// Revision history:
+//
+// ER - October 2013 - Created this code in the Remoting sample's client library.
+// HvR - July 2026 - Factored out of the archived Remoting sample (see #158).
+//
+
+using System.Linq.Expressions;
+
+namespace Reaqtor;
+
+/// <summary>
+/// Expression tree rewriting services for reactive service clients, which, after normalization,
+/// convert all invocation expressions and the root level lambda expression to a form using unary
+/// lambdas by tupletizing the arguments.
+/// </summary>
+public class TupletizingReactiveExpressionServices : CheckedReactiveExpressionServices
+{
+    /// <summary>
+    /// Creates a new tupletizing expression service provider instance.
+    /// </summary>
+    /// <param name="reactiveClientInterfaceType">Interface type of the IReactiveClient variant used to obtain reactive resources.</param>
+    public TupletizingReactiveExpressionServices(Type reactiveClientInterfaceType)
+        : base(reactiveClientInterfaceType)
+    {
+    }
+
+    /// <summary>
+    /// Normalizes the specified expression prior to submission to the service.
+    /// </summary>
+    /// <param name="expression">The expression to normalize.</param>
+    /// <returns>The normalized expression.</returns>
+    public override Expression Normalize(Expression expression)
+    {
+        var normalized = base.Normalize(expression);
+        return ExpressionTupletization.Tupletize(normalized);
+    }
+}

--- a/Reaqtor/Core/Client/Tests.Reaqtor.Client.Core/Reaqtor/CheckedReactiveExpressionServicesTests.cs
+++ b/Reaqtor/Core/Client/Tests.Reaqtor.Client.Core/Reaqtor/CheckedReactiveExpressionServicesTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 
@@ -125,6 +125,66 @@ public class CheckedReactiveExpressionServicesTests
     }
 
     [TestMethod]
+    public void CheckedReactiveExpressionServices_DateTimeNowAccessorForm_ExcludedFromAllowListTable()
+    {
+        // Uses the accessor MethodInfo call form (get_Now) rather than the property access form, and a
+        // subclass that stops blessing DateTime wholesale so the declarative table's exclusions engage.
+        var getNow = typeof(DateTime).GetProperty(nameof(DateTime.Now)).GetMethod;
+        var expr = Expression.Lambda<Func<DateTime>>(Expression.Call(getNow));
+
+        var services = new NoDateTimeBlessingExpressionServices(typeof(IReactiveClientProxy));
+        var normalized = services.Normalize(expr);
+
+        var lambda = (LambdaExpression)normalized;
+        Assert.AreEqual(ExpressionType.Constant, lambda.Body.NodeType);
+    }
+
+    [TestMethod]
+    public void CheckedReactiveExpressionServices_DateTimeArithmetic_AllowedByTableWhenBlessingNarrowed()
+    {
+        // With DateTime no longer blessed wholesale, non-excluded members still pass via the declarative table.
+        Expression<Func<DateTime, DateTime>> expr = d => d.AddDays(1);
+
+        var services = new NoDateTimeBlessingExpressionServices(typeof(IReactiveClientProxy));
+        var normalized = services.Normalize(expr);
+
+        var lambda = (LambdaExpression)normalized;
+        var call = (MethodCallExpression)lambda.Body;
+        Assert.AreEqual(nameof(DateTime.AddDays), call.Method.Name);
+    }
+
+    [TestMethod]
+    public void CheckedReactiveExpressionServices_MemberWithoutDeclaringType_RejectedNotCrashing()
+    {
+        var dynamicMethod = new System.Reflection.Emit.DynamicMethod("Answer", typeof(int), Type.EmptyTypes);
+        var il = dynamicMethod.GetILGenerator();
+        il.Emit(System.Reflection.Emit.OpCodes.Ldc_I4, 42);
+        il.Emit(System.Reflection.Emit.OpCodes.Ret);
+
+        Assert.IsNull(dynamicMethod.DeclaringType);
+        Assert.IsFalse(new ExposedExpressionServices(typeof(IReactiveClientProxy)).IsAllowed(dynamicMethod));
+    }
+
+    [TestMethod]
+    public void CheckedReactiveExpressionServices_AssemblyPrefixLookalike_NotBlessed()
+    {
+        var assemblyBuilder = System.Reflection.Emit.AssemblyBuilder.DefineDynamicAssembly(new AssemblyName("ReaqtorContrib"), System.Reflection.Emit.AssemblyBuilderAccess.Run);
+        var moduleBuilder = assemblyBuilder.DefineDynamicModule("ReaqtorContrib");
+        var typeBuilder = moduleBuilder.DefineType("ReaqtorContrib.Lookalike", TypeAttributes.Public | TypeAttributes.Abstract | TypeAttributes.Sealed);
+        var methodBuilder = typeBuilder.DefineMethod("Evil", MethodAttributes.Public | MethodAttributes.Static, typeof(int), Type.EmptyTypes);
+        var il = methodBuilder.GetILGenerator();
+        il.Emit(System.Reflection.Emit.OpCodes.Ldc_I4, 42);
+        il.Emit(System.Reflection.Emit.OpCodes.Ret);
+        var lookalike = typeBuilder.CreateType().GetMethod("Evil");
+
+        var services = new ExposedExpressionServices(typeof(IReactiveClientProxy));
+        Assert.IsFalse(services.IsAllowed(lookalike));
+
+        // Sanity check: genuine Reaqtor assemblies remain blessed.
+        Assert.IsTrue(services.IsAllowed(typeof(ReactiveExpressionServices).GetMethod(nameof(ReactiveExpressionServices.Normalize))));
+    }
+
+    [TestMethod]
     public void CheckedReactiveExpressionServices_RejectedElementInit_ArgumentsStillScanned()
     {
         Expression<Func<TestBag>> expr = () => new TestBag { Path.Combine("a", "b") };
@@ -198,8 +258,31 @@ public class CheckedReactiveExpressionServicesTests
     {
         public string Name { get; set; }
 
-        public void Add(string item) => _ = item;
+        public void Add(string item) => Name = item;
 
         public System.Collections.IEnumerator GetEnumerator() => throw new NotImplementedException();
+    }
+
+    private sealed class NoDateTimeBlessingExpressionServices : CheckedReactiveExpressionServices
+    {
+        public NoDateTimeBlessingExpressionServices(Type reactiveClientInterfaceType)
+            : base(reactiveClientInterfaceType)
+        {
+        }
+
+        protected override bool IsAllowedMember(MemberInfo member)
+        {
+            return member.DeclaringType != typeof(DateTime) && base.IsAllowedMember(member);
+        }
+    }
+
+    private sealed class ExposedExpressionServices : CheckedReactiveExpressionServices
+    {
+        public ExposedExpressionServices(Type reactiveClientInterfaceType)
+            : base(reactiveClientInterfaceType)
+        {
+        }
+
+        public bool IsAllowed(MemberInfo member) => IsAllowedMember(member);
     }
 }

--- a/Reaqtor/Core/Client/Tests.Reaqtor.Client.Core/Reaqtor/CheckedReactiveExpressionServicesTests.cs
+++ b/Reaqtor/Core/Client/Tests.Reaqtor.Client.Core/Reaqtor/CheckedReactiveExpressionServicesTests.cs
@@ -1,0 +1,145 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT License.
+// See the LICENSE file in the project root for more information.
+
+//
+// Revision history:
+//
+// HvR - July 2026 - Created this file as part of factoring expression services out of the archived Remoting sample (see #158).
+//
+
+using System.Linq.Expressions;
+using System.Reflection;
+using System.Text.Json.Nodes;
+
+using Reaqtor;
+
+namespace Tests.Reaqtor;
+
+[TestClass]
+public class CheckedReactiveExpressionServicesTests
+{
+    [TestMethod]
+    public void CheckedReactiveExpressionServices_DataModelMember_Preserved()
+    {
+        Expression<Func<string, int>> expr = s => s.Length;
+
+        var normalized = Normalize(expr);
+
+        var lambda = (LambdaExpression)normalized;
+        var member = (MemberExpression)lambda.Body;
+        Assert.AreEqual(typeof(string), member.Member.DeclaringType);
+    }
+
+    [TestMethod]
+    public void CheckedReactiveExpressionServices_DateTimeOffsetArithmetic_Preserved()
+    {
+        Expression<Func<DateTimeOffset, DateTimeOffset>> expr = d => d + TimeSpan.FromSeconds(1);
+
+        var normalized = Normalize(expr);
+
+        var lambda = (LambdaExpression)normalized;
+        Assert.AreEqual(ExpressionType.Add, lambda.Body.NodeType);
+    }
+
+    [TestMethod]
+    public void CheckedReactiveExpressionServices_JsonNodeIndexer_Preserved()
+    {
+        Expression<Func<JsonNode, JsonNode>> expr = n => n["x"];
+
+        var normalized = Normalize(expr);
+
+        var lambda = (LambdaExpression)normalized;
+        var call = (MethodCallExpression)lambda.Body;
+        Assert.AreEqual(typeof(JsonNode), call.Method.DeclaringType);
+    }
+
+    [TestMethod]
+    public void CheckedReactiveExpressionServices_JsonArrayIndexer_Preserved()
+    {
+        Expression<Func<JsonArray, JsonNode>> expr = a => a[0];
+
+        var normalized = Normalize(expr);
+
+        var lambda = (LambdaExpression)normalized;
+        Assert.IsInstanceOfType<MethodCallExpression>(lambda.Body);
+    }
+
+    [TestMethod]
+    public void CheckedReactiveExpressionServices_JsonValueCreate_Preserved()
+    {
+        Expression<Func<int, JsonNode>> expr = x => JsonValue.Create(x, null);
+
+        var normalized = Normalize(expr);
+
+        var lambda = (LambdaExpression)normalized;
+        var call = (MethodCallExpression)lambda.Body;
+        Assert.AreEqual(typeof(JsonValue), call.Method.DeclaringType);
+    }
+
+    [TestMethod]
+    public void CheckedReactiveExpressionServices_DisallowedClosedSubexpression_FoldedToConstant()
+    {
+        Expression<Func<string>> expr = () => Path.Combine("a", "b");
+
+        var normalized = Normalize(expr);
+
+        var lambda = (LambdaExpression)normalized;
+        var constant = (ConstantExpression)lambda.Body;
+        Assert.AreEqual(Path.Combine("a", "b"), constant.Value);
+    }
+
+    [TestMethod]
+    public void CheckedReactiveExpressionServices_DateTimeNow_PreservedByDataModelBlessing()
+    {
+        Expression<Func<DateTime>> expr = () => DateTime.Now;
+
+        var normalized = Normalize(expr);
+
+        // DateTime is a valid data model type, so IsAllowedMember blesses all of its members before
+        // the declarative table (which deliberately omits Now and UtcNow) is ever consulted. This
+        // documents the behavior inherited from the archived Remoting client library.
+        var lambda = (LambdaExpression)normalized;
+        Assert.IsInstanceOfType<MemberExpression>(lambda.Body);
+    }
+
+    [TestMethod]
+    public void CheckedReactiveExpressionServices_DisallowedMemberOverBoundParameter_Throws()
+    {
+        Expression<Func<string, string>> expr = s => Path.Combine(s, "b");
+
+        Assert.ThrowsExactly<System.Linq.CompilerServices.UnboundParameterException>(() => _ = Normalize(expr));
+    }
+
+    [TestMethod]
+    public void CheckedReactiveExpressionServices_IsAllowedMemberHook_BlessesAdditionalMembers()
+    {
+        Expression<Func<string, string>> expr = s => Path.Combine(s, "b");
+
+        var services = new PathBlessingExpressionServices(typeof(IReactiveClientProxy));
+        var normalized = services.Normalize(expr);
+
+        var lambda = (LambdaExpression)normalized;
+        var call = (MethodCallExpression)lambda.Body;
+        Assert.AreEqual(typeof(Path), call.Method.DeclaringType);
+    }
+
+    private static Expression Normalize(Expression expression)
+    {
+        var services = new CheckedReactiveExpressionServices(typeof(IReactiveClientProxy));
+        return services.Normalize(expression);
+    }
+
+    private sealed class PathBlessingExpressionServices : CheckedReactiveExpressionServices
+    {
+        public PathBlessingExpressionServices(Type reactiveClientInterfaceType)
+            : base(reactiveClientInterfaceType)
+        {
+        }
+
+        protected override bool IsAllowedMember(MemberInfo member)
+        {
+            return member.DeclaringType == typeof(Path) || base.IsAllowedMember(member);
+        }
+    }
+}

--- a/Reaqtor/Core/Client/Tests.Reaqtor.Client.Core/Reaqtor/CheckedReactiveExpressionServicesTests.cs
+++ b/Reaqtor/Core/Client/Tests.Reaqtor.Client.Core/Reaqtor/CheckedReactiveExpressionServicesTests.cs
@@ -124,6 +124,39 @@ public class CheckedReactiveExpressionServicesTests
         Assert.AreEqual(typeof(Path), call.Method.DeclaringType);
     }
 
+    [TestMethod]
+    public void CheckedReactiveExpressionServices_RejectedElementInit_ArgumentsStillScanned()
+    {
+        Expression<Func<TestBag>> expr = () => new TestBag { Path.Combine("a", "b") };
+
+        var services = new CtorOnlyBlessingExpressionServices(typeof(IReactiveClientProxy));
+        var normalized = services.Normalize(expr);
+
+        // The rejected Add method is forgiven, but the initializer's arguments are still scanned,
+        // so the disallowed closed subexpression gets folded to a constant.
+        var lambda = (LambdaExpression)normalized;
+        var listInit = (ListInitExpression)lambda.Body;
+        var argument = (ConstantExpression)listInit.Initializers[0].Arguments[0];
+        Assert.AreEqual(Path.Combine("a", "b"), argument.Value);
+    }
+
+    [TestMethod]
+    public void CheckedReactiveExpressionServices_RejectedMemberBinding_ChildrenStillScanned()
+    {
+        Expression<Func<TestBag>> expr = () => new TestBag { Name = Path.Combine("a", "b") };
+
+        var services = new CtorOnlyBlessingExpressionServices(typeof(IReactiveClientProxy));
+        var normalized = services.Normalize(expr);
+
+        // The rejected bound member is forgiven, but the binding's child expression is still scanned,
+        // so the disallowed closed subexpression gets folded to a constant.
+        var lambda = (LambdaExpression)normalized;
+        var memberInit = (MemberInitExpression)lambda.Body;
+        var assignment = (MemberAssignment)memberInit.Bindings[0];
+        var value = (ConstantExpression)assignment.Expression;
+        Assert.AreEqual(Path.Combine("a", "b"), value.Value);
+    }
+
     private static Expression Normalize(Expression expression)
     {
         var services = new CheckedReactiveExpressionServices(typeof(IReactiveClientProxy));
@@ -141,5 +174,32 @@ public class CheckedReactiveExpressionServicesTests
         {
             return member.DeclaringType == typeof(Path) || base.IsAllowedMember(member);
         }
+    }
+
+    private sealed class CtorOnlyBlessingExpressionServices : CheckedReactiveExpressionServices
+    {
+        public CtorOnlyBlessingExpressionServices(Type reactiveClientInterfaceType)
+            : base(reactiveClientInterfaceType)
+        {
+        }
+
+        protected override bool IsAllowedMember(MemberInfo member)
+        {
+            if (member.DeclaringType == typeof(TestBag))
+            {
+                return member is ConstructorInfo;
+            }
+
+            return base.IsAllowedMember(member);
+        }
+    }
+
+    private sealed class TestBag : System.Collections.IEnumerable
+    {
+        public string Name { get; set; }
+
+        public void Add(string item) => _ = item;
+
+        public System.Collections.IEnumerator GetEnumerator() => throw new NotImplementedException();
     }
 }

--- a/Reaqtor/Core/Client/Tests.Reaqtor.Client.Core/Reaqtor/DetupletizingReactiveExpressionServicesTests.cs
+++ b/Reaqtor/Core/Client/Tests.Reaqtor.Client.Core/Reaqtor/DetupletizingReactiveExpressionServicesTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Client/Tests.Reaqtor.Client.Core/Reaqtor/DetupletizingReactiveExpressionServicesTests.cs
+++ b/Reaqtor/Core/Client/Tests.Reaqtor.Client.Core/Reaqtor/DetupletizingReactiveExpressionServicesTests.cs
@@ -74,21 +74,7 @@ public class DetupletizingReactiveExpressionServicesTests
         AssertEqual(expr, rt);
     }
 
-    private static void AssertEqual(Expression x, Expression y)
-    {
-        Assert.IsTrue(new ExpressionEqualityComparer(() => new Comparator()).Equals(x, y));
-    }
+    private static void AssertEqual(Expression x, Expression y) => ExpressionAssert.AreEqual(x, y);
 
-    private static void AssertNotEqual(Expression x, Expression y)
-    {
-        Assert.IsFalse(new ExpressionEqualityComparer(() => new Comparator()).Equals(x, y));
-    }
-
-    private sealed class Comparator : ExpressionEqualityComparator
-    {
-        protected override bool EqualsGlobalParameter(ParameterExpression x, ParameterExpression y)
-        {
-            return x.Name == y.Name && Equals(x.Type, y.Type);
-        }
-    }
+    private static void AssertNotEqual(Expression x, Expression y) => ExpressionAssert.AreNotEqual(x, y);
 }

--- a/Reaqtor/Core/Client/Tests.Reaqtor.Client.Core/Reaqtor/DetupletizingReactiveExpressionServicesTests.cs
+++ b/Reaqtor/Core/Client/Tests.Reaqtor.Client.Core/Reaqtor/DetupletizingReactiveExpressionServicesTests.cs
@@ -1,0 +1,94 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT License.
+// See the LICENSE file in the project root for more information.
+
+//
+// Revision history:
+//
+// ER - August 2014 - Created this code in the Remoting sample's test library.
+// HvR - July 2026 - Factored out of the archived Remoting sample (see #158).
+//
+
+using System.Linq.CompilerServices;
+using System.Linq.Expressions;
+using System.Reflection;
+
+using Reaqtor;
+
+namespace Tests.Reaqtor;
+
+[TestClass]
+public class DetupletizingReactiveExpressionServicesTests
+{
+    [TestMethod]
+    public void DetupletizingReactiveExpressionServices_OneWay_NotDetupletized()
+    {
+        var expr = Expression.Invoke(Expression.Parameter(typeof(Func<List<int>, int>)), Expression.New(typeof(List<int>)));
+        var detupletizer = new DetupletizingReactiveExpressionServices(typeof(IReactiveClientProxy));
+        var actual = detupletizer.Normalize(expr);
+        AssertEqual(expr, actual);
+    }
+
+    [TestMethod]
+    public void DetupletizingReactiveExpressionServices_OneWay_Lambda()
+    {
+        Expression<Func<int, int>> expected = x => x;
+        Expression<Func<Tuple<int>, int>> expr = t => t.Item1;
+        var detupletizer = new DetupletizingReactiveExpressionServices(typeof(IReactiveClientProxy));
+        var actual = detupletizer.Normalize(expr);
+        AssertEqual(expected, actual);
+    }
+
+    [TestMethod]
+    public void DetupletizingReactiveExpressionServices_OneWay_Invocation()
+    {
+        var expected = Expression.Invoke(Expression.Parameter(typeof(Func<int, int>)), Expression.Constant(42));
+        var ctor = (ConstructorInfo)ReflectionHelpers.InfoOf(() => new Tuple<int>(default));
+        var expr = Expression.Invoke(Expression.Parameter(typeof(Func<Tuple<int>, int>)), Expression.New(ctor, Expression.Constant(42)));
+        var detupletizer = new DetupletizingReactiveExpressionServices(typeof(IReactiveClientProxy));
+        var actual = detupletizer.Normalize(expr);
+        AssertEqual(expected, actual);
+    }
+
+    [TestMethod]
+    public void DetupletizingReactiveExpressionServices_Roundtrip_Lambda()
+    {
+        Expression<Func<int, int>> expr = x => x;
+        var tupletizer = new TupletizingReactiveExpressionServices(typeof(IReactiveClientProxy));
+        var normalized = tupletizer.Normalize(expr);
+        AssertNotEqual(expr, normalized);
+        var detupletizer = new DetupletizingReactiveExpressionServices(typeof(IReactiveClientProxy));
+        var rt = detupletizer.Normalize(normalized);
+        AssertEqual(expr, rt);
+    }
+
+    [TestMethod]
+    public void DetupletizingReactiveExpressionServices_Roundtrip_Invocation()
+    {
+        var expr = Expression.Invoke(Expression.Parameter(typeof(Func<int, int>)), Expression.Constant(42));
+        var tupletizer = new TupletizingReactiveExpressionServices(typeof(IReactiveClientProxy));
+        var normalized = tupletizer.Normalize(expr);
+        AssertNotEqual(expr, normalized);
+        var detupletizer = new DetupletizingReactiveExpressionServices(typeof(IReactiveClientProxy));
+        var rt = detupletizer.Normalize(normalized);
+        AssertEqual(expr, rt);
+    }
+
+    private static void AssertEqual(Expression x, Expression y)
+    {
+        Assert.IsTrue(new ExpressionEqualityComparer(() => new Comparator()).Equals(x, y));
+    }
+
+    private static void AssertNotEqual(Expression x, Expression y)
+    {
+        Assert.IsFalse(new ExpressionEqualityComparer(() => new Comparator()).Equals(x, y));
+    }
+
+    private sealed class Comparator : ExpressionEqualityComparator
+    {
+        protected override bool EqualsGlobalParameter(ParameterExpression x, ParameterExpression y)
+        {
+            return x.Name == y.Name && Equals(x.Type, y.Type);
+        }
+    }
+}

--- a/Reaqtor/Core/Client/Tests.Reaqtor.Client.Core/Reaqtor/TupletizingReactiveExpressionServicesTests.cs
+++ b/Reaqtor/Core/Client/Tests.Reaqtor.Client.Core/Reaqtor/TupletizingReactiveExpressionServicesTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Client/Tests.Reaqtor.Client.Core/Reaqtor/TupletizingReactiveExpressionServicesTests.cs
+++ b/Reaqtor/Core/Client/Tests.Reaqtor.Client.Core/Reaqtor/TupletizingReactiveExpressionServicesTests.cs
@@ -1,0 +1,79 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT License.
+// See the LICENSE file in the project root for more information.
+
+//
+// Revision history:
+//
+// HvR - July 2026 - Created this file as part of factoring expression services out of the archived Remoting sample (see #158).
+//
+
+using System.Linq.Expressions;
+
+using Reaqtor;
+
+namespace Tests.Reaqtor;
+
+[TestClass]
+public class TupletizingReactiveExpressionServicesTests
+{
+    [TestMethod]
+    public void TupletizingReactiveExpressionServices_Lambda_Packed()
+    {
+        Expression<Func<int, int, int>> expr = (x, y) => x + y;
+
+        var tupletizer = new TupletizingReactiveExpressionServices(typeof(IReactiveClientProxy));
+        var normalized = tupletizer.Normalize(expr);
+
+        var lambda = (LambdaExpression)normalized;
+        Assert.HasCount(1, lambda.Parameters);
+        Assert.AreEqual(typeof(Tuple<int, int>), lambda.Parameters[0].Type);
+    }
+
+    [TestMethod]
+    public void TupletizingReactiveExpressionServices_UnboundInvocation_Tupletized()
+    {
+        var expr = Expression.Invoke(Expression.Parameter(typeof(Func<int, int, int>), "f"), Expression.Constant(1), Expression.Constant(2));
+
+        var tupletizer = new TupletizingReactiveExpressionServices(typeof(IReactiveClientProxy));
+        var normalized = tupletizer.Normalize(expr);
+
+        var invoke = (InvocationExpression)normalized;
+        Assert.HasCount(1, invoke.Arguments);
+        Assert.AreEqual(typeof(Tuple<int, int>), invoke.Arguments[0].Type);
+        Assert.AreEqual(typeof(Func<Tuple<int, int>, int>), invoke.Expression.Type);
+    }
+
+    [TestMethod]
+    public void TupletizingReactiveExpressionServices_AnonymousType_Tupletized()
+    {
+        Expression<Func<int, object>> expr = x => new { a = x, b = x + 1 };
+
+        var tupletizer = new TupletizingReactiveExpressionServices(typeof(IReactiveClientProxy));
+        var normalized = tupletizer.Normalize(expr);
+
+        // The anonymous type is replaced by a tuple, and the root lambda is packed.
+        var lambda = (LambdaExpression)normalized;
+        Assert.HasCount(1, lambda.Parameters);
+        Assert.AreEqual(typeof(Tuple<int>), lambda.Parameters[0].Type);
+
+        var finder = new AnonymousTypeFinder();
+        finder.Visit(normalized);
+        Assert.IsFalse(finder.Found);
+    }
+
+    private sealed class AnonymousTypeFinder : ExpressionVisitor
+    {
+        public bool Found { get; private set; }
+
+        public override Expression Visit(Expression node)
+        {
+            if (node != null && node.Type.Name.Contains("AnonymousType", StringComparison.Ordinal))
+            {
+                Found = true;
+            }
+
+            return base.Visit(node);
+        }
+    }
+}

--- a/Reaqtor/Core/Client/Tests.Reaqtor.Client.Core/Tests.Reaqtor.Client.Core.csproj
+++ b/Reaqtor/Core/Client/Tests.Reaqtor.Client.Core/Tests.Reaqtor.Client.Core.csproj
@@ -5,6 +5,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Compile Include="..\..\..\..\Common\TestUtilities\ExpressionAssert.cs" Link="ExpressionAssert.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\Reaqtor.Client.Core\Reaqtor.Client.Core.csproj" />
     <ProjectReference Include="..\Reaqtor.Client.Model\Reaqtor.Client.Model.csproj" />
   </ItemGroup>

--- a/Reaqtor/Core/Engine/Reaqtor.QueryEngine.ReificationFramework/Internal/DeploymentReactiveServiceContext.cs
+++ b/Reaqtor/Core/Engine/Reaqtor.QueryEngine.ReificationFramework/Internal/DeploymentReactiveServiceContext.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 

--- a/Reaqtor/Core/Engine/Reaqtor.QueryEngine.ReificationFramework/Internal/DeploymentReactiveServiceContext.cs
+++ b/Reaqtor/Core/Engine/Reaqtor.QueryEngine.ReificationFramework/Internal/DeploymentReactiveServiceContext.cs
@@ -1,8 +1,7 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 
-using System.Linq.CompilerServices;
 using System.Linq.Expressions;
 
 namespace Reaqtor.QueryEngine.ReificationFramework;
@@ -24,76 +23,7 @@ internal class DeploymentReactiveServiceContext : ReactiveServiceContext
         public override Expression Normalize(Expression expression)
         {
             var normalized = base.Normalize(expression);
-
-            var tupletized = new InvocationTupletizer().Visit(normalized);
-            if (tupletized is LambdaExpression lambda)
-            {
-                return ExpressionTupletizer.Pack(lambda);
-            }
-
-            return tupletized;
-        }
-    }
-
-    // TODO: Move InvocationTupletizer to a common location.
-
-    /// <summary>
-    /// Tupletizer for unbound parameter invocation sites.
-    /// </summary>
-    private class InvocationTupletizer : ScopedExpressionVisitor<ParameterExpression>
-    {
-        /// <summary>
-        /// Visits the children of the <see cref="System.Linq.Expressions.InvocationExpression" />.
-        /// </summary>
-        /// <param name="node">The expression to visit.</param>
-        /// <returns>
-        /// The modified expression, if it or any subexpression was modified; otherwise, returns the original expression.
-        /// </returns>
-        protected override Expression VisitInvocation(InvocationExpression node)
-        {
-            var expr = Visit(node.Expression);
-            var args = Visit(node.Arguments);
-
-            if (expr.NodeType == ExpressionType.Parameter)
-            {
-                var parameter = (ParameterExpression)expr;
-
-                // Turns f(x, y, z) into f((x, y, z)) when f is an unbound parameter, i.e. representing a known resource.
-                if (IsUnboundParameter(parameter))
-                {
-                    if (args.Count > 0)
-                    {
-                        var tuple = ExpressionTupletizer.Pack(args);
-                        var funcType = Expression.GetDelegateType(tuple.Type, node.Type);
-                        var function = Expression.Parameter(funcType, parameter.Name);
-                        return Expression.Invoke(function, tuple);
-                    }
-                }
-            }
-
-            return node.Update(expr, args);
-        }
-
-        /// <summary>
-        /// Gets the state associated with the specified parameter declaration.
-        /// </summary>
-        /// <param name="parameter">The parameter to obtain associated state for.</param>
-        /// <returns>State associated with the specified parameter declaration.</returns>
-        protected override ParameterExpression GetState(ParameterExpression parameter)
-        {
-            return parameter;
-        }
-
-        /// <summary>
-        /// Determines whether the specified parameter is unbound.
-        /// </summary>
-        /// <param name="parameter">The parameter to check.</param>
-        /// <returns>
-        ///   <c>true</c> if the specified parameter is unbound; otherwise, <c>false</c>.
-        /// </returns>
-        private bool IsUnboundParameter(ParameterExpression parameter)
-        {
-            return !TryLookup(parameter, out _);
+            return ExpressionTupletization.Tupletize(normalized);
         }
     }
 }

--- a/Reaqtor/Core/Engine/Tests.Reaqtor.QueryEngine/Utils/TupletizingContext.cs
+++ b/Reaqtor/Core/Engine/Tests.Reaqtor.QueryEngine/Utils/TupletizingContext.cs
@@ -29,72 +29,12 @@ internal class TupletizingClientContext : ReactiveClientContext
         public override Expression Normalize(Expression expression)
         {
             var normalized = base.Normalize(expression);
-            var tupletized = new InvocationTupletizer().Visit(normalized);
-            if (tupletized is LambdaExpression lambda)
-            {
-                tupletized = ExpressionTupletizer.Pack(lambda);
-            }
+            var tupletized = ExpressionTupletization.Tupletize(normalized);
 
             var sync = new AsyncToSyncRewriter(new Dictionary<Type, Type>()).Rewrite(tupletized);
 
             return sync;
         }
-    }
-
-    // TODO: Move InvocationTupletizer to a common location.
-
-    /// <summary>
-    /// Tupletizer for unbound parameter invocation sites.
-    /// </summary>
-    private class InvocationTupletizer : ScopedExpressionVisitor<ParameterExpression>
-    {
-        /// <summary>
-        /// Visits the children of the <see cref="T:System.Linq.Expressions.InvocationExpression" />.
-        /// </summary>
-        /// <param name="node">The expression to visit.</param>
-        /// <returns>
-        /// The modified expression, if it or any subexpression was modified; otherwise, returns the original expression.
-        /// </returns>
-        protected override Expression VisitInvocation(InvocationExpression node)
-        {
-            var expr = Visit(node.Expression);
-            var args = Visit(node.Arguments);
-
-            if (expr.NodeType == ExpressionType.Parameter)
-            {
-                var parameter = (ParameterExpression)expr;
-
-                // Turns f(x, y, z) into f((x, y, z)) when f is an unbound parameter, i.e. representing a known resource.
-                if (IsUnboundParameter(parameter))
-                {
-                    if (args.Count > 0)
-                    {
-                        var tuple = ExpressionTupletizer.Pack(args);
-                        var funcType = Expression.GetDelegateType(tuple.Type, node.Type);
-                        var function = Expression.Parameter(funcType, parameter.Name);
-                        return Expression.Invoke(function, tuple);
-                    }
-                }
-            }
-
-            return node.Update(expr, args);
-        }
-
-        /// <summary>
-        /// Gets the state associated with the specified parameter declaration.
-        /// </summary>
-        /// <param name="parameter">The parameter to obtain associated state for.</param>
-        /// <returns>State associated with the specified parameter declaration.</returns>
-        protected override ParameterExpression GetState(ParameterExpression parameter) => parameter;
-
-        /// <summary>
-        /// Determines whether the specified parameter is unbound.
-        /// </summary>
-        /// <param name="parameter">The parameter to check.</param>
-        /// <returns>
-        ///   <c>true</c> if the specified parameter is unbound; otherwise, <c>false</c>.
-        /// </returns>
-        private bool IsUnboundParameter(ParameterExpression parameter) => !TryLookup(parameter, out _);
     }
 }
 
@@ -216,69 +156,7 @@ public class TupletizingContext : ReactiveServiceContext
         public override Expression Normalize(Expression expression)
         {
             var normalized = base.Normalize(expression);
-            var tupletized = new InvocationTupletizer().Visit(normalized);
-            if (tupletized is LambdaExpression lambda)
-            {
-                tupletized = ExpressionTupletizer.Pack(lambda);
-            }
-
-            return tupletized;
+            return ExpressionTupletization.Tupletize(normalized);
         }
-    }
-
-    // TODO: Move InvocationTupletizer to a common location.
-
-    /// <summary>
-    /// Tupletizer for unbound parameter invocation sites.
-    /// </summary>
-    private class InvocationTupletizer : ScopedExpressionVisitor<ParameterExpression>
-    {
-        /// <summary>
-        /// Visits the children of the <see cref="T:System.Linq.Expressions.InvocationExpression" />.
-        /// </summary>
-        /// <param name="node">The expression to visit.</param>
-        /// <returns>
-        /// The modified expression, if it or any subexpression was modified; otherwise, returns the original expression.
-        /// </returns>
-        protected override Expression VisitInvocation(InvocationExpression node)
-        {
-            var expr = Visit(node.Expression);
-            var args = Visit(node.Arguments);
-
-            if (expr.NodeType == ExpressionType.Parameter)
-            {
-                var parameter = (ParameterExpression)expr;
-
-                // Turns f(x, y, z) into f((x, y, z)) when f is an unbound parameter, i.e. representing a known resource.
-                if (IsUnboundParameter(parameter))
-                {
-                    if (args.Count > 0)
-                    {
-                        var tuple = ExpressionTupletizer.Pack(args);
-                        var funcType = Expression.GetDelegateType(tuple.Type, node.Type);
-                        var function = Expression.Parameter(funcType, parameter.Name);
-                        return Expression.Invoke(function, tuple);
-                    }
-                }
-            }
-
-            return node.Update(expr, args);
-        }
-
-        /// <summary>
-        /// Gets the state associated with the specified parameter declaration.
-        /// </summary>
-        /// <param name="parameter">The parameter to obtain associated state for.</param>
-        /// <returns>State associated with the specified parameter declaration.</returns>
-        protected override ParameterExpression GetState(ParameterExpression parameter) => parameter;
-
-        /// <summary>
-        /// Determines whether the specified parameter is unbound.
-        /// </summary>
-        /// <param name="parameter">The parameter to check.</param>
-        /// <returns>
-        ///   <c>true</c> if the specified parameter is unbound; otherwise, <c>false</c>.
-        /// </returns>
-        private bool IsUnboundParameter(ParameterExpression parameter) => !TryLookup(parameter, out _);
     }
 }

--- a/Reaqtor/Core/Shared/Reaqtor.Shared.Core/Reaqtor/ExpressionTupletization.cs
+++ b/Reaqtor/Core/Shared/Reaqtor.Shared.Core/Reaqtor/ExpressionTupletization.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 
@@ -9,6 +9,7 @@
 // HvR - July 2026 - Factored out of the archived Remoting sample (see #158).
 //
 
+using System.Globalization;
 using System.Linq.CompilerServices;
 using System.Linq.Expressions;
 
@@ -28,6 +29,12 @@ public static class ExpressionTupletization
     /// </summary>
     /// <param name="expression">The expression to tupletize.</param>
     /// <returns>The tupletized expression.</returns>
+    /// <exception cref="NotSupportedException">
+    /// The root level lambda expression has a tuple-typed parameter. The packed form cannot represent
+    /// such lambdas unambiguously: after packing, the parameter's own tuple shape merges with the
+    /// packing tuple, and <see cref="Detupletize"/> on the receiving side cannot distinguish the two,
+    /// which would silently produce an incorrect expression.
+    /// </exception>
     public static Expression Tupletize(Expression expression)
     {
         ArgumentNullException.ThrowIfNull(expression);
@@ -36,6 +43,14 @@ public static class ExpressionTupletization
 
         if (result is LambdaExpression lambda)
         {
+            foreach (var parameter in lambda.Parameters)
+            {
+                if (ExpressionTupletizer.IsTuple(parameter.Type))
+                {
+                    throw new NotSupportedException(string.Format(CultureInfo.InvariantCulture, "Parameter '{0}' of the root level lambda expression has tuple type '{1}'. Lambda expressions with tuple-typed parameters cannot be represented unambiguously in the tupletized form and would not round-trip through Detupletize correctly.", parameter.Name, parameter.Type));
+                }
+            }
+
             result = ExpressionTupletizer.Pack(lambda);
         }
 
@@ -51,7 +66,10 @@ public static class ExpressionTupletization
     /// <returns>The detupletized expression.</returns>
     /// <remarks>
     /// A root level lambda expression is only unpacked when it has exactly one parameter whose type is
-    /// a tuple type; other lambda expressions pass through unchanged.
+    /// a tuple type; other lambda expressions pass through unchanged. Note that a unary lambda whose
+    /// parameter is genuinely tuple-typed is indistinguishable from the packed form and is therefore
+    /// always interpreted as packed; <see cref="Tupletize"/> refuses to produce such lambdas for the
+    /// same reason.
     /// </remarks>
     public static Expression Detupletize(Expression expression)
     {

--- a/Reaqtor/Core/Shared/Reaqtor.Shared.Core/Reaqtor/ExpressionTupletization.cs
+++ b/Reaqtor/Core/Shared/Reaqtor.Shared.Core/Reaqtor/ExpressionTupletization.cs
@@ -1,0 +1,178 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT License.
+// See the LICENSE file in the project root for more information.
+
+//
+// Revision history:
+//
+// ER - October 2013 - Created this code in the Remoting sample's client library.
+// HvR - July 2026 - Factored out of the archived Remoting sample (see #158).
+//
+
+using System.Linq.CompilerServices;
+using System.Linq.Expressions;
+
+namespace Reaqtor;
+
+/// <summary>
+/// Provides expression rewriting helpers to convert between n-ary invocations of unbound parameters
+/// (representing known resources) and their unary tupletized forms, as used on the wire between
+/// reactive service clients and services.
+/// </summary>
+public static class ExpressionTupletization
+{
+    /// <summary>
+    /// Converts all invocation expressions of unbound parameters and the root level lambda expression,
+    /// if any, to a form using unary lambdas by tupletizing the arguments, e.g. rewriting an invocation
+    /// <c>f(x, y)</c> to <c>f((x, y))</c>.
+    /// </summary>
+    /// <param name="expression">The expression to tupletize.</param>
+    /// <returns>The tupletized expression.</returns>
+    public static Expression Tupletize(Expression expression)
+    {
+        ArgumentNullException.ThrowIfNull(expression);
+
+        var result = new InvocationTupletizer().Visit(expression);
+
+        if (result is LambdaExpression lambda)
+        {
+            result = ExpressionTupletizer.Pack(lambda);
+        }
+
+        return result;
+    }
+
+    /// <summary>
+    /// Converts all invocation expressions of unbound parameters and the root level lambda expression,
+    /// if any, from a form using unary lambdas with tuple arguments to n-ary lambdas with the tuple
+    /// arguments unpacked, e.g. rewriting an invocation <c>f((x, y))</c> to <c>f(x, y)</c>.
+    /// </summary>
+    /// <param name="expression">The expression to detupletize.</param>
+    /// <returns>The detupletized expression.</returns>
+    /// <remarks>
+    /// A root level lambda expression is only unpacked when it has exactly one parameter whose type is
+    /// a tuple type; other lambda expressions pass through unchanged.
+    /// </remarks>
+    public static Expression Detupletize(Expression expression)
+    {
+        ArgumentNullException.ThrowIfNull(expression);
+
+        var result = new InvocationDetupletizer().Visit(expression);
+
+        if (result is LambdaExpression lambda && lambda.Parameters.Count == 1 && ExpressionTupletizer.IsTuple(lambda.Parameters[0].Type))
+        {
+            result = ExpressionTupletizer.Unpack(lambda);
+        }
+
+        return result;
+    }
+
+    /// <summary>
+    /// Tupletizer for unbound parameter invocation sites.
+    /// </summary>
+    private sealed class InvocationTupletizer : ScopedExpressionVisitor<ParameterExpression>
+    {
+        /// <summary>
+        /// Visits the children of the <see cref="InvocationExpression" />.
+        /// </summary>
+        /// <param name="node">The expression to visit.</param>
+        /// <returns>
+        /// The modified expression, if it or any subexpression was modified; otherwise, returns the original expression.
+        /// </returns>
+        protected override Expression VisitInvocation(InvocationExpression node)
+        {
+            var expr = Visit(node.Expression);
+            var args = Visit(node.Arguments);
+
+            if (expr.NodeType == ExpressionType.Parameter)
+            {
+                var parameter = (ParameterExpression)expr;
+
+                // Turns f(x, y, z) into f((x, y, z)) when f is an unbound parameter, i.e. representing a known resource.
+                if (IsUnboundParameter(parameter))
+                {
+                    if (args.Count > 0)
+                    {
+                        var tuple = ExpressionTupletizer.Pack(args);
+                        var funcType = Expression.GetDelegateType(tuple.Type, node.Type);
+                        var function = Expression.Parameter(funcType, parameter.Name);
+                        return Expression.Invoke(function, tuple);
+                    }
+                }
+            }
+
+            return node.Update(expr, args);
+        }
+
+        /// <summary>
+        /// Gets the state associated with the specified parameter declaration.
+        /// </summary>
+        /// <param name="parameter">The parameter to obtain associated state for.</param>
+        /// <returns>State associated with the specified parameter declaration.</returns>
+        protected override ParameterExpression GetState(ParameterExpression parameter) => parameter;
+
+        /// <summary>
+        /// Determines whether the specified parameter is unbound.
+        /// </summary>
+        /// <param name="parameter">The parameter to check.</param>
+        /// <returns>
+        ///   <c>true</c> if the specified parameter is unbound; otherwise, <c>false</c>.
+        /// </returns>
+        private bool IsUnboundParameter(ParameterExpression parameter) => !TryLookup(parameter, out _);
+    }
+
+    /// <summary>
+    /// Detupletizer for unbound parameter invocation sites.
+    /// </summary>
+    private sealed class InvocationDetupletizer : ScopedExpressionVisitor<ParameterExpression>
+    {
+        /// <summary>
+        /// Visits the children of the <see cref="InvocationExpression" />.
+        /// </summary>
+        /// <param name="node">The expression to visit.</param>
+        /// <returns>
+        /// The modified expression, if it or any subexpression was modified; otherwise, returns the original expression.
+        /// </returns>
+        protected override Expression VisitInvocation(InvocationExpression node)
+        {
+            // Turns f((x, y, z)) into f(x, y, z) when f is an unbound parameter, i.e. representing a known resource.
+            if (node.Expression is ParameterExpression function && IsUnboundParameter(function) && node.Arguments.Count == 1 && IsTupleNew(node.Arguments[0]))
+            {
+                var args = ExpressionTupletizer.Unpack(Visit(node.Arguments[0]));
+
+                var newFunctionType = Expression.GetDelegateType([.. args.Select(a => a.Type), node.Type]);
+
+                var newFunction = Expression.Parameter(newFunctionType, function.Name);
+
+                return Expression.Invoke(newFunction, args);
+            }
+
+            return base.VisitInvocation(node);
+        }
+
+        /// <summary>
+        /// Gets the state associated with the specified parameter declaration.
+        /// </summary>
+        /// <param name="parameter">The parameter to obtain associated state for.</param>
+        /// <returns>State associated with the specified parameter declaration.</returns>
+        protected override ParameterExpression GetState(ParameterExpression parameter) => parameter;
+
+        /// <summary>
+        /// Determines whether the specified parameter is unbound.
+        /// </summary>
+        /// <param name="parameter">The parameter to check.</param>
+        /// <returns>
+        ///   <c>true</c> if the specified parameter is unbound; otherwise, <c>false</c>.
+        /// </returns>
+        private bool IsUnboundParameter(ParameterExpression parameter) => !TryLookup(parameter, out _);
+
+        /// <summary>
+        /// Determines whether the specified expression is a tuple creation expression.
+        /// </summary>
+        /// <param name="expression">The expression to check.</param>
+        /// <returns>
+        ///   <c>true</c> if the specified expression creates a tuple; otherwise, <c>false</c>.
+        /// </returns>
+        private static bool IsTupleNew(Expression expression) => expression.NodeType == ExpressionType.New && ExpressionTupletizer.IsTuple(expression.Type);
+    }
+}

--- a/Reaqtor/Core/Shared/Tests.Reaqtor.Shared.Core/Reaqtor/ExpressionTupletizationTests.cs
+++ b/Reaqtor/Core/Shared/Tests.Reaqtor.Shared.Core/Reaqtor/ExpressionTupletizationTests.cs
@@ -161,21 +161,7 @@ public class ExpressionTupletizationTests
         AssertEqual(expr, rt);
     }
 
-    private static void AssertEqual(Expression x, Expression y)
-    {
-        Assert.IsTrue(new ExpressionEqualityComparer(() => new Comparator()).Equals(x, y));
-    }
+    private static void AssertEqual(Expression x, Expression y) => ExpressionAssert.AreEqual(x, y);
 
-    private static void AssertNotEqual(Expression x, Expression y)
-    {
-        Assert.IsFalse(new ExpressionEqualityComparer(() => new Comparator()).Equals(x, y));
-    }
-
-    private sealed class Comparator : ExpressionEqualityComparator
-    {
-        protected override bool EqualsGlobalParameter(ParameterExpression x, ParameterExpression y)
-        {
-            return x.Name == y.Name && Equals(x.Type, y.Type);
-        }
-    }
+    private static void AssertNotEqual(Expression x, Expression y) => ExpressionAssert.AreNotEqual(x, y);
 }

--- a/Reaqtor/Core/Shared/Tests.Reaqtor.Shared.Core/Reaqtor/ExpressionTupletizationTests.cs
+++ b/Reaqtor/Core/Shared/Tests.Reaqtor.Shared.Core/Reaqtor/ExpressionTupletizationTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information.
 
@@ -125,6 +125,16 @@ public class ExpressionTupletizationTests
         var actual = ExpressionTupletization.Detupletize(expr);
 
         AssertEqual(expr, actual);
+    }
+
+    [TestMethod]
+    public void ExpressionTupletization_Tupletize_RootLambda_TupleParameter_Throws()
+    {
+        Expression<Func<Tuple<int, int>, int, int>> binary = (t, y) => t.Item1 * 100 + y;
+        Assert.ThrowsExactly<NotSupportedException>(() => ExpressionTupletization.Tupletize(binary));
+
+        Expression<Func<Tuple<int, int>, int>> unary = t => t.Item1 + t.Item2;
+        Assert.ThrowsExactly<NotSupportedException>(() => ExpressionTupletization.Tupletize(unary));
     }
 
     [TestMethod]

--- a/Reaqtor/Core/Shared/Tests.Reaqtor.Shared.Core/Reaqtor/ExpressionTupletizationTests.cs
+++ b/Reaqtor/Core/Shared/Tests.Reaqtor.Shared.Core/Reaqtor/ExpressionTupletizationTests.cs
@@ -1,0 +1,171 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT License.
+// See the LICENSE file in the project root for more information.
+
+using System.Linq.CompilerServices;
+using System.Linq.Expressions;
+using System.Reflection;
+
+using Reaqtor;
+
+namespace Tests.Reaqtor.Shared.Core.Reaqtor;
+
+[TestClass]
+public class ExpressionTupletizationTests
+{
+    [TestMethod]
+    public void ExpressionTupletization_ArgumentChecking()
+    {
+        Assert.ThrowsExactly<ArgumentNullException>(() => ExpressionTupletization.Tupletize(null));
+        Assert.ThrowsExactly<ArgumentNullException>(() => ExpressionTupletization.Detupletize(null));
+    }
+
+    [TestMethod]
+    public void ExpressionTupletization_Tupletize_UnboundInvocation()
+    {
+        var expr = Expression.Invoke(Expression.Parameter(typeof(Func<int, int, int>), "f"), Expression.Constant(1), Expression.Constant(2));
+
+        var ctor = (ConstructorInfo)ReflectionHelpers.InfoOf(() => new Tuple<int, int>(default, default));
+        var expected = Expression.Invoke(
+            Expression.Parameter(typeof(Func<Tuple<int, int>, int>), "f"),
+            Expression.New(ctor, [Expression.Constant(1), Expression.Constant(2)], typeof(Tuple<int, int>).GetProperty(nameof(Tuple<,>.Item1)), typeof(Tuple<int, int>).GetProperty(nameof(Tuple<,>.Item2))));
+
+        var actual = ExpressionTupletization.Tupletize(expr);
+
+        AssertEqual(expected, actual);
+    }
+
+    [TestMethod]
+    public void ExpressionTupletization_Tupletize_ZeroArgumentInvocation_Unchanged()
+    {
+        var expr = Expression.Invoke(Expression.Parameter(typeof(Func<int>), "f"));
+
+        var actual = ExpressionTupletization.Tupletize(expr);
+
+        AssertEqual(expr, actual);
+    }
+
+    [TestMethod]
+    public void ExpressionTupletization_Tupletize_BoundInvocation_NotTupletized()
+    {
+        Expression<Func<Func<int, int, int>, int>> expr = f => f(1, 2);
+
+        var actual = ExpressionTupletization.Tupletize(expr);
+
+        // The root lambda gets packed, but the invocation of the bound parameter f stays n-ary.
+        var lambda = (LambdaExpression)actual;
+        Assert.AreEqual(typeof(Tuple<Func<int, int, int>>), lambda.Parameters[0].Type);
+
+        var invoke = (InvocationExpression)lambda.Body;
+        Assert.HasCount(2, invoke.Arguments);
+        Assert.AreEqual(typeof(Func<int, int, int>), invoke.Expression.Type);
+    }
+
+    [TestMethod]
+    public void ExpressionTupletization_Tupletize_RootLambda_Packed()
+    {
+        Expression<Func<int, int, int>> expr = (x, y) => x + y;
+
+        var actual = ExpressionTupletization.Tupletize(expr);
+
+        var lambda = (LambdaExpression)actual;
+        Assert.HasCount(1, lambda.Parameters);
+        Assert.AreEqual(typeof(Tuple<int, int>), lambda.Parameters[0].Type);
+    }
+
+    [TestMethod]
+    public void ExpressionTupletization_Detupletize_UnboundInvocation()
+    {
+        var expected = Expression.Invoke(Expression.Parameter(typeof(Func<int, int>), "f"), Expression.Constant(42));
+
+        var ctor = (ConstructorInfo)ReflectionHelpers.InfoOf(() => new Tuple<int>(default));
+        var expr = Expression.Invoke(Expression.Parameter(typeof(Func<Tuple<int>, int>), "f"), Expression.New(ctor, Expression.Constant(42)));
+
+        var actual = ExpressionTupletization.Detupletize(expr);
+
+        AssertEqual(expected, actual);
+    }
+
+    [TestMethod]
+    public void ExpressionTupletization_Detupletize_NonTupleArgument_Unchanged()
+    {
+        var expr = Expression.Invoke(Expression.Parameter(typeof(Func<List<int>, int>), "f"), Expression.New(typeof(List<int>)));
+
+        var actual = ExpressionTupletization.Detupletize(expr);
+
+        AssertEqual(expr, actual);
+    }
+
+    [TestMethod]
+    public void ExpressionTupletization_Detupletize_RootLambda_TupleParameter_Unpacked()
+    {
+        Expression<Func<int, int>> expected = x => x;
+        Expression<Func<Tuple<int>, int>> expr = t => t.Item1;
+
+        var actual = ExpressionTupletization.Detupletize(expr);
+
+        AssertEqual(expected, actual);
+    }
+
+    [TestMethod]
+    public void ExpressionTupletization_Detupletize_RootLambda_NonTupleParameter_Unchanged()
+    {
+        Expression<Func<int, int>> expr = x => x;
+
+        var actual = ExpressionTupletization.Detupletize(expr);
+
+        AssertEqual(expr, actual);
+    }
+
+    [TestMethod]
+    public void ExpressionTupletization_Detupletize_RootLambda_NAry_Unchanged()
+    {
+        Expression<Func<int, int, int>> expr = (x, y) => x + y;
+
+        var actual = ExpressionTupletization.Detupletize(expr);
+
+        AssertEqual(expr, actual);
+    }
+
+    [TestMethod]
+    public void ExpressionTupletization_Roundtrip_Lambda()
+    {
+        Expression<Func<int, int>> expr = x => x;
+
+        var tupletized = ExpressionTupletization.Tupletize(expr);
+        AssertNotEqual(expr, tupletized);
+
+        var rt = ExpressionTupletization.Detupletize(tupletized);
+        AssertEqual(expr, rt);
+    }
+
+    [TestMethod]
+    public void ExpressionTupletization_Roundtrip_Invocation()
+    {
+        var expr = Expression.Invoke(Expression.Parameter(typeof(Func<int, int>), "f"), Expression.Constant(42));
+
+        var tupletized = ExpressionTupletization.Tupletize(expr);
+        AssertNotEqual(expr, tupletized);
+
+        var rt = ExpressionTupletization.Detupletize(tupletized);
+        AssertEqual(expr, rt);
+    }
+
+    private static void AssertEqual(Expression x, Expression y)
+    {
+        Assert.IsTrue(new ExpressionEqualityComparer(() => new Comparator()).Equals(x, y));
+    }
+
+    private static void AssertNotEqual(Expression x, Expression y)
+    {
+        Assert.IsFalse(new ExpressionEqualityComparer(() => new Comparator()).Equals(x, y));
+    }
+
+    private sealed class Comparator : ExpressionEqualityComparator
+    {
+        protected override bool EqualsGlobalParameter(ParameterExpression x, ParameterExpression y)
+        {
+            return x.Name == y.Name && Equals(x.Type, y.Type);
+        }
+    }
+}

--- a/Reaqtor/Core/Shared/Tests.Reaqtor.Shared.Core/Tests.Reaqtor.Shared.Core.csproj
+++ b/Reaqtor/Core/Shared/Tests.Reaqtor.Shared.Core/Tests.Reaqtor.Shared.Core.csproj
@@ -5,6 +5,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Compile Include="..\..\..\..\Common\TestUtilities\ExpressionAssert.cs" Link="ExpressionAssert.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\Reaqtor.Shared.Core\Reaqtor.Shared.Core.csproj" />
   </ItemGroup>
 

--- a/Reaqtor/Core/Testing/Reaqtor.ReificationFramework/Client/ReificationClientContext.cs
+++ b/Reaqtor/Core/Testing/Reaqtor.ReificationFramework/Client/ReificationClientContext.cs
@@ -17,6 +17,6 @@ public class ReificationClientContext : ReactiveClientContext
     public ReificationClientContext(IReactiveExpressionServices expressionServices, IReactiveServiceProvider serviceProvider)
         : base(expressionServices, serviceProvider)
     {
-        // NB: base used to accept new TupletizingExpressionServices(typeof(IReactiveClientProxy)), which has dependencies on DataModel etc.
+        // NB: A typical choice for the expression services is new TupletizingReactiveExpressionServices(typeof(IReactiveClientProxy)).
     }
 }

--- a/Reaqtor/Core/Testing/Reaqtor.ReificationFramework/ReificationTestBase.cs
+++ b/Reaqtor/Core/Testing/Reaqtor.ReificationFramework/ReificationTestBase.cs
@@ -31,5 +31,5 @@ public abstract class ReificationTestBase
     /// Gets the expression services used to construct a <see cref="ReificationClientContext"/>.
     /// </summary>
     /// <returns>An expression services implementation.</returns>
-    protected abstract IReactiveExpressionServices GetExpressionServices(); // E.g. "return new TupletizingExpressionServices(typeof(IReactiveClientProxy))".
+    protected virtual IReactiveExpressionServices GetExpressionServices() => new TupletizingReactiveExpressionServices(typeof(IReactiveClientProxy));
 }

--- a/archive/README.md
+++ b/archive/README.md
@@ -21,6 +21,22 @@ intra-archive references and the retained `.sln` files remain internally consist
 | `Nuqleon/Pearls/LINQ/BinaryExpressionSerialization/` | Prototype binary expression serializer whose default object serializer is built on **`BinaryFormatter`**, which is removed at runtime on .NET 9+. Leaf pearl; its raison d'être cannot function on modern .NET. |
 | `Common/TestUtilities/AssertEx.Legacy.cs` | The callback-based `AssertEx.ThrowsException{Async}` helpers, superseded in the live tree by MSTest 4's `Assert.ThrowsExactly{Async}` (which returns the caught exception). Kept because archived test projects still call them. |
 
+## Code factored back out of the archive
+
+Some transport-agnostic building blocks that lived in the archived Remoting sample have since
+been factored back into the shipped libraries (see #158):
+
+- The invocation tupletization/detupletization machinery from
+  `Reaqtor.Remoting.Client.Library/ExpressionServices/{Tupletizing,Detupletizing}ExpressionServices.cs`
+  now lives in `Reaqtor.ExpressionTupletization` (in `Reaqtor.Shared.Core`).
+- The allow-list based `ExpressionServices` family now lives in `Reaqtor.Client.Core` as
+  `CheckedReactiveExpressionServices`, `TupletizingReactiveExpressionServices`, and
+  `DetupletizingReactiveExpressionServices` (with the JSON allow list moved from Newtonsoft.Json
+  to `System.Text.Json.Nodes`; consumers can bless additional members by overriding
+  `CheckedReactiveExpressionServices.IsAllowedMember`).
+
+The archived copies remain for reference but should not be used as a source for new code.
+
 ## Resurrecting a project
 
 To revive any of these on modern .NET, the relevant Framework dependency must be replaced first


### PR DESCRIPTION
Factors the transport-agnostic expression services out of the archived `Reaqtor/Samples/Remoting` client library into the shipped libraries, per the plan posted on #158 (all design decisions confirmed there on 2026-07-02).

## What moved where

- **`Reaqtor.Shared.Core`** gains `Reaqtor.ExpressionTupletization`, a static helper with `Tupletize`/`Detupletize` that hosts the invocation (de)tupletization visitors previously duplicated five times across the tree ("TODO: Move InvocationTupletizer to a common location").
- **`Reaqtor.Client.Core`** gains the policy types:
  - `CheckedReactiveExpressionServices` — allow-list enforcement with a `protected virtual bool IsAllowedMember(MemberInfo)` extension hook, plus anonymous-type tupletization in `Normalize`.
  - `TupletizingReactiveExpressionServices` (derives from Checked) and `DetupletizingReactiveExpressionServices` (derives from `ReactiveExpressionServices` — detupletization is a receiving-side concern, so allow-list scanning deliberately does not apply; documented in remarks).
  - `Internal/DataModelHelpers` (cache over `DataType.TryCheck`).

## Deliberate behavior deltas vs the archived copies

- **JSON allow list**: `System.Text.Json.Nodes` (`JsonNode`/`JsonObject`/`JsonArray`/`JsonValue`, in-box on net10.0) replaces Newtonsoft's `JObject`/`JProperty`. `JsonSerializer`/`JsonDocument`/`JsonElement` are deliberately not blessed. Consumers that need JSON.NET can re-add it via `IsAllowedMember`.
- **`Detupletize` root-lambda guard**: only unary lambdas with a tuple-typed parameter are unpacked; other root lambdas pass through instead of `ExpressionTupletizer.Unpack` throwing. Resolves the archived "TODO: Check if the lambda parameter is tuple". Covered by tests.
- **`IsTuple` unified** on `ExpressionTupletizer.IsTuple` (the QueryEngine test copies used a weaker `FullName.StartsWith("System.Tuple`")` check).

## Empirical findings (documented in tests, no behavior change)

- A disallowed member over a bound parameter surfaces as `System.Linq.CompilerServices.UnboundParameterException` (an `InvalidOperationException` subclass) from local evaluation.
- The archived `[Utc]Now` exclusions in the member allow list are shadowed by the data-model type blessing: `DateTime`/`DateTimeOffset` are valid data model types, so `IsAllowedMember` blesses all their members before the declarative table is consulted — `DateTime.Now` is preserved, not folded. This matches the archived behavior exactly (same check order); it is now called out in the XML remarks and pinned by a test. If the exclusion should win, that's a follow-up policy decision.

## Dedupe

Replaced the live verbatim `InvocationTupletizer` copies in:
- `Tests.Reaqtor.QueryEngine/Utils/TupletizingContext.cs` (both nested copies)
- `Reaqtor.QueryEngine.ReificationFramework/Internal/DeploymentReactiveServiceContext.cs`

`ReificationTestBase.GetExpressionServices()` goes abstract → virtual (source- and binary-compatible; zero live derivers), defaulting to `new TupletizingReactiveExpressionServices(typeof(IReactiveClientProxy))` — restoring the pre-archive default the old comment referenced.

**Follow-up dedupe candidates (not touched here):** `CheckpointingQueryEngine.ExpressionHelpers.cs` (engine-side, behavior-sensitive), `Reaqtor.Shebang.Service/Engine/LocalReactiveServiceProvider.cs`, `Reaqtor.IoT/Client/ReactorContext.cs`, OperatorLocalStorage pearl `Engine/QueryEngineContext.cs`.

## Notes for reviewers

- `Reaqtor.Client.Core` now references `Nuqleon.DataModel` + `Nuqleon.DataModel.CompilerServices`, widening its package closure (pulls Nuqleon.Memory, Bonsai). The archived client library carried the same dependency.
- The `DecompileTuple` TODO in `ReactiveExpressionServices.Normalize` is intentionally untouched (constant-inlining concern, not invocation tupletization).
- After this lands, `spike/grpc-remoting` (#157) can delete its verbatim `ExpressionServices` copies and re-add JSON.NET blessing via a thin `IsAllowedMember` override.

## Tests

- 12 new tests for `ExpressionTupletization` (Shared.Core), including the roundtrip identity and the root-lambda guard.
- 17 new tests for the three service types (Client.Core): allow-list positives (data model, DateTimeOffset arithmetic, STJ nodes), fold-to-constant, throw-on-unbound, and the `IsAllowedMember` hook.
- Full `Tests.Reaqtor.QueryEngine` suite green after the dedupe (492 passed / 1 pre-existing skip).

Closes #158

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AXwFDPoDt2ouRXrcKqXVJA
