### PR TITLE
Make the archived .NET Framework projects open, compile, and test again

### DIFF
--- a/archive/Directory.Build.props
+++ b/archive/Directory.Build.props
@@ -1,14 +1,113 @@
 <Project>
 
   <!--
-    The archive/ tree is reference-only (.NET Framework code, excluded from every live solution) and is
-    deliberately NOT subject to the .NET 10 modernizations applied to the live tree. Inherit the repo
-    defaults, then opt out of implicit usings so the archived sources compile unchanged.
+    The archive/ tree is reference-only .NET Framework code (net472 and netstandard2.0/2.1), excluded
+    from every live solution and not built by CI. It is deliberately NOT subject to the .NET 10
+    modernizations applied to the live tree. Inherit the repo defaults, then relax the strict-build
+    regime (below) so the frozen sources open and compile quietly on the .NET 10 SDK: the Roslyn
+    analyzers are turned OFF for this subtree (RunAnalyzers=false, see below) and warnings never fail
+    the build, so opening these solutions in Visual Studio surfaces no analyzer noise on code nobody
+    will refactor.
   -->
   <Import Project="../Directory.Build.props" />
 
   <PropertyGroup>
+    <!-- Archived sources predate implicit usings (the root enables them). -->
     <ImplicitUsings>disable</ImplicitUsings>
+
+    <!--
+      The archive is reference-only, frozen .NET Framework code that nobody is going to refactor. Opening
+      these solutions in Visual Studio must not bury the developer under analyzer warnings/suggestions, and
+      building must not fail on them either (issue #169). RunAnalyzers=false turns the whole Roslyn analyzer
+      pass off for the archive subtree - both the CA* quality analyzers and the IDE* code-style analyzers,
+      in the IDE's live analysis AND at build - so the archived projects open and compile quietly.
+      (EnforceCodeStyleInBuild only governs the command-line build, not VS live analysis, so it cannot
+      achieve this on its own.) Warnings-as-errors stays off too, so any residual compiler (CS*) warning
+      remains a warning rather than failing the reference build.
+    -->
+    <RunAnalyzers>false</RunAnalyzers>
+    <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
+    <CodeAnalysisTreatWarningsAsErrors>false</CodeAnalysisTreatWarningsAsErrors>
+
+    <!--
+      The root turns on XML documentation generation for shipping-style libraries, which makes the C#
+      compiler emit the CS1591 "missing XML comment" family (thousands of them - the Remoting sample code
+      is undocumented) as ordinary compiler warnings that RunAnalyzers cannot suppress. The archive ships
+      nothing and needs no doc files, so turn generation off: that removes the entire CS1591 / CS157x /
+      CS158x doc-warning flood from both the build and the Visual Studio Error List.
+    -->
+    <GenerateDocumentationFile>false</GenerateDocumentationFile>
   </PropertyGroup>
+
+  <!--
+    The root Directory.Build.props adds version-less Microsoft.SourceLink.GitHub and
+    Nerdbank.GitVersioning to every project, bound to the root's CENTRAL package versions. The archive
+    runs with Central Package Management OFF (archive/Directory.Packages.props), so those version-less
+    references have nothing to bind to and restore fails. The archive is never packed, shipped, or
+    versioned, so both build-time packages are dead weight here - remove them. (Removing NBGV also stops
+    it stamping assembly-version attributes that would clash with the retained legacy AssemblyInfo.cs.)
+    Both are PrivateAssets=All, so removal is invisible to any consumer.
+  -->
+  <ItemGroup>
+    <PackageReference Remove="Microsoft.SourceLink.GitHub" />
+    <PackageReference Remove="Nerdbank.GitVersioning" />
+  </ItemGroup>
+
+  <!--
+    Compile the net472 / netstandard targets on the .NET 10 SDK without Visual Studio or standalone
+    targeting packs installed (otherwise MSB3644 "reference assemblies not found"). CPM is OFF here, so
+    an inline Version is required. The meta-package self-conditions on the .NETFramework target framework
+    identifier, so it is a no-op for the net10.0 Pearls and for the non-net472 passes of the
+    multi-targeting Museum libraries.
+  -->
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.3" PrivateAssets="all" />
+  </ItemGroup>
+
+  <!--
+    The archived libraries retain a legacy Properties\AssemblyInfo.cs whose sole content is
+    [assembly: CLSCompliant(true)]. The root synthesizes that same AllowMultiple=false attribute
+    (WriteCodeFragment) for every non-test/perf/playground project, so both copies land in the
+    compilation => CS0579 "Duplicate 'CLSCompliant' attribute", a hard error that TreatWarningsAsErrors
+    =false does not rescue. Drop the synthesized copy; the archived source keeps its own.
+  -->
+  <ItemGroup>
+    <AssemblyAttribute Remove="System.CLSCompliantAttribute" />
+  </ItemGroup>
+
+  <!--
+    Test projects. The frozen archived tests call MSTest APIs removed in MSTest 4 (Assert.ThrowsException
+    {Async}, [ExpectedException], the (message, params) assert overloads), so pin the whole MSTest package
+    set to the last 3.x that still carries them. Keep the repo's Microsoft.Testing.Platform runner
+    (inherited EnableMSTestRunner=true / OutputType=Exe from the root) so the archived tests are discovered
+    and run in Visual Studio's Test Explorer and via `dotnet test` exactly like the live tree - just on
+    MSTest 3.7.3 (which brings its own aligned MTP) rather than 4.
+
+    Drop the root's Microsoft.Testing.Extensions.* packages: the root pins them to the MTP 2.x line MSTest
+    4 uses, which is binary-incompatible with 3.7.3's MTP 1.x (a mismatch throws an IDataConsumer
+    TypeLoadException at run time). The coverage/trx/hangdump extensions are optional and are not needed to
+    discover or run the tests; the archive is reference-only and out of CI, so we leave them out rather
+    than re-pin an aligned 1.x set.
+  -->
+  <ItemGroup Condition="'$(IsTestProject)' == 'true'">
+    <PackageReference Update="MSTest.TestFramework" Version="3.7.3" />
+    <PackageReference Update="MSTest.TestAdapter" Version="3.7.3" />
+    <PackageReference Remove="Microsoft.Testing.Extensions.CodeCoverage" />
+    <PackageReference Remove="Microsoft.Testing.Extensions.TrxReport" />
+    <PackageReference Remove="Microsoft.Testing.Extensions.HangDump" />
+  </ItemGroup>
+
+  <!--
+    Archived test projects call only the legacy callback-style AssertEx.ThrowsException{Async}<T>, which
+    lives in archive/Common/TestUtilities/AssertEx.Legacy.cs (a partial of AssertEx with self-contained
+    explicit usings). The root injects the modernized Common/TestUtilities/AssertEx.cs into every Tests.*
+    project, but that file uses a file-scoped namespace and relies on implicit usings, so it will not
+    compile under this subtree's ImplicitUsings=disable. Drop the modernized file here and compile the
+    legacy shim instead (same partial class, disjoint members => merges cleanly).
+  -->
+  <ItemGroup Condition="'$(IsTestProject)' == 'true'">
+    <Compile Remove="$(MSBuildThisFileDirectory)..\Common\TestUtilities\AssertEx.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Common\TestUtilities\AssertEx.Legacy.cs" Link="AssertEx.Legacy.cs" />
+  </ItemGroup>
 
 </Project>

--- a/archive/Nuqleon/Core/LINQ/Tests.VisualBasic/Tests.VisualBasic.vbproj
+++ b/archive/Nuqleon/Core/LINQ/Tests.VisualBasic/Tests.VisualBasic.vbproj
@@ -1,0 +1,21 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <!-- net472 shell over the live net10.0 Nuqleon/Core/LINQ/Tests.VisualBasic VB fixture, so the archived
+         net472 Tests.Nuqleon.Linq.Expressions.Serialization can reference it: the live copy is net10.0 and
+         unpublished, so it can be neither referenced nor swapped for a NuGet package. The single .vb source
+         is LINKED from the live project (like the archive's other reused live sources - Marvin.cs and the
+         Glitching *.Declarative.cs) so it stays one source of truth rather than a diverging copy. -->
+    <TargetFramework>net472</TargetFramework>
+    <IsTestProject>false</IsTestProject>
+    <!-- VB support library of test fixtures (not a test runner). Override the Exe output type that
+         Directory.Build.props applies by name to 'Tests.*' projects at evaluation time. -->
+    <OutputType>Library</OutputType>
+    <LangVersion>16</LangVersion>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="..\..\..\..\..\Nuqleon\Core\LINQ\Tests.VisualBasic\VisualBasicModule.vb" Link="VisualBasicModule.vb" />
+  </ItemGroup>
+
+</Project>

--- a/archive/Nuqleon/Museum/Nuqleon.Linq.Expressions.Serialization/Nuqleon.Linq.Expressions.Serialization.csproj
+++ b/archive/Nuqleon/Museum/Nuqleon.Linq.Expressions.Serialization/Nuqleon.Linq.Expressions.Serialization.csproj
@@ -8,8 +8,8 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Nuqleon.Serialization\Nuqleon.Serialization.csproj" />
-    <ProjectReference Include="..\..\Core\LINQ\Nuqleon.Linq.CompilerServices\Nuqleon.Linq.CompilerServices.csproj" />
-    <ProjectReference Include="..\..\Core\JSON\Nuqleon.Json\Nuqleon.Json.csproj" />
+    <PackageReference Include="Nuqleon.Linq.CompilerServices" Version="1.0.0-beta.24" />
+    <PackageReference Include="Nuqleon.Json" Version="1.0.0-beta.24" />
   </ItemGroup>
 
 </Project>

--- a/archive/Nuqleon/Museum/Nuqleon.Museum.slnx
+++ b/archive/Nuqleon/Museum/Nuqleon.Museum.slnx
@@ -1,14 +1,6 @@
 <Solution>
   <Folder Name="/deps/" />
-  <Folder Name="/deps/BCL/">
-    <Project Path="../Core/BCL/Nuqleon.Memory/Nuqleon.Memory.csproj" />
-    <Project Path="../Core/BCL/Nuqleon.Time/Nuqleon.Time.csproj" />
-  </Folder>
-  <Folder Name="/deps/JSON/">
-    <Project Path="../Core/JSON/Nuqleon.Json/Nuqleon.Json.csproj" />
-  </Folder>
   <Folder Name="/deps/LINQ/">
-    <Project Path="../Core/LINQ/Nuqleon.Linq.CompilerServices/Nuqleon.Linq.CompilerServices.csproj" />
     <Project Path="../Core/LINQ/Tests.VisualBasic/Tests.VisualBasic.vbproj" />
   </Folder>
   <Folder Name="/src/">

--- a/archive/Nuqleon/Museum/Nuqleon.Serialization/Nuqleon.Serialization.csproj
+++ b/archive/Nuqleon/Museum/Nuqleon.Serialization/Nuqleon.Serialization.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\Core\LINQ\Nuqleon.Linq.CompilerServices\Nuqleon.Linq.CompilerServices.csproj" />
+    <PackageReference Include="Nuqleon.Linq.CompilerServices" Version="1.0.0-beta.24" />
   </ItemGroup>
 
 </Project>

--- a/archive/Nuqleon/Museum/Nuqleon.StringSegment/Nuqleon.StringSegment.csproj
+++ b/archive/Nuqleon/Museum/Nuqleon.StringSegment/Nuqleon.StringSegment.csproj
@@ -6,11 +6,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\Core\BCL\Nuqleon.Memory\Nuqleon.Memory.csproj" />
+    <PackageReference Include="Nuqleon.Memory" Version="1.0.0-beta.24" />
   </ItemGroup>
 
   <ItemGroup>
-    <Compile Include="..\..\..\Common\Marvin.cs" Link="System\Marvin.cs" />
+    <Compile Include="..\..\..\..\Common\Marvin.cs" Link="System\Marvin.cs" />
   </ItemGroup>
 
 </Project>

--- a/archive/Nuqleon/Pearls/BCL/ProjectJohnnie/Perf.Nuqleon.Memory.Diagnostics/Perf.Nuqleon.Memory.Diagnostics.csproj
+++ b/archive/Nuqleon/Pearls/BCL/ProjectJohnnie/Perf.Nuqleon.Memory.Diagnostics/Perf.Nuqleon.Memory.Diagnostics.csproj
@@ -4,6 +4,6 @@
     <OutputType>Exe</OutputType>
   </PropertyGroup>
   <ItemGroup>
-    <ProjectReference Include="..\Nuqleon.Memory.Diagnostics\Nuqleon.Memory.Diagnostics.csproj" />
+    <PackageReference Include="Nuqleon.Memory.Diagnostics" Version="1.0.0-beta.24" />
   </ItemGroup>
 </Project>

--- a/archive/Nuqleon/Pearls/BCL/ProjectJohnnie/ProjectJohnnie/Nuqleon.Memory.Diagnostics.Playground.csproj
+++ b/archive/Nuqleon/Pearls/BCL/ProjectJohnnie/ProjectJohnnie/Nuqleon.Memory.Diagnostics.Playground.csproj
@@ -4,7 +4,7 @@
     <OutputType>Exe</OutputType>
   </PropertyGroup>
   <ItemGroup>
-    <ProjectReference Include="..\Nuqleon.Memory.Diagnostics\Nuqleon.Memory.Diagnostics.csproj" />
+    <PackageReference Include="Nuqleon.Memory.Diagnostics" Version="1.0.0-beta.24" />
   </ItemGroup>
   <ItemGroup>
     <None Update="Utils\TupleEqualityComparers.Generated.tt">

--- a/archive/Nuqleon/Pearls/LINQ/BinaryExpressionSerialization/BinaryExpressionSerialization.slnx
+++ b/archive/Nuqleon/Pearls/LINQ/BinaryExpressionSerialization/BinaryExpressionSerialization.slnx
@@ -1,13 +1,4 @@
 <Solution>
-  <Folder Name="/deps/">
-    <Project Path="../../../Core/BCL/Nuqleon.Memory/Nuqleon.Memory.csproj" />
-    <Project Path="../../../Core/BCL/Nuqleon.Reflection.Virtualization/Nuqleon.Reflection.Virtualization.csproj" />
-    <Project Path="../../../Core/BCL/Nuqleon.Time/Nuqleon.Time.csproj" />
-    <Project Path="../../../Core/JSON/Nuqleon.Json/Nuqleon.Json.csproj" />
-    <Project Path="../../../Core/LINQ/Nuqleon.Linq.CompilerServices/Nuqleon.Linq.CompilerServices.csproj" />
-    <Project Path="../../../Core/LINQ/Nuqleon.Linq.Expressions.Bonsai.Serialization/Nuqleon.Linq.Expressions.Bonsai.Serialization.csproj" />
-    <Project Path="../../../Core/LINQ/Nuqleon.Linq.Expressions.Bonsai/Nuqleon.Linq.Expressions.Bonsai.csproj" />
-  </Folder>
   <Folder Name="/src/">
     <Project Path="BinaryExpressionSerialization/Nuqleon.Pearls.Linq.Expressions.Bonsai.Serialization.Binary.Perf.csproj" />
     <Project Path="Library/Nuqleon.Pearls.Linq.Expressions.Bonsai.Serialization.Binary.csproj" />

--- a/archive/Nuqleon/Pearls/LINQ/BinaryExpressionSerialization/BinaryExpressionSerialization/Nuqleon.Pearls.Linq.Expressions.Bonsai.Serialization.Binary.Perf.csproj
+++ b/archive/Nuqleon/Pearls/LINQ/BinaryExpressionSerialization/BinaryExpressionSerialization/Nuqleon.Pearls.Linq.Expressions.Bonsai.Serialization.Binary.Perf.csproj
@@ -1,11 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net10.0</TargetFramework>
+    <!-- Benchmarks the BinaryFormatter-based prototype serializer; net472 keeps BinaryFormatter
+         functional (it is removed at runtime on .NET 9+). -->
+    <TargetFramework>net472</TargetFramework>
     <IsPackable>false</IsPackable>
     <OutputType>Exe</OutputType>
-    <!-- Benchmarks the BinaryFormatter-based prototype serializer, obsolete on .NET 10. -->
-    <NoWarn>$(NoWarn);SYSLIB0011</NoWarn>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -31,8 +31,8 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Library\Nuqleon.Pearls.Linq.Expressions.Bonsai.Serialization.Binary.csproj" />
-    <ProjectReference Include="..\..\..\..\Core\JSON\Nuqleon.Json\Nuqleon.Json.csproj" />
-    <ProjectReference Include="..\..\..\..\Core\LINQ\Nuqleon.Linq.Expressions.Bonsai.Serialization\Nuqleon.Linq.Expressions.Bonsai.Serialization.csproj" />
+    <PackageReference Include="Nuqleon.Json" Version="1.0.0-beta.24" />
+    <PackageReference Include="Nuqleon.Linq.Expressions.Bonsai.Serialization" Version="1.0.0-beta.24" />
   </ItemGroup>
 
 </Project>

--- a/archive/Nuqleon/Pearls/LINQ/BinaryExpressionSerialization/Library/Nuqleon.Pearls.Linq.Expressions.Bonsai.Serialization.Binary.csproj
+++ b/archive/Nuqleon/Pearls/LINQ/BinaryExpressionSerialization/Library/Nuqleon.Pearls.Linq.Expressions.Bonsai.Serialization.Binary.csproj
@@ -1,19 +1,21 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net10.0</TargetFramework>
+    <!-- Prototype whose default object serializer is BinaryFormatter, which is removed at runtime on
+         .NET 9+. Kept at net472, where BinaryFormatter is functional, so the prototype and its tests
+         actually run rather than throwing PlatformNotSupportedException. (The .NET 10 migration had
+         modernised this to net10.0, which broke it at run time - and made the SYSLIB0011 obsoletion
+         suppression that came with it moot.) -->
+    <TargetFramework>net472</TargetFramework>
     <Description>Prototype of binary expression tree serialization.</Description>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <!-- NB: Also supports non-slim expressions. Currently not enabled in build. -->
     <DefineConstants>$(DefineConstants);USE_SLIM</DefineConstants>
-    <!-- Experimental prototype whose default object serializer is built on BinaryFormatter, which is
-         obsolete and throws at runtime on .NET 10. Kept as reference; suppress the obsoletion. -->
-    <NoWarn>$(NoWarn);SYSLIB0011</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\..\..\Core\LINQ\Nuqleon.Linq.CompilerServices\Nuqleon.Linq.CompilerServices.csproj" />
-    <ProjectReference Include="..\..\..\..\Core\LINQ\Nuqleon.Linq.Expressions.Bonsai\Nuqleon.Linq.Expressions.Bonsai.csproj" />
+    <PackageReference Include="Nuqleon.Linq.CompilerServices" Version="1.0.0-beta.24" />
+    <PackageReference Include="Nuqleon.Linq.Expressions.Bonsai" Version="1.0.0-beta.24" />
   </ItemGroup>
 
 </Project>

--- a/archive/Nuqleon/Pearls/LINQ/BinaryExpressionSerialization/Tests/Tests.Nuqleon.Pearls.Linq.Expressions.Bonsai.Serialization.Binary.csproj
+++ b/archive/Nuqleon/Pearls/LINQ/BinaryExpressionSerialization/Tests/Tests.Nuqleon.Pearls.Linq.Expressions.Bonsai.Serialization.Binary.csproj
@@ -1,7 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net10.0</TargetFramework>
+    <!-- net472: the framework where BinaryFormatter (used by the serializer under test) is functional. -->
+    <TargetFramework>net472</TargetFramework>
     <!-- NB: Also supports non-slim expressions. Currently not enabled in build. -->
     <DefineConstants>$(DefineConstants);USE_SLIM</DefineConstants>
   </PropertyGroup>

--- a/archive/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Client.Library/Reaqtor.Remoting.Client.Library.csproj
+++ b/archive/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Client.Library/Reaqtor.Remoting.Client.Library.csproj
@@ -11,14 +11,14 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Reaqtor.Remoting.Protocol\Reaqtor.Remoting.Protocol.csproj" />
-    <ProjectReference Include="..\..\..\Core\Client\Reaqtor.Client.Model\Reaqtor.Client.Model.csproj" />
-    <ProjectReference Include="..\..\..\Core\Client\Reaqtor.Client.Core\Reaqtor.Client.Core.csproj" />
-    <ProjectReference Include="..\..\..\Core\Client\Reaqtor.Client\Reaqtor.Client.csproj" />
-    <ProjectReference Include="..\..\..\Core\Hosting\Reaqtor.Hosting.Shared\Reaqtor.Hosting.Shared.csproj" />
-    <ProjectReference Include="..\..\..\Core\Service\Reaqtor.Service.Contracts\Reaqtor.Service.Contracts.csproj" />
-    <ProjectReference Include="..\..\..\Core\Shared\Reaqtor.Shared.Model\Reaqtor.Shared.Model.csproj" />
-    <ProjectReference Include="..\..\..\..\Nuqleon\Core\DataModel\Nuqleon.DataModel\Nuqleon.DataModel.csproj" />
-    <ProjectReference Include="..\..\..\..\Nuqleon\Core\LINQ\Nuqleon.Linq.CompilerServices\Nuqleon.Linq.CompilerServices.csproj" />
+    <PackageReference Include="Reaqtor.Client.Model" Version="1.0.0-beta.24" />
+    <PackageReference Include="Reaqtor.Client.Core" Version="1.0.0-beta.24" />
+    <PackageReference Include="Reaqtor.Client" Version="1.0.0-beta.24" />
+    <PackageReference Include="Reaqtor.Hosting.Shared" Version="1.0.0-beta.24" />
+    <PackageReference Include="Reaqtor.Service.Contracts" Version="1.0.0-beta.24" />
+    <PackageReference Include="Reaqtor.Shared.Model" Version="1.0.0-beta.24" />
+    <PackageReference Include="Nuqleon.DataModel" Version="1.0.0-beta.24" />
+    <PackageReference Include="Nuqleon.Linq.CompilerServices" Version="1.0.0-beta.24" />
   </ItemGroup>
 
   <ItemGroup>

--- a/archive/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Deployable/Reaqtor.Remoting.Deployable.csproj
+++ b/archive/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Deployable/Reaqtor.Remoting.Deployable.csproj
@@ -11,12 +11,12 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Reaqtor.Remoting.Platform\Reaqtor.Remoting.Platform.csproj" />
-    <ProjectReference Include="..\..\..\Core\Client\Reaqtor.Client\Reaqtor.Client.csproj" />
-    <ProjectReference Include="..\..\..\Core\Hosting\Reaqtor.Hosting.Shared\Reaqtor.Hosting.Shared.csproj" />
-    <ProjectReference Include="..\..\..\Core\Engine\Reaqtor.QueryEngine\Reaqtor.QueryEngine.csproj" />
-    <ProjectReference Include="..\..\..\..\Nuqleon\Core\DataModel\Nuqleon.DataModel\Nuqleon.DataModel.csproj" />
-    <ProjectReference Include="..\..\..\..\Nuqleon\Core\DataModel\Nuqleon.DataModel.CompilerServices\Nuqleon.DataModel.CompilerServices.csproj" />
-    <ProjectReference Include="..\..\..\..\Reaqtive\Core\Reaqtive.Linq\Reaqtive.Linq.csproj" />
+    <PackageReference Include="Reaqtor.Client" Version="1.0.0-beta.24" />
+    <PackageReference Include="Reaqtor.Hosting.Shared" Version="1.0.0-beta.24" />
+    <PackageReference Include="Reaqtor.QueryEngine" Version="1.0.0-beta.24" />
+    <PackageReference Include="Nuqleon.DataModel" Version="1.0.0-beta.24" />
+    <PackageReference Include="Nuqleon.DataModel.CompilerServices" Version="1.0.0-beta.24" />
+    <PackageReference Include="Reaqtive.Linq" Version="1.0.0-beta.24" />
   </ItemGroup>
 
   <ItemGroup>

--- a/archive/Reaqtor/Samples/Remoting/Reaqtor.Remoting.KeyValueStore/Reaqtor.Remoting.KeyValueStore.csproj
+++ b/archive/Reaqtor/Samples/Remoting/Reaqtor.Remoting.KeyValueStore/Reaqtor.Remoting.KeyValueStore.csproj
@@ -11,8 +11,8 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Reaqtor.Remoting.Protocol\Reaqtor.Remoting.Protocol.csproj" />
-    <ProjectReference Include="..\..\..\Core\Engine\Reaqtor.QueryEngine.KeyValueStore.InMemory\Reaqtor.QueryEngine.KeyValueStore.InMemory.csproj" />
-    <ProjectReference Include="..\..\..\Core\Engine\Reaqtor.QueryEngine\Reaqtor.QueryEngine.csproj" />
+    <PackageReference Include="Reaqtor.QueryEngine.KeyValueStore.InMemory" Version="1.0.0-beta.24" />
+    <PackageReference Include="Reaqtor.QueryEngine" Version="1.0.0-beta.24" />
   </ItemGroup>
 
 </Project>

--- a/archive/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Messaging/Reaqtor.Remoting.Messaging.csproj
+++ b/archive/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Messaging/Reaqtor.Remoting.Messaging.csproj
@@ -7,7 +7,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Reaqtor.Remoting.Protocol\Reaqtor.Remoting.Protocol.csproj" />
-    <ProjectReference Include="..\..\..\Core\Hosting\Reaqtor.Hosting.Shared\Reaqtor.Hosting.Shared.csproj" />
+    <PackageReference Include="Reaqtor.Hosting.Shared" Version="1.0.0-beta.24" />
   </ItemGroup>
 
 </Project>

--- a/archive/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Platform/Reaqtor.Remoting.Platform.csproj
+++ b/archive/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Platform/Reaqtor.Remoting.Platform.csproj
@@ -16,12 +16,12 @@
   <ItemGroup>
     <ProjectReference Include="..\Reaqtor.Remoting.Protocol\Reaqtor.Remoting.Protocol.csproj" />
     <ProjectReference Include="..\Reaqtor.Remoting.Client.Library\Reaqtor.Remoting.Client.Library.csproj" />
-    <ProjectReference Include="..\..\..\Core\Client\Reaqtor.Client\Reaqtor.Client.csproj" />
-    <ProjectReference Include="..\..\..\Core\Engine\Reaqtor.Engine.Contracts\Reaqtor.Engine.Contracts.csproj" />
-    <ProjectReference Include="..\..\..\Core\Hosting\Reaqtor.Hosting.Shared\Reaqtor.Hosting.Shared.csproj" />
-    <ProjectReference Include="..\..\..\Core\Service\Reaqtor.Service\Reaqtor.Service.csproj" />
-    <ProjectReference Include="..\..\..\..\Nuqleon\Core\LINQ\Nuqleon.Linq.CompilerServices\Nuqleon.Linq.CompilerServices.csproj" />
-    <ProjectReference Include="..\..\..\..\Reaqtive\Core\Reaqtive.Scheduler\Reaqtive.Scheduler.csproj" />
+    <PackageReference Include="Reaqtor.Client" Version="1.0.0-beta.24" />
+    <PackageReference Include="Reaqtor.Engine.Contracts" Version="1.0.0-beta.24" />
+    <PackageReference Include="Reaqtor.Hosting.Shared" Version="1.0.0-beta.24" />
+    <PackageReference Include="Reaqtor.Service" Version="1.0.0-beta.24" />
+    <PackageReference Include="Nuqleon.Linq.CompilerServices" Version="1.0.0-beta.24" />
+    <PackageReference Include="Reaqtive.Scheduler" Version="1.0.0-beta.24" />
   </ItemGroup>
 
 </Project>

--- a/archive/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Protocol/Reaqtor.Remoting.Protocol.csproj
+++ b/archive/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Protocol/Reaqtor.Remoting.Protocol.csproj
@@ -6,12 +6,12 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\..\Core\Hosting\Reaqtor.Hosting.Shared\Reaqtor.Hosting.Shared.csproj" />
-    <ProjectReference Include="..\..\..\Core\Service\Reaqtor.Service.Contracts\Reaqtor.Service.Contracts.csproj" />
+    <PackageReference Include="Reaqtor.Hosting.Shared" Version="1.0.0-beta.24" />
+    <PackageReference Include="Reaqtor.Service.Contracts" Version="1.0.0-beta.24" />
     <ProjectReference Include="..\..\..\..\Nuqleon\Core\BCL\Nuqleon.Runtime.Remoting.Tasks\Nuqleon.Runtime.Remoting.Tasks.csproj" />
-    <ProjectReference Include="..\..\..\..\Nuqleon\Core\LINQ\Nuqleon.Linq.CompilerServices\Nuqleon.Linq.CompilerServices.csproj" />
-    <ProjectReference Include="..\..\..\..\Nuqleon\Core\DataModel\Nuqleon.DataModel\Nuqleon.DataModel.csproj" />
-    <ProjectReference Include="..\..\..\..\Reaqtive\Core\Reaqtive.Scheduler\Reaqtive.Scheduler.csproj" />
+    <PackageReference Include="Nuqleon.Linq.CompilerServices" Version="1.0.0-beta.24" />
+    <PackageReference Include="Nuqleon.DataModel" Version="1.0.0-beta.24" />
+    <PackageReference Include="Reaqtive.Scheduler" Version="1.0.0-beta.24" />
   </ItemGroup>
 
 </Project>

--- a/archive/Reaqtor/Samples/Remoting/Reaqtor.Remoting.QueryCoordinator/Reaqtor.Remoting.QueryCoordinator.csproj
+++ b/archive/Reaqtor/Samples/Remoting/Reaqtor.Remoting.QueryCoordinator/Reaqtor.Remoting.QueryCoordinator.csproj
@@ -8,7 +8,7 @@
   <ItemGroup>
     <ProjectReference Include="..\Reaqtor.Remoting.Protocol\Reaqtor.Remoting.Protocol.csproj" />
     <ProjectReference Include="..\Reaqtor.Remoting.Platform\Reaqtor.Remoting.Platform.csproj" />
-    <ProjectReference Include="..\..\..\Core\Hosting\Reaqtor.Hosting.Shared\Reaqtor.Hosting.Shared.csproj" />
+    <PackageReference Include="Reaqtor.Hosting.Shared" Version="1.0.0-beta.24" />
   </ItemGroup>
 
 </Project>

--- a/archive/Reaqtor/Samples/Remoting/Reaqtor.Remoting.QueryEvaluator/Reaqtor.Remoting.QueryEvaluator.csproj
+++ b/archive/Reaqtor/Samples/Remoting/Reaqtor.Remoting.QueryEvaluator/Reaqtor.Remoting.QueryEvaluator.csproj
@@ -8,11 +8,11 @@
   <ItemGroup>
     <ProjectReference Include="..\Reaqtor.Remoting.Protocol\Reaqtor.Remoting.Protocol.csproj" />
     <ProjectReference Include="..\Reaqtor.Remoting.Platform\Reaqtor.Remoting.Platform.csproj" />
-    <ProjectReference Include="..\..\..\Core\Engine\Reaqtor.QueryEngine\Reaqtor.QueryEngine.csproj" />
-    <ProjectReference Include="..\..\..\Core\Engine\Reaqtor.QueryEngine.Serialization.DataModel\Reaqtor.QueryEngine.Serialization.DataModel.csproj" />
-    <ProjectReference Include="..\..\..\Core\Hosting\Reaqtor.Hosting.Service\Reaqtor.Hosting.Service.csproj" />
-    <ProjectReference Include="..\..\..\..\Nuqleon\Core\JSON\Nuqleon.Json.Serialization\Nuqleon.Json.Serialization.csproj" />
-    <ProjectReference Include="..\..\..\..\Reaqtive\Core\Reaqtive.TestingFramework\Reaqtive.TestingFramework.csproj" />
+    <PackageReference Include="Reaqtor.QueryEngine" Version="1.0.0-beta.24" />
+    <PackageReference Include="Reaqtor.QueryEngine.Serialization.DataModel" Version="1.0.0-beta.24" />
+    <PackageReference Include="Reaqtor.Hosting.Service" Version="1.0.0-beta.24" />
+    <PackageReference Include="Nuqleon.Json.Serialization" Version="1.0.0-beta.24" />
+    <PackageReference Include="Reaqtive.TestingFramework" Version="1.0.0-beta.24" />
 
     <!-- NB: This ensures that reactive artifact types can be loaded dynamically. -->
     <ProjectReference Include="..\Reaqtor.Remoting.Deployable\Reaqtor.Remoting.Deployable.csproj" />

--- a/archive/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Reactor.Client.Library/Reaqtor.Remoting.Reactor.Client.Library.csproj
+++ b/archive/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Reactor.Client.Library/Reaqtor.Remoting.Reactor.Client.Library.csproj
@@ -13,9 +13,9 @@
   <ItemGroup>
     <ProjectReference Include="..\Reaqtor.Remoting.Client.Library\Reaqtor.Remoting.Client.Library.csproj" />
     <ProjectReference Include="..\Reaqtor.Remoting.Platform\Reaqtor.Remoting.Platform.csproj" />
-    <ProjectReference Include="..\..\..\Core\Client\Reaqtor.Client.Model\Reaqtor.Client.Model.csproj" />
-    <ProjectReference Include="..\..\..\Core\Client\Reaqtor.Client.Core\Reaqtor.Client.Core.csproj" />
-    <ProjectReference Include="..\..\..\..\Nuqleon\Core\DataModel\Nuqleon.DataModel\Nuqleon.DataModel.csproj" />
+    <PackageReference Include="Reaqtor.Client.Model" Version="1.0.0-beta.24" />
+    <PackageReference Include="Reaqtor.Client.Core" Version="1.0.0-beta.24" />
+    <PackageReference Include="Nuqleon.DataModel" Version="1.0.0-beta.24" />
   </ItemGroup>
 
 </Project>

--- a/archive/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Reactor.Client/Reaqtor.Remoting.Reactor.Client.csproj
+++ b/archive/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Reactor.Client/Reaqtor.Remoting.Reactor.Client.csproj
@@ -20,10 +20,10 @@
     <ProjectReference Include="..\Reaqtor.Remoting.Reactor.Client.Library\Reaqtor.Remoting.Reactor.Client.Library.csproj" />
     <ProjectReference Include="..\Reaqtor.Remoting.Reactor.Deployable\Reaqtor.Remoting.Reactor.Deployable.csproj" />
     <ProjectReference Include="..\Reaqtor.Remoting.TestingFramework\Reaqtor.Remoting.TestingFramework.csproj" />
-    <ProjectReference Include="..\..\..\..\Nuqleon\Core\DataModel\Nuqleon.DataModel\Nuqleon.DataModel.csproj" />
-    <ProjectReference Include="..\..\..\..\Nuqleon\Core\LINQ\Nuqleon.Linq.CompilerServices\Nuqleon.Linq.CompilerServices.csproj" />
-    <ProjectReference Include="..\..\..\..\Reaqtive\Core\Reaqtive.Linq\Reaqtive.Linq.csproj" />
-    <ProjectReference Include="..\..\..\..\Reaqtive\Core\Reaqtive.TestingFramework\Reaqtive.TestingFramework.csproj" />
+    <PackageReference Include="Nuqleon.DataModel" Version="1.0.0-beta.24" />
+    <PackageReference Include="Nuqleon.Linq.CompilerServices" Version="1.0.0-beta.24" />
+    <PackageReference Include="Reaqtive.Linq" Version="1.0.0-beta.24" />
+    <PackageReference Include="Reaqtive.TestingFramework" Version="1.0.0-beta.24" />
   </ItemGroup>
 
 </Project>

--- a/archive/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Reactor.Deployable/Reaqtor.Remoting.Reactor.Deployable.csproj
+++ b/archive/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Reactor.Deployable/Reaqtor.Remoting.Reactor.Deployable.csproj
@@ -10,10 +10,10 @@
     <ProjectReference Include="..\Reaqtor.Remoting.Client.Library\Reaqtor.Remoting.Client.Library.csproj" />
     <ProjectReference Include="..\Reaqtor.Remoting.Reactor.Client.Library\Reaqtor.Remoting.Reactor.Client.Library.csproj" />
     <ProjectReference Include="..\Reaqtor.Remoting.Platform\Reaqtor.Remoting.Platform.csproj" />
-    <ProjectReference Include="..\..\..\Core\Client\Reaqtor.Client\Reaqtor.Client.csproj" />
-    <ProjectReference Include="..\..\..\..\Nuqleon\Core\BCL\Nuqleon.Collections.Specialized\Nuqleon.Collections.Specialized.csproj" />
-    <ProjectReference Include="..\..\..\..\Nuqleon\Core\DataModel\Nuqleon.DataModel\Nuqleon.DataModel.csproj" />
-    <ProjectReference Include="..\..\..\..\Reaqtive\Core\Reaqtive.Linq\Reaqtive.Linq.csproj" />
+    <PackageReference Include="Reaqtor.Client" Version="1.0.0-beta.24" />
+    <PackageReference Include="Nuqleon.Collections.Specialized" Version="1.0.0-beta.24" />
+    <PackageReference Include="Nuqleon.DataModel" Version="1.0.0-beta.24" />
+    <PackageReference Include="Reaqtive.Linq" Version="1.0.0-beta.24" />
   </ItemGroup>
 
 </Project>

--- a/archive/Reaqtor/Samples/Remoting/Reaqtor.Remoting.ReificationFramework/Reaqtor.Remoting.ReificationFramework.csproj
+++ b/archive/Reaqtor/Samples/Remoting/Reaqtor.Remoting.ReificationFramework/Reaqtor.Remoting.ReificationFramework.csproj
@@ -8,9 +8,9 @@
   <ItemGroup>
     <ProjectReference Include="..\Reaqtor.Remoting.Protocol\Reaqtor.Remoting.Protocol.csproj" />
     <ProjectReference Include="..\Reaqtor.Remoting.Platform.InMemory\Reaqtor.Remoting.Platform.InMemory.csproj" />
-    <ProjectReference Include="..\..\..\Core\Testing\Reaqtor.ReificationFramework\Reaqtor.ReificationFramework.csproj" />
-    <ProjectReference Include="..\..\..\Core\Testing\Reaqtor.ReifiedOperations\Reaqtor.ReifiedOperations.csproj" />
-    <ProjectReference Include="..\..\..\..\Reaqtive\Core\Reaqtive.TestingFramework\Reaqtive.TestingFramework.csproj" />
+    <PackageReference Include="Reaqtor.ReificationFramework" Version="1.0.0-beta.24" />
+    <PackageReference Include="Reaqtor.ReifiedOperations" Version="1.0.0-beta.24" />
+    <PackageReference Include="Reaqtive.TestingFramework" Version="1.0.0-beta.24" />
   </ItemGroup>
 
 </Project>

--- a/archive/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Samples/Reaqtor.Remoting.Samples.csproj
+++ b/archive/Reaqtor/Samples/Remoting/Reaqtor.Remoting.Samples/Reaqtor.Remoting.Samples.csproj
@@ -8,7 +8,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Reaqtor.Remoting.Client.Library\Reaqtor.Remoting.Client.Library.csproj" />
-    <ProjectReference Include="..\..\..\..\Nuqleon\Core\DataModel\Nuqleon.DataModel\Nuqleon.DataModel.csproj" />
+    <PackageReference Include="Nuqleon.DataModel" Version="1.0.0-beta.24" />
   </ItemGroup>
 
 </Project>

--- a/archive/Reaqtor/Samples/Remoting/Reaqtor.Remoting.StateStore/Reaqtor.Remoting.StateStore.csproj
+++ b/archive/Reaqtor/Samples/Remoting/Reaqtor.Remoting.StateStore/Reaqtor.Remoting.StateStore.csproj
@@ -11,7 +11,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Reaqtor.Remoting.Protocol\Reaqtor.Remoting.Protocol.csproj" />
-    <ProjectReference Include="..\..\..\Core\Engine\Reaqtor.QueryEngine\Reaqtor.QueryEngine.csproj" />
+    <PackageReference Include="Reaqtor.QueryEngine" Version="1.0.0-beta.24" />
   </ItemGroup>
 
 </Project>

--- a/archive/Reaqtor/Samples/Remoting/Reaqtor.Remoting.TestingFramework/Reaqtor.Remoting.TestingFramework.csproj
+++ b/archive/Reaqtor/Samples/Remoting/Reaqtor.Remoting.TestingFramework/Reaqtor.Remoting.TestingFramework.csproj
@@ -14,8 +14,8 @@
     <ProjectReference Include="..\Reaqtor.Remoting.Platform.InMemory\Reaqtor.Remoting.Platform.InMemory.csproj" />
     <ProjectReference Include="..\Reaqtor.Remoting.Reactor.Client.Library\Reaqtor.Remoting.Reactor.Client.Library.csproj" />
     <ProjectReference Include="..\Reaqtor.Remoting.Reactor.Deployable\Reaqtor.Remoting.Reactor.Deployable.csproj" />
-    <ProjectReference Include="..\..\..\..\Nuqleon\Core\DataModel\Nuqleon.DataModel\Nuqleon.DataModel.csproj" />
-    <ProjectReference Include="..\..\..\..\Reaqtive\Core\Reaqtive.TestingFramework\Reaqtive.TestingFramework.csproj" />
+    <PackageReference Include="Nuqleon.DataModel" Version="1.0.0-beta.24" />
+    <PackageReference Include="Reaqtive.TestingFramework" Version="1.0.0-beta.24" />
   </ItemGroup>
 
 </Project>

--- a/archive/Reaqtor/Samples/Remoting/Reaqtor.Remoting.VersioningTests/Reaqtor.Remoting.VersioningTests.csproj
+++ b/archive/Reaqtor/Samples/Remoting/Reaqtor.Remoting.VersioningTests/Reaqtor.Remoting.VersioningTests.csproj
@@ -1,38 +1,24 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\Import.targets" />
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
   <PropertyGroup>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProjectGuid>{025D7FF1-7B62-45D2-B503-B6081A536B75}</ProjectGuid>
+    <TargetFramework>net472</TargetFramework>
     <OutputType>Exe</OutputType>
-    <AppDesignerFolder>Properties</AppDesignerFolder>
-    <RootNamespace>Microsoft.Reactive.Remoting.VersioningTests</RootNamespace>
-    <AssemblyName>Microsoft.Reactive.Remoting.VersioningTests</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
-    <FileAlignment>512</FileAlignment>
   </PropertyGroup>
-  <Import Project="..\..\Common.targets" />
+
   <ItemGroup>
-    <Reference Include="System" />
-    <Reference Include="System.Configuration" />
-    <Reference Include="System.Core" />
-    <Reference Include="Microsoft.CSharp" />
+    <!-- ZipFile / ZipArchive (de)compress the versioning TestCases.zip, and LINQ-to-XML reads the settings
+         and writes the gate results - none are default framework references for a net472 SDK project. -->
     <Reference Include="System.IO.Compression" />
     <Reference Include="System.IO.Compression.FileSystem" />
-    <Reference Include="System.XML" />
     <Reference Include="System.Xml.Linq" />
   </ItemGroup>
+
   <ItemGroup>
-    <Compile Include="Program.cs" />
-    <Compile Include="Properties\AssemblyInfo.cs" />
+    <!-- Reaqtive.TestingFramework.TestRunner (used by Program.cs). This is the published, renamed form of
+         the fossil's original Microsoft.Reactive.TestingFramework project reference. -->
+    <PackageReference Include="Reaqtive.TestingFramework" Version="1.0.0-beta.24" />
   </ItemGroup>
-  <ItemGroup>
-    <ProjectReference Include="..\Microsoft.Reactive.TestingFramework\Microsoft.Reactive.TestingFramework.csproj">
-      <Project>{5c497ba0-e8d2-4cb5-95a5-3ab80e3d1de5}</Project>
-      <Name>Microsoft.Reactive.TestingFramework</Name>
-    </ProjectReference>
-  </ItemGroup>
+
   <ItemGroup>
     <Content Include="RunSettings.xml">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
@@ -44,5 +30,5 @@
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>
   </ItemGroup>
-  <Import Project="..\After.targets" />
+
 </Project>

--- a/archive/Reaqtor/Samples/Remoting/Reaqtor.Remoting.VersioningTests/Reaqtor.Remoting.VersioningTests.csproj
+++ b/archive/Reaqtor/Samples/Remoting/Reaqtor.Remoting.VersioningTests/Reaqtor.Remoting.VersioningTests.csproj
@@ -14,8 +14,10 @@
   </ItemGroup>
 
   <ItemGroup>
-    <!-- Reaqtive.TestingFramework.TestRunner (used by Program.cs). This is the published, renamed form of
-         the fossil's original Microsoft.Reactive.TestingFramework project reference. -->
+    <!-- Reaqtive.TestingFramework.TestRunner (used by Program.cs). The original legacy-format version of
+         this project file referenced a sibling Microsoft.Reactive.TestingFramework project - the internal
+         pre-open-sourcing name for the code now published as the Reaqtive.TestingFramework package (not
+         to be confused with Rx.NET's Microsoft.Reactive.Testing, which is unrelated). -->
     <PackageReference Include="Reaqtive.TestingFramework" Version="1.0.0-beta.24" />
   </ItemGroup>
 

--- a/archive/Reaqtor/Samples/Remoting/Remoting.slnx
+++ b/archive/Reaqtor/Samples/Remoting/Remoting.slnx
@@ -2,86 +2,7 @@
   <Folder Name="/deps/" />
   <Folder Name="/deps/Nuqleon/" />
   <Folder Name="/deps/Nuqleon/BCL/">
-    <Project Path="../../../Nuqleon/Core/BCL/Nuqleon.Collections.Specialized/Nuqleon.Collections.Specialized.csproj" />
-    <Project Path="../../../Nuqleon/Core/BCL/Nuqleon.IO.StreamSegment/Nuqleon.IO.StreamSegment.csproj" />
-    <Project Path="../../../Nuqleon/Core/BCL/Nuqleon.Memory/Nuqleon.Memory.csproj" />
-    <Project Path="../../../Nuqleon/Core/BCL/Nuqleon.Reflection.Virtualization/Nuqleon.Reflection.Virtualization.csproj" />
     <Project Path="../../../Nuqleon/Core/BCL/Nuqleon.Runtime.Remoting.Tasks/Nuqleon.Runtime.Remoting.Tasks.csproj" />
-    <Project Path="../../../Nuqleon/Core/BCL/Nuqleon.Time/Nuqleon.Time.csproj" />
-  </Folder>
-  <Folder Name="/deps/Nuqleon/DataModel/">
-    <Project Path="../../../Nuqleon/Core/DataModel/Nuqleon.DataModel.CompilerServices/Nuqleon.DataModel.CompilerServices.csproj" />
-    <Project Path="../../../Nuqleon/Core/DataModel/Nuqleon.DataModel.Serialization.Json/Nuqleon.DataModel.Serialization.Json.csproj" />
-    <Project Path="../../../Nuqleon/Core/DataModel/Nuqleon.DataModel/Nuqleon.DataModel.csproj" />
-  </Folder>
-  <Folder Name="/deps/Nuqleon/JSON/">
-    <Project Path="../../../Nuqleon/Core/JSON/Nuqleon.Json.Interop.Newtonsoft/Nuqleon.Json.Interop.Newtonsoft.csproj" />
-    <Project Path="../../../Nuqleon/Core/JSON/Nuqleon.Json.Serialization/Nuqleon.Json.Serialization.csproj" />
-    <Project Path="../../../Nuqleon/Core/JSON/Nuqleon.Json/Nuqleon.Json.csproj" />
-  </Folder>
-  <Folder Name="/deps/Nuqleon/LINQ/">
-    <Project Path="../../../Nuqleon/Core/LINQ/Nuqleon.Linq.CompilerServices/Nuqleon.Linq.CompilerServices.csproj" />
-    <Project Path="../../../Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Bonsai.Serialization/Nuqleon.Linq.Expressions.Bonsai.Serialization.csproj" />
-    <Project Path="../../../Nuqleon/Core/LINQ/Nuqleon.Linq.Expressions.Bonsai/Nuqleon.Linq.Expressions.Bonsai.csproj" />
-  </Folder>
-  <Folder Name="/deps/Reaqtive/">
-    <Project Path="../../../Reaqtive/Core/Reaqtive.Core/Reaqtive.Core.csproj" />
-    <Project Path="../../../Reaqtive/Core/Reaqtive.Interfaces/Reaqtive.Interfaces.csproj" />
-    <Project Path="../../../Reaqtive/Core/Reaqtive.Linq/Reaqtive.Linq.csproj" />
-    <Project Path="../../../Reaqtive/Core/Reaqtive.Quotation/Reaqtive.Quotation.csproj" />
-    <Project Path="../../../Reaqtive/Core/Reaqtive.Scheduler/Reaqtive.Scheduler.csproj" />
-    <Project Path="../../../Reaqtive/Core/Reaqtive.Testing/Reaqtive.Testing.csproj" />
-    <Project Path="../../../Reaqtive/Core/Reaqtive.TestingFramework/Reaqtive.TestingFramework.csproj" />
-  </Folder>
-  <Folder Name="/deps/Reaqtor/" />
-  <Folder Name="/deps/Reaqtor/Client/">
-    <Project Path="../../Core/Client/Reaqtor.Client.Core/Reaqtor.Client.Core.csproj" />
-    <Project Path="../../Core/Client/Reaqtor.Client.Model/Reaqtor.Client.Model.csproj" />
-    <Project Path="../../Core/Client/Reaqtor.Client/Reaqtor.Client.csproj" />
-  </Folder>
-  <Folder Name="/deps/Reaqtor/Engine/">
-    <Project Path="../../Core/Engine/Reaqtor.Engine.Contracts/Reaqtor.Engine.Contracts.csproj" />
-    <Project Path="../../Core/Engine/Reaqtor.QueryEngine.Interfaces/Reaqtor.QueryEngine.Interfaces.csproj" />
-    <Project Path="../../Core/Engine/Reaqtor.QueryEngine.KeyValueStore.InMemory/Reaqtor.QueryEngine.KeyValueStore.InMemory.csproj" />
-    <Project Path="../../Core/Engine/Reaqtor.QueryEngine.Serialization.DataModel/Reaqtor.QueryEngine.Serialization.DataModel.csproj" />
-    <Project Path="../../Core/Engine/Reaqtor.QueryEngine/Reaqtor.QueryEngine.csproj" />
-  </Folder>
-  <Folder Name="/deps/Reaqtor/Expressions/">
-    <Project Path="../../Core/Expressions/Reaqtor.Expressions.Binding/Reaqtor.Expressions.Binding.csproj" />
-    <Project Path="../../Core/Expressions/Reaqtor.Expressions.Core/Reaqtor.Expressions.Core.csproj" />
-    <Project Path="../../Core/Expressions/Reaqtor.Expressions.Model/Reaqtor.Expressions.Model.csproj" />
-  </Folder>
-  <Folder Name="/deps/Reaqtor/Hosting/">
-    <Project Path="../../Core/Hosting/Reaqtor.Hosting.Service/Reaqtor.Hosting.Service.csproj" />
-    <Project Path="../../Core/Hosting/Reaqtor.Hosting.Shared/Reaqtor.Hosting.Shared.csproj" />
-  </Folder>
-  <Folder Name="/deps/Reaqtor/Local/">
-    <Project Path="../../Core/Local/Reaqtor.Local.Core/Reaqtor.Local.Core.csproj" />
-    <Project Path="../../Core/Local/Reaqtor.Local.Model/Reaqtor.Local.Model.csproj" />
-  </Folder>
-  <Folder Name="/deps/Reaqtor/Metadata/">
-    <Project Path="../../Core/Metadata/Reaqtor.Metadata.Model/Reaqtor.Metadata.Model.csproj" />
-  </Folder>
-  <Folder Name="/deps/Reaqtor/Reactive/">
-    <Project Path="../../Core/Reactive/Reaqtor.Reactive.HigherOrder/Reaqtor.Reactive.HigherOrder.csproj" />
-  </Folder>
-  <Folder Name="/deps/Reaqtor/Reliable/">
-    <Project Path="../../Core/Reliable/Reaqtor.Reliable.Model/Reaqtor.Reliable.Model.csproj" />
-    <Project Path="../../Core/Reliable/Reaqtor.Reliable/Reaqtor.Reliable.csproj" />
-  </Folder>
-  <Folder Name="/deps/Reaqtor/Service/">
-    <Project Path="../../Core/Service/Reaqtor.Service.Contracts/Reaqtor.Service.Contracts.csproj" />
-    <Project Path="../../Core/Service/Reaqtor.Service.Core/Reaqtor.Service.Core.csproj" />
-    <Project Path="../../Core/Service/Reaqtor.Service.Model/Reaqtor.Service.Model.csproj" />
-    <Project Path="../../Core/Service/Reaqtor.Service/Reaqtor.Service.csproj" />
-  </Folder>
-  <Folder Name="/deps/Reaqtor/Shared/">
-    <Project Path="../../Core/Shared/Reaqtor.Shared.Core/Reaqtor.Shared.Core.csproj" />
-    <Project Path="../../Core/Shared/Reaqtor.Shared.Model/Reaqtor.Shared.Model.csproj" />
-  </Folder>
-  <Folder Name="/deps/Reaqtor/Testing/">
-    <Project Path="../../Core/Testing/Reaqtor.ReificationFramework/Reaqtor.ReificationFramework.csproj" />
-    <Project Path="../../Core/Testing/Reaqtor.ReifiedOperations/Reaqtor.ReifiedOperations.csproj" />
   </Folder>
   <Folder Name="/src/">
     <Project Path="Reaqtor.Remoting.Demo/Reaqtor.Remoting.Demo.csproj" />
@@ -143,9 +64,7 @@
   <Folder Name="/src/Testing/">
     <Project Path="Reaqtor.Remoting.ReificationFramework/Reaqtor.Remoting.ReificationFramework.csproj" />
     <Project Path="Reaqtor.Remoting.TestingFramework/Reaqtor.Remoting.TestingFramework.csproj" />
-    <Project Path="Reaqtor.Remoting.VersioningTests/Reaqtor.Remoting.VersioningTests.csproj">
-      <Build Project="false" />
-    </Project>
+    <Project Path="Reaqtor.Remoting.VersioningTests/Reaqtor.Remoting.VersioningTests.csproj" />
   </Folder>
   <Folder Name="/test/">
     <Project Path="Tests.Reaqtor.Remoting.Glitching/Tests.Reaqtor.Remoting.Glitching.csproj" />

--- a/archive/Reaqtor/Samples/Remoting/Tests.Reaqtor.Remoting.Glitching/Tests.Reaqtor.Remoting.Glitching.csproj
+++ b/archive/Reaqtor/Samples/Remoting/Tests.Reaqtor.Remoting.Glitching/Tests.Reaqtor.Remoting.Glitching.csproj
@@ -2,14 +2,24 @@
 
   <PropertyGroup>
     <TargetFrameworks>net472</TargetFrameworks>
+    <!-- This project links live Tests.Reaqtive.Linq operator sources (the *.Declarative.cs Compile items
+         below) that were written for the live tree's implicit usings and carry no using directives for
+         System.* or MSTest. The archive disables implicit usings by default, so re-enable them here and
+         add the MSTest namespace (MSTest 3.x, unlike 4.x, does not contribute it) so those frozen linked
+         sources compile unchanged. -->
+    <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
+
+  <ItemGroup>
+    <Using Include="Microsoft.VisualStudio.TestTools.UnitTesting" />
+  </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\Reaqtor.Remoting.Protocol\Reaqtor.Remoting.Protocol.csproj" />
     <ProjectReference Include="..\Reaqtor.Remoting.TestingFramework\Reaqtor.Remoting.TestingFramework.csproj" />
-    <ProjectReference Include="..\..\..\..\Reaqtive\Core\Reaqtive.Testing\Reaqtive.Testing.csproj" />
-    <ProjectReference Include="..\..\..\..\Reaqtive\Core\Reaqtive.TestingFramework\Reaqtive.TestingFramework.csproj" />
-    <ProjectReference Include="..\..\..\..\Reaqtive\Core\Reaqtive.Scheduler\Reaqtive.Scheduler.csproj" />
+    <PackageReference Include="Reaqtive.Testing" Version="1.0.0-beta.24" />
+    <PackageReference Include="Reaqtive.TestingFramework" Version="1.0.0-beta.24" />
+    <PackageReference Include="Reaqtive.Scheduler" Version="1.0.0-beta.24" />
   </ItemGroup>
 
   <PropertyGroup>
@@ -24,145 +34,145 @@
   </PropertyGroup>
 
   <ItemGroup Condition="'$(ContinuousIntegrationBuild)' != 'true' Or '$(EnableGlitching)' == 'true'">
-    <Compile Include="..\..\..\..\Reaqtive\Core\Tests.Reaqtive.Linq\Operators\Aggregate.Declarative.cs">
+    <Compile Include="..\..\..\..\..\Reaqtive\Core\Tests.Reaqtive.Linq\Operators\Aggregate.Declarative.cs">
       <Link>Operators\Aggregate.Declarative.cs</Link>
     </Compile>
-    <Compile Include="..\..\..\..\Reaqtive\Core\Tests.Reaqtive.Linq\Operators\All.Declarative.cs">
+    <Compile Include="..\..\..\..\..\Reaqtive\Core\Tests.Reaqtive.Linq\Operators\All.Declarative.cs">
       <Link>Operators\All.Declarative.cs</Link>
     </Compile>
-    <Compile Include="..\..\..\..\Reaqtive\Core\Tests.Reaqtive.Linq\Operators\Any.Declarative.cs">
+    <Compile Include="..\..\..\..\..\Reaqtive\Core\Tests.Reaqtive.Linq\Operators\Any.Declarative.cs">
       <Link>Operators\Any.Declarative.cs</Link>
     </Compile>
-    <Compile Include="..\..\..\..\Reaqtive\Core\Tests.Reaqtive.Linq\Operators\Average.Declarative.cs">
+    <Compile Include="..\..\..\..\..\Reaqtive\Core\Tests.Reaqtive.Linq\Operators\Average.Declarative.cs">
       <Link>Operators\Average.Declarative.cs</Link>
     </Compile>
-    <Compile Include="..\..\..\..\Reaqtive\Core\Tests.Reaqtive.Linq\Operators\Average.Declarative.Generated.cs">
+    <Compile Include="..\..\..\..\..\Reaqtive\Core\Tests.Reaqtive.Linq\Operators\Average.Declarative.Generated.cs">
       <Link>Operators\Average.Declarative.Generated.cs</Link>
     </Compile>
-    <Compile Include="..\..\..\..\Reaqtive\Core\Tests.Reaqtive.Linq\Operators\Buffer.Declarative.cs">
+    <Compile Include="..\..\..\..\..\Reaqtive\Core\Tests.Reaqtive.Linq\Operators\Buffer.Declarative.cs">
       <Link>Operators\Buffer.Declarative.cs</Link>
     </Compile>
-    <Compile Include="..\..\..\..\Reaqtive\Core\Tests.Reaqtive.Linq\Operators\Contains.Declarative.cs">
+    <Compile Include="..\..\..\..\..\Reaqtive\Core\Tests.Reaqtive.Linq\Operators\Contains.Declarative.cs">
       <Link>Operators\Contains.Declarative.cs</Link>
     </Compile>
-    <Compile Include="..\..\..\..\Reaqtive\Core\Tests.Reaqtive.Linq\Operators\Count.Declarative.cs">
+    <Compile Include="..\..\..\..\..\Reaqtive\Core\Tests.Reaqtive.Linq\Operators\Count.Declarative.cs">
       <Link>Operators\Count.Declarative.cs</Link>
     </Compile>
-    <Compile Include="..\..\..\..\Reaqtive\Core\Tests.Reaqtive.Linq\Operators\DelaySubscription.Declarative.cs">
+    <Compile Include="..\..\..\..\..\Reaqtive\Core\Tests.Reaqtive.Linq\Operators\DelaySubscription.Declarative.cs">
       <Link>Operators\DelaySubscription.Declarative.cs</Link>
     </Compile>
-    <Compile Include="..\..\..\..\Reaqtive\Core\Tests.Reaqtive.Linq\Operators\DefaultIfEmpty.Declarative.cs">
+    <Compile Include="..\..\..\..\..\Reaqtive\Core\Tests.Reaqtive.Linq\Operators\DefaultIfEmpty.Declarative.cs">
       <Link>Operators\DefaultIfEmpty.Declarative.cs</Link>
     </Compile>
-    <Compile Include="..\..\..\..\Reaqtive\Core\Tests.Reaqtive.Linq\Operators\Distinct.Declarative.cs">
+    <Compile Include="..\..\..\..\..\Reaqtive\Core\Tests.Reaqtive.Linq\Operators\Distinct.Declarative.cs">
       <Link>Operators\Distinct.Declarative.cs</Link>
     </Compile>
-    <Compile Include="..\..\..\..\Reaqtive\Core\Tests.Reaqtive.Linq\Operators\DistinctUntilChanged.Declarative.cs">
+    <Compile Include="..\..\..\..\..\Reaqtive\Core\Tests.Reaqtive.Linq\Operators\DistinctUntilChanged.Declarative.cs">
       <Link>Operators\DistinctUntilChanged.Declarative.cs</Link>
     </Compile>
-    <Compile Include="..\..\..\..\Reaqtive\Core\Tests.Reaqtive.Linq\Operators\ElementAt.Declarative.cs">
+    <Compile Include="..\..\..\..\..\Reaqtive\Core\Tests.Reaqtive.Linq\Operators\ElementAt.Declarative.cs">
       <Link>Operators\ElementAt.Declarative.cs</Link>
     </Compile>
-    <Compile Include="..\..\..\..\Reaqtive\Core\Tests.Reaqtive.Linq\Operators\Empty.Declarative.cs">
+    <Compile Include="..\..\..\..\..\Reaqtive\Core\Tests.Reaqtive.Linq\Operators\Empty.Declarative.cs">
       <Link>Operators\Empty.Declarative.cs</Link>
     </Compile>
-    <Compile Include="..\..\..\..\Reaqtive\Core\Tests.Reaqtive.Linq\Operators\FirstAsync.Declarative.cs">
+    <Compile Include="..\..\..\..\..\Reaqtive\Core\Tests.Reaqtive.Linq\Operators\FirstAsync.Declarative.cs">
       <Link>Operators\FirstAsync.Declarative.cs</Link>
     </Compile>
-    <Compile Include="..\..\..\..\Reaqtive\Core\Tests.Reaqtive.Linq\Operators\GroupBy.Declarative.cs">
+    <Compile Include="..\..\..\..\..\Reaqtive\Core\Tests.Reaqtive.Linq\Operators\GroupBy.Declarative.cs">
       <Link>Operators\GroupBy.Declarative.cs</Link>
     </Compile>
-    <Compile Include="..\..\..\..\Reaqtive\Core\Tests.Reaqtive.Linq\Operators\IgnoreElements.Declarative.cs">
+    <Compile Include="..\..\..\..\..\Reaqtive\Core\Tests.Reaqtive.Linq\Operators\IgnoreElements.Declarative.cs">
       <Link>Operators\IgnoreElements.Declarative.cs</Link>
     </Compile>
-    <Compile Include="..\..\..\..\Reaqtive\Core\Tests.Reaqtive.Linq\Operators\IsEmpty.Declarative.cs">
+    <Compile Include="..\..\..\..\..\Reaqtive\Core\Tests.Reaqtive.Linq\Operators\IsEmpty.Declarative.cs">
       <Link>Operators\IsEmpty.Declarative.cs</Link>
     </Compile>
-    <Compile Include="..\..\..\..\Reaqtive\Core\Tests.Reaqtive.Linq\Operators\LastAsync.Declarative.cs">
+    <Compile Include="..\..\..\..\..\Reaqtive\Core\Tests.Reaqtive.Linq\Operators\LastAsync.Declarative.cs">
       <Link>Operators\LastAsync.Declarative.cs</Link>
     </Compile>
-    <Compile Include="..\..\..\..\Reaqtive\Core\Tests.Reaqtive.Linq\Operators\LongCount.Declarative.cs">
+    <Compile Include="..\..\..\..\..\Reaqtive\Core\Tests.Reaqtive.Linq\Operators\LongCount.Declarative.cs">
       <Link>Operators\LongCount.Declarative.cs</Link>
     </Compile>
-    <Compile Include="..\..\..\..\Reaqtive\Core\Tests.Reaqtive.Linq\Operators\Merge.Declarative.cs">
+    <Compile Include="..\..\..\..\..\Reaqtive\Core\Tests.Reaqtive.Linq\Operators\Merge.Declarative.cs">
       <Link>Operators\Merge.Declarative.cs</Link>
     </Compile>
-    <Compile Include="..\..\..\..\Reaqtive\Core\Tests.Reaqtive.Linq\Operators\MinMax.Declarative.Generated.cs">
+    <Compile Include="..\..\..\..\..\Reaqtive\Core\Tests.Reaqtive.Linq\Operators\MinMax.Declarative.Generated.cs">
       <Link>Operators\MinMax.Declarative.Generated.cs</Link>
     </Compile>
-    <Compile Include="..\..\..\..\Reaqtive\Core\Tests.Reaqtive.Linq\Operators\Never.Declarative.cs">
+    <Compile Include="..\..\..\..\..\Reaqtive\Core\Tests.Reaqtive.Linq\Operators\Never.Declarative.cs">
       <Link>Operators\Never.Declarative.cs</Link>
     </Compile>
-    <Compile Include="..\..\..\..\Reaqtive\Core\Tests.Reaqtive.Linq\Operators\Regressions.Declarative.cs">
+    <Compile Include="..\..\..\..\..\Reaqtive\Core\Tests.Reaqtive.Linq\Operators\Regressions.Declarative.cs">
       <Link>Operators\Regressions.Declarative.cs</Link>
     </Compile>
-    <Compile Include="..\..\..\..\Reaqtive\Core\Tests.Reaqtive.Linq\Operators\Retry.Declarative.cs">
+    <Compile Include="..\..\..\..\..\Reaqtive\Core\Tests.Reaqtive.Linq\Operators\Retry.Declarative.cs">
       <Link>Operators\Retry.Declarative.cs</Link>
     </Compile>
-    <Compile Include="..\..\..\..\Reaqtive\Core\Tests.Reaqtive.Linq\Operators\Return.Declarative.cs">
+    <Compile Include="..\..\..\..\..\Reaqtive\Core\Tests.Reaqtive.Linq\Operators\Return.Declarative.cs">
       <Link>Operators\Return.Declarative.cs</Link>
     </Compile>
-    <Compile Include="..\..\..\..\Reaqtive\Core\Tests.Reaqtive.Linq\Operators\Sample.Declarative.cs">
+    <Compile Include="..\..\..\..\..\Reaqtive\Core\Tests.Reaqtive.Linq\Operators\Sample.Declarative.cs">
       <Link>Operators\Sample.Declarative.cs</Link>
     </Compile>
-    <Compile Include="..\..\..\..\Reaqtive\Core\Tests.Reaqtive.Linq\Operators\Scan.Declarative.cs">
+    <Compile Include="..\..\..\..\..\Reaqtive\Core\Tests.Reaqtive.Linq\Operators\Scan.Declarative.cs">
       <Link>Operators\Scan.Declarative.cs</Link>
     </Compile>
-    <Compile Include="..\..\..\..\Reaqtive\Core\Tests.Reaqtive.Linq\Operators\Select.Declarative.cs">
+    <Compile Include="..\..\..\..\..\Reaqtive\Core\Tests.Reaqtive.Linq\Operators\Select.Declarative.cs">
       <Link>Operators\Select.Declarative.cs</Link>
     </Compile>
-    <Compile Include="..\..\..\..\Reaqtive\Core\Tests.Reaqtive.Linq\Operators\SelectMany.Declarative.cs">
+    <Compile Include="..\..\..\..\..\Reaqtive\Core\Tests.Reaqtive.Linq\Operators\SelectMany.Declarative.cs">
       <Link>Operators\SelectMany.Declarative.cs</Link>
     </Compile>
-    <Compile Include="..\..\..\..\Reaqtive\Core\Tests.Reaqtive.Linq\Operators\SequenceEqual.Declarative.cs">
+    <Compile Include="..\..\..\..\..\Reaqtive\Core\Tests.Reaqtive.Linq\Operators\SequenceEqual.Declarative.cs">
       <Link>Operators\SequenceEqual.Declarative.cs</Link>
     </Compile>
-    <Compile Include="..\..\..\..\Reaqtive\Core\Tests.Reaqtive.Linq\Operators\SingleAsync.Declarative.cs">
+    <Compile Include="..\..\..\..\..\Reaqtive\Core\Tests.Reaqtive.Linq\Operators\SingleAsync.Declarative.cs">
       <Link>Operators\SingleAsync.Declarative.cs</Link>
     </Compile>
-    <Compile Include="..\..\..\..\Reaqtive\Core\Tests.Reaqtive.Linq\Operators\Skip.Declarative.cs">
+    <Compile Include="..\..\..\..\..\Reaqtive\Core\Tests.Reaqtive.Linq\Operators\Skip.Declarative.cs">
       <Link>Operators\Skip.Declarative.cs</Link>
     </Compile>
-    <Compile Include="..\..\..\..\Reaqtive\Core\Tests.Reaqtive.Linq\Operators\SkipUntil.Declarative.cs">
+    <Compile Include="..\..\..\..\..\Reaqtive\Core\Tests.Reaqtive.Linq\Operators\SkipUntil.Declarative.cs">
       <Link>Operators\SkipUntil.Declarative.cs</Link>
     </Compile>
-    <Compile Include="..\..\..\..\Reaqtive\Core\Tests.Reaqtive.Linq\Operators\SkipWhile.Declarative.cs">
+    <Compile Include="..\..\..\..\..\Reaqtive\Core\Tests.Reaqtive.Linq\Operators\SkipWhile.Declarative.cs">
       <Link>Operators\SkipWhile.Declarative.cs</Link>
     </Compile>
-    <Compile Include="..\..\..\..\Reaqtive\Core\Tests.Reaqtive.Linq\Operators\StartWith.Declarative.cs">
+    <Compile Include="..\..\..\..\..\Reaqtive\Core\Tests.Reaqtive.Linq\Operators\StartWith.Declarative.cs">
       <Link>Operators\StartWith.Declarative.cs</Link>
     </Compile>
-    <Compile Include="..\..\..\..\Reaqtive\Core\Tests.Reaqtive.Linq\Operators\Sum.Declarative.cs">
+    <Compile Include="..\..\..\..\..\Reaqtive\Core\Tests.Reaqtive.Linq\Operators\Sum.Declarative.cs">
       <Link>Operators\Sum.Declarative.cs</Link>
     </Compile>
-    <Compile Include="..\..\..\..\Reaqtive\Core\Tests.Reaqtive.Linq\Operators\Sum.Declarative.Generated.cs">
+    <Compile Include="..\..\..\..\..\Reaqtive\Core\Tests.Reaqtive.Linq\Operators\Sum.Declarative.Generated.cs">
       <Link>Operators\Sum.Declarative.Generated.cs</Link>
     </Compile>
-    <Compile Include="..\..\..\..\Reaqtive\Core\Tests.Reaqtive.Linq\Operators\Switch.Declarative.cs">
+    <Compile Include="..\..\..\..\..\Reaqtive\Core\Tests.Reaqtive.Linq\Operators\Switch.Declarative.cs">
       <Link>Operators\Switch.Declarative.cs</Link>
     </Compile>
-    <Compile Include="..\..\..\..\Reaqtive\Core\Tests.Reaqtive.Linq\Operators\Take.Declarative.cs">
+    <Compile Include="..\..\..\..\..\Reaqtive\Core\Tests.Reaqtive.Linq\Operators\Take.Declarative.cs">
       <Link>Operators\Take.Declarative.cs</Link>
     </Compile>
-    <Compile Include="..\..\..\..\Reaqtive\Core\Tests.Reaqtive.Linq\Operators\TakeUntil.Declarative.cs">
+    <Compile Include="..\..\..\..\..\Reaqtive\Core\Tests.Reaqtive.Linq\Operators\TakeUntil.Declarative.cs">
       <Link>Operators\TakeUntil.Declarative.cs</Link>
     </Compile>
-    <Compile Include="..\..\..\..\Reaqtive\Core\Tests.Reaqtive.Linq\Operators\TakeWhile.Declarative.cs">
+    <Compile Include="..\..\..\..\..\Reaqtive\Core\Tests.Reaqtive.Linq\Operators\TakeWhile.Declarative.cs">
       <Link>Operators\TakeWhile.Declarative.cs</Link>
     </Compile>
-    <Compile Include="..\..\..\..\Reaqtive\Core\Tests.Reaqtive.Linq\Operators\Throttle.Declarative.cs">
+    <Compile Include="..\..\..\..\..\Reaqtive\Core\Tests.Reaqtive.Linq\Operators\Throttle.Declarative.cs">
       <Link>Operators\Throttle.Declarative.cs</Link>
     </Compile>
-    <Compile Include="..\..\..\..\Reaqtive\Core\Tests.Reaqtive.Linq\Operators\Throw.Declarative.cs">
+    <Compile Include="..\..\..\..\..\Reaqtive\Core\Tests.Reaqtive.Linq\Operators\Throw.Declarative.cs">
       <Link>Operators\Throw.Declarative.cs</Link>
     </Compile>
-    <Compile Include="..\..\..\..\Reaqtive\Core\Tests.Reaqtive.Linq\Operators\ToList.Declarative.cs">
+    <Compile Include="..\..\..\..\..\Reaqtive\Core\Tests.Reaqtive.Linq\Operators\ToList.Declarative.cs">
       <Link>Operators\ToList.Declarative.cs</Link>
     </Compile>
-    <Compile Include="..\..\..\..\Reaqtive\Core\Tests.Reaqtive.Linq\Operators\Where.Declarative.cs">
+    <Compile Include="..\..\..\..\..\Reaqtive\Core\Tests.Reaqtive.Linq\Operators\Where.Declarative.cs">
       <Link>Operators\Where.Declarative.cs</Link>
     </Compile>
-    <Compile Include="..\..\..\..\Reaqtive\Core\Tests.Reaqtive.Linq\Operators\Window.Declarative.cs">
+    <Compile Include="..\..\..\..\..\Reaqtive\Core\Tests.Reaqtive.Linq\Operators\Window.Declarative.cs">
       <Link>Operators\Window.Declarative.cs</Link>
     </Compile>
   </ItemGroup>

--- a/archive/Reaqtor/Samples/Remoting/Tests.Reaqtor.Remoting/Tests.Reaqtor.Remoting.csproj
+++ b/archive/Reaqtor/Samples/Remoting/Tests.Reaqtor.Remoting/Tests.Reaqtor.Remoting.csproj
@@ -10,15 +10,15 @@
     <ProjectReference Include="..\Reaqtor.Remoting.Protocol\Reaqtor.Remoting.Protocol.csproj" />
     <ProjectReference Include="..\Reaqtor.Remoting.Reactor.Client.Library\Reaqtor.Remoting.Reactor.Client.Library.csproj" />
     <ProjectReference Include="..\Reaqtor.Remoting.TestingFramework\Reaqtor.Remoting.TestingFramework.csproj" />
-    <ProjectReference Include="..\..\..\Core\Client\Reaqtor.Client.Model\Reaqtor.Client.Model.csproj" />
-    <ProjectReference Include="..\..\..\Core\Client\Reaqtor.Client.Core\Reaqtor.Client.Core.csproj" />
-    <ProjectReference Include="..\..\..\Core\Client\Reaqtor.Client\Reaqtor.Client.csproj" />
-    <ProjectReference Include="..\..\..\Core\Expressions\Reaqtor.Expressions.Model\Reaqtor.Expressions.Model.csproj" />
-    <ProjectReference Include="..\..\..\Core\Local\Reaqtor.Local.Model\Reaqtor.Local.Model.csproj" />
-    <ProjectReference Include="..\..\..\Core\Shared\Reaqtor.Shared.Model\Reaqtor.Shared.Model.csproj" />
-    <ProjectReference Include="..\..\..\Core\Shared\Reaqtor.Shared.Core\Reaqtor.Shared.Core.csproj" />
-    <ProjectReference Include="..\..\..\..\Reaqtive\Core\Reaqtive.Scheduler\Reaqtive.Scheduler.csproj" />
-    <ProjectReference Include="..\..\..\..\Nuqleon\Core\LINQ\Nuqleon.Linq.CompilerServices\Nuqleon.Linq.CompilerServices.csproj" />
+    <PackageReference Include="Reaqtor.Client.Model" Version="1.0.0-beta.24" />
+    <PackageReference Include="Reaqtor.Client.Core" Version="1.0.0-beta.24" />
+    <PackageReference Include="Reaqtor.Client" Version="1.0.0-beta.24" />
+    <PackageReference Include="Reaqtor.Expressions.Model" Version="1.0.0-beta.24" />
+    <PackageReference Include="Reaqtor.Local.Model" Version="1.0.0-beta.24" />
+    <PackageReference Include="Reaqtor.Shared.Model" Version="1.0.0-beta.24" />
+    <PackageReference Include="Reaqtor.Shared.Core" Version="1.0.0-beta.24" />
+    <PackageReference Include="Reaqtive.Scheduler" Version="1.0.0-beta.24" />
+    <PackageReference Include="Nuqleon.Linq.CompilerServices" Version="1.0.0-beta.24" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## What & why

The .NET 10 migration (#155) moved 46 .NET-Framework-dependent projects into `archive/` as reference-only source but left them broken — their references still pointed at the now-net10.0 live tree, so the projects no longer restored, opened, compiled, or ran, and opening the archive solutions in Visual Studio buried the developer in analyzer and missing-XML-doc warnings on frozen code.

This makes the archived projects **open, compile, and test** again on the .NET 10 SDK, while keeping them reference-only (excluded from every live solution and CI).

## Build configuration — `archive/Directory.Build.props` (one central layer)

- **Quiet in the IDE and at build:** `RunAnalyzers=false` (no CA/IDE analyzer noise), `GenerateDocumentationFile=false` (removes the CS1591 doc-warning flood on the undocumented sample code), warnings-as-errors off.
- **Restore fixes (archive runs Central Package Management-off):** remove the version-less SourceLink / Nerdbank.GitVersioning refs the root injects; add `Microsoft.NETFramework.ReferenceAssemblies` so net472 builds on the SDK without Visual Studio / targeting packs; drop the synthesized `[CLSCompliant]` that duplicated the legacy `AssemblyInfo.cs` (CS0579).
- **Test projects:** pin MSTest to **3.7.3** (the last line that still carries the APIs the frozen tests call — `Assert.ThrowsException`, `[ExpectedException]`, the `(message, params)` overloads), keep the Microsoft.Testing.Platform runner so they're discovered and run in Visual Studio Test Explorer, drop the MTP 2.x extensions (incompatible with 3.7.3's MTP 1.x), and compile the legacy `AssertEx` shim.

## Per-project

- Convert the stale cross-tree `ProjectReference`s to `PackageReference`s pinned at **`1.0.0-beta.24`** (the last multi-targeted release, which ships net472 assets); keep intra-archive sibling references as project references.
- Re-point the stale linked sources (`Marvin.cs`; the Glitching `*.Declarative.cs`) at the live tree, and enable implicit usings on the Glitching project so they compile.
- Mirror the tiny unpublished `Tests.VisualBasic` VB fixture into a net472 shell that links the live source.
- Keep the `BinaryExpressionSerialization` prototype (Library / Perf / Tests) at **net472**, where `BinaryFormatter` — which it is built on, and which is removed at runtime on .NET 9+ — is functional, so it runs rather than throwing `PlatformNotSupportedException`.
- Revive the pre-rename `Reaqtor.Remoting.VersioningTests` harness: convert the broken non-SDK fossil to an SDK-style net472 project and swap its dead `Microsoft.Reactive.TestingFramework` reference for the renamed **`Reaqtive.TestingFramework` `1.0.0-beta.24`** package, keeping it in the Remoting solution. (It builds and launches; a full versioning pass needs a `TestCases.zip` and non-stale settings that aren't in the repo.)
- Strip the stale `/deps` entries from the **three** archive solutions that had them (`Museum`, `BinaryExpressionSerialization`, `Remoting`; `OperatorFusion` had none).

## Verification

Every archived project targets **.NET Framework 4.7.2** (`net472`; the two Museum libraries also multi-target `netstandard2.0`/`netstandard2.1`) — nothing targets `net10.0`. They are **compiled by the .NET 10 SDK toolchain**, cross-targeting net472 via `Microsoft.NETFramework.ReferenceAssemblies` (no Framework targeting pack required), and the resulting binaries **run on the installed .NET Framework 4.8 runtime**.

- All four archive solutions **and** the orphan projects build **0 warnings / 0 errors**.
- The archived tests run green on .NET Framework: **442 passing, 0 failing** (the Glitching fault-injection suite is runnable but slow by design).
- Live solutions and CI are untouched — the archive stays excluded from every live solution.

Closes #169

🤖 Generated with [Claude Code](https://claude.com/claude-code)
